### PR TITLE
translations: don't include locations

### DIFF
--- a/translations/monero.ts
+++ b/translations/monero.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation type="unfinished"></translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation type="unfinished"></translation>
     </message>
@@ -661,941 +505,687 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1603,57 +1193,46 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1664,224 +1243,180 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -1889,489 +1424,340 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2383,218 +1769,170 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2665,550 +2003,415 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3222,42 +2425,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3266,73 +2461,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3340,1762 +2521,1345 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5103,65 +3867,50 @@ Grand total:
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5169,93 +3918,74 @@ Grand total:
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5263,149 +3993,120 @@ Grand total:
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,320 +4114,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5734,313 +4371,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6048,125 +4618,99 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6174,80 +4718,63 @@ daemon to work correctly.</source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_de.ts
+++ b/translations/monero_de.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Ungültige Ziel-Adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation>Versuchte die Transaktion in einer Datei zu speichern, welche bereits existiert. Beende um ein Überschreiben nicht zu riskieren. Datei: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Schreiben der Transaktion(en) in eine Datei fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>der Hintergrunddienst ist beschäftigt. Bitte versuche es später erneut.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>keine Verbindung zum Hintergrunddienst. Stelle sicher, dass der Hintergrunddienst läuft.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>Transaktion %s wurde durch den Hintergrunddienst abgelehnt mit dem Status:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation>. Grund: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>Unbekannte Ausnahme: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>Unbehandelte Ausnahme</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation>Multisig-Signatur der Datei fehlschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation>Multisig-Signatur der Transaktion fehlgeschlagen: </translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation>Dies ist eine View-Only-Wallet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation>Signieren der Transaktion fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Eingefordertes Wechselgeld geht nicht an eine bezahlte Adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Der geforderte Wechselgeld-Betrag ist höher als die Zahlung an die Wechselgeld-Adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation>Das Wechselgeld geht an mehr als eine Adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation>sende %s an %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation>ohne Ziele</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation>%s Wechselgeld nach %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation>kein Wechselgeld</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation>%lu Transaktionen geladen, für %s, Gebühr %s, %s, %s, mit minimaler Ringgröße %lu. %s</translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>Hintergrunddienst ist beschäftigt. Bitte versuche es später erneut.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>keine Verbindung zum Hintergrunddienst. Stelle sicher, dass der Hintergrunddienst läuft.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation>RPC-Fehler: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation>nicht genügend Outputs für festgelegte Ringgröße</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation>verwendbare Outputs gefunden</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>nicht genügend Geld zum Transferieren vorhanden, verfügbarer Betrag %s, gesendeter Betrag %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>Fehler beim Parsen der Adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>Fehler beim Parsen des Spend-Keys</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation>Weder View-Key noch Spend-Key geliefert, Vorgang abgebrochen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>Fehler beim Parsen des geheimen Spend-Keys</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>Fehler beim Verifizieren des geheimen Spend-Keys</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>Spend-Key stimmt nicht mit Adresse überein</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>Fehler beim Verifizieren des geheimen View-Keys</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>View-Key stimmt nicht mit Adresse überein</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>Generieren einer neuen Wallet fehlgeschlagen:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation>Electrum-Seed ist leer</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>Senden der Anfrage zum Importieren der Wallet fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Fehler beim Laden unsignierter Transaktionen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation>Fehler beim Laden der Transaktion aus Datei</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation>Diese Wallet ist eine View-Only-Wallet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation>Fehler beim Speichern der Datei </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>Schlüsselbilder können nur mit einem vertrauenswürdigen Hintergrunddienst importiert werden</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation>Fehler beim Importieren der Schlüsselbilder:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation>Fehler beim Vergeben einer Beschreibung der Unteradresse: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation>Fehler beim Erhalten von Multisig-Informationen: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation>Multisig-Ausführung fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation>Fehler bei der Vollendung des Erstellens einer Multisig-Wallet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation>Fehler bei der Fertigstellung einer Multisig-Wallet: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation>Fehler beim Export von Multisig-Bildern: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation>Fehler beim Parsen importierter Multisig-Bilder</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation>Fehler beim Importieren der Multisig-Bilder: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation>Fehler beim Wiederherstellen der Multisig-Transaktion: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation>Um alles zu senden wird eine Ziel-Adresse benötigt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation>Ziele und Beträge sind ungleich</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation>Ungültige Zieladresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation>eine einzelne Transaktion kann nicht mehr als eine Zahlungs-ID nutzen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished">Fehler beim Einrichten der Zahlungs-ID, wenngleich diese korrekt decodiert wurde</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation>Ungültiger Output:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation>Fehler beim Markieren der Outputs als „ausgegeben“</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation>Fehler beim Markieren des Outputs als „ausgegeben“</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation>Fehler beim Markieren des Outputs als „nicht verwendet“</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation>Guthaben nicht ausreichend für den Transfer, gesamter Kontostand %s, gesendeter Betrag %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>Guthaben nicht ausreichend für den Transfer, lediglich %s verfügbar, Transaktionsbetrag %s = %s + %s (Gebühr)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation>Betrag des Outputs</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation>Transaktion wurde nicht erstellt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>Transaktion %s wurde durch den Hintergrunddienst abgelehnt mit dem Status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation>eines der Ziele ist null</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>keine geeignete Möglichkeit zur Aufteilung der Transaktionen gefunden</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation>unbekannter Transaktionsfehler: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation>Interner Fehler:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation>Unerwarteter Fehler:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation>Unbekannter Fehler</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation>Fehler beim Parsen der Transaktions-ID</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation>keine Transaktionsschlüssel für diese Transaktions-ID gefunden</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation>Fehler beim Parsen des Transaktionsschlüssels</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation>Fehler beim Parsen der Adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation>Adresse darf keine Unteradresse sein</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation>Die eingegebene Zeichenkette ist kein Schlüssel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation>Fehler beim Parsen des Output-Betrags</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation>Fehler beim Parsen des Schlüsselbilds</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation>Fehler beim Parsen der Adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation>Fehler beim Parsen des Schlüssels</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation>Verifizierung des Schlüssels fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation>Schlüssel stimmt nicht mit Adresse überein</translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation>Nein</translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation>Ungültige IP-Adresse angegeben für --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation>Nutzername angegeben mit --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation> darf nicht leer sein</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation> benötigt Passwort des RPC-Servers --</translation>
     </message>
@@ -661,941 +505,687 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation>Sende %s.  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>Deine Transaktion muss auf %llu Transaktionen aufgeteilt werden. Resultierend daraus wird eine Gebühr für jede einzelne Transaktion erhoben, zusammengerechnet %s Gebühren.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation>Die Transaktionsgebühr beträgt %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation>Nicht genügend Geld im verfügbaren Guthaben</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation>Keine Adresse angegeben</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation>Fehler beim Parsen der Zahlungs-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation>Fehler beim Parsen des Schlüsselbilds</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation>Keine Outputs gefunden</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation>Es werden mehrere Transaktionen erstellt, dies ist nicht vorgesehen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation>Die Transaktion nutzt keine oder mehrere Inputs, was nicht passieren sollte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Betrag erfolgreich gesendet, Transaktion: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Angefordertes Wechselgeld geht nicht an eine bezahlte Adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Das eingeforderte Wechselgeld hat einen höheren Betrag als die Zahlung an die Wechselgeld-Adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation>Wechselgeld geht an mehr als eine Adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation>sende %s an %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation>ohne Ziele</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation>kein Wechselgeld</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Hintergrunddienst ist lokal, als vertrauenswürdig betrachtet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation>falsch</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation>Befehle: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation>Unbekannter Befehl:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation>Verwendung von Befehlen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation>Beschreibung des Befehls: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation>Befehl wird durch Geräte-Wallet nicht unterstützt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation>Fehler beim Abrufen des Seeds</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation>Falsches Passwort</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation>Dein ursprüngliches Passwort war falsch.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation>Fehler beim Umschreiben der Wallet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation>Zufällige Zahlungs-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation>Aktuelle Gebühr ist %s %s pro %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation> (aktuell)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation>Diese Wallet wurde bereits zuvor genutzt, bitte verwende eine neue Wallet zum Erstellen einer Multisig-Wallet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation>Sende diese Multisig-Informationen an andere Beteiligte, nutze dann make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] mit den Informationen anderer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation>Weiterer Schritt notwendig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation> Multisig-Adresse: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation>Multisig-Adresse: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation>Diese Multisig-Wallet ist noch nicht fertiggestellt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation>Fehler beim Speichern der Datei</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation>Fehler beim Exportieren von Multisig-Informationen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation>Multisig-Informationen exportiert nach </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation>Fehler beim Lesen der Datei</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation>Multisig-Informationen importiert</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation>Fehler beim Importieren der Multisig-Informationen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation>Dies ist keine Multisig-Wallet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation>Signieren der Multisig-Transaktion fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation>Multisig-Fehler: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation>Signieren der Multisig-Transaktion fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation>Fehler beim Laden der Multisig-Transaktion aus Datei</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation>Transaktion erfolgreich gesendet, Transaktion </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation>Unbekannter Fehler</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation>Unerwarteter Fehler:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation>Ungültiges Schlüsselbild</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation>Ungültige Transaktions-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation>Datei ist nicht vorhanden</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation>Ungültiges Schlüsselbild: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation>Ungültiger Ring: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation>Fortfahrend.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation>Ungültiges Schlüsselbild oder ungültige Transaktions-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation>Ungültiges Argument: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation>müsste &quot;add&quot; sein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation>Fehler beim Öffnen der Datei</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation>Fehler beim Speichern der bekannten Ringe: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation>Eingefroren: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation>Nicht eingefroren: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation> Bytes gesendet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation> Bytes empfangen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation>Willkommen bei Monero, der privaten Kryptowährung. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation>Monero ist, wie Bitcoin, eine Kryptowährung. Also: digitales Geld.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation>Monero schützt deine Privatsphäre auf der Blockchain, und während Monero bestrebt ist, sich andauernd zu verbessern,</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation>kann keine Privatsphärentechnologie hundertprozentig perfekt sein - Monero mit eingeschlossen.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation>Monero kann dich nicht vor bösartiger Software schützen, und es könnte nicht so effektiv gegen machtvolle Gegner sein, wie wir hoffen.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation>Priorität muss entweder 0, 1, 2, 3 oder 4 sein, oder eine von: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation>ungültige Einheit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation>ungültiger Wert</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation>Ungültige Höhe</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation>ungültige Meinung: muss entweder 1/ja oder 0/nein sein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation>Beende Mining im Hintergrunddienst.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation>Wähle einen neuen Hintergrunddienst zum Verbinden.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation>Speichere die aktuellen Blockchain-Daten.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation>Synchronisiere Transaktionen und Guthaben.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1603,57 +1193,46 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation>Zeige die Zahlungen der angegebenen Zahlungsadressen.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation>Zeige Höhe der Blockchain.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation>Spende &lt;Betrag&gt; ans Entwicklerteam (donate.getmonero.org).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1664,224 +1243,180 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation>Speichere Wallet-Daten.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation>Privaten View-Key anzeigen.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation>Privaten Spend-Key anzeigen.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation>Gebe eine beliebige Beschreibung für die Wallet an.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation>Erhalte die Beschreibung der Wallet.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation>Wallet-Status anzeigen.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation>Wallet-Information anzeigen.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation>Signiere die Inhalte einer Datei.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation>Zeige Informationen eines Transfers an diese/von dieser Adresse.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation>Wallet-Passwort ändern.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation>Exportiere die zum Erstellen einer Multisig-Wallet erforderlichen Dateien</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation>Diese Wallet in eine Multisig-Wallet umwandeln</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation>Exportiere Multisig-Informationen für andere Beteiligte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation>Importiere Multisig-Informationen von anderen Beteiligten</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -1889,491 +1424,342 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation>Drucke grundlegende Informationen über Monero für Erstnutzer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation>0 oder 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation>0, 1, 2, 3 oder 4, oder eine von </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation>Monero, Millinero, Micronero, Nanonero, Piconero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation>Betrag</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation>Blockhöhe</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation>1/ja oder 0/nein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation>Ungültiger Wallet-Name. Bitte versuche es erneut oder nutze Ctrl-C zum Beenden.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation>Wallet und Schlüsseldateien gefunden, lade...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation>Schlüsseldatei nicht gefunden. Öffnen der Wallet fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation>Keine Wallet mit diesem Namen gefunden. Bestätige Erstellung einer neuen Wallet mit dem Namen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation>Generiert neue Wallet...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation>Verifikation des Multisig-Seeds fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation>Keine Daten eingespeist, abgebrochen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation>Fehler beim Parsen der Adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation>Diese Adresse ist eine Subadresse, welche hier nicht genutzt werden kann.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation>View-Key stimmt nicht mit Standardadresse überein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation>Kontoerstellung fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation>Spend-Key stimmt nicht mit Standardadresse überein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation>Fehler: M/N wird derzeitig nicht unterstützt. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation>Fehler beim Parsen des geheimen View-Keys</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation>Fehler beim Verifizieren des geheimen View-Keys</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation>Fehler: M/N wird derzeitig nicht unterstützt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation>Keine Wiederherstellungshöhe angegeben.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation>Kontoerstellung abgebrochen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation>Wiederherstellungshöhe ist: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation>Wiederherstellungshöhe </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation>Fehler beim Öffnen des Kontos</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation>Wallet konnte keine Verbindung zum Hintergrunddienst herstellen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation>Liste der verfügbaren Sprachen für den Seed deiner Wallet:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation>Sollte dein Bildschirm abstürzen, beende &quot;blind&quot; mit ^C und führe anschließend mit --use-english-language-names neu aus</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation>ungültige Sprachauswahl. Bitte versuche es erneut.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation>ungültiges Passwort</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation>Du hast bisher eine veraltete Version der Wallet genutzt. Bitte verwende den neuen, von uns bereitgestellten Seed.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation>Generierte neue Wallet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation>View-Key: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation>Generieren einer neuen Wallet fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2392,222 +1778,174 @@ deine Wallet erneut zu synchronisieren (deine Wallet-Schlüssel sind in KEINEM F
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation>Neue Wallet auf Hardwaregerät erstellt: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation>Generieren einer neuen Multisig-Wallet fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation>Neue %u/%u Multisig-Wallet erstellt: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation>Wallet-Datei-Pfad ungültig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation>Schlüsseldatei nicht gefunden. Öffnen der Wallet fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation>Wallet geöffnet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation>Du hast bisher eine veraltete Version der Wallet genutzt. Bitte fahre fort, um deine Wallet zu aktualisieren.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation>Du hast bisher eine veraltete Version der Wallet genutzt. Das Dateiformat deiner Wallet wird gerade aktualisiert.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation>Laden der Wallet fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation>Nutze den Befehl &quot;help&quot;, um die Liste verfügbarer Befehle anzusehen.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation>Nutze &quot;help &lt;command&gt;&quot;, um die Dokumentation eines Befehls anzusehen.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation>Deinitialisierung der Wallet fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation>Daten der Wallet gespeichert</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation>Lesen des Wallet-Passworts fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>dieser Befehl erfordert einen vertrauenswürdigen Hintergrunddienst. Aktiviere mit --trusted-daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation>Mining wurde NICHT gestartet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation>Mining wurde NICHT gestoppt: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation>vertrauenswürdig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation>nicht vertrauenswürdig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation>Dies scheint keine gültige URL eines Hintergrunddienstes zu sein.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation>Blockchain gespeichert</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation>Blockchain kann nicht gespeichert werden: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation>Höhe </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation>Transaktions-ID </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation>Index </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation>Passwort eingeben</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation>Neuen Transfer seit Start des Rescans empfangen. Schlüsselbilder sind nicht vollständig.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation>Aktualisierung abgeschlossen, empfangene Blöcke: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>Hintergrunddienst ist beschäftigt. Bitte versuche es später erneut.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2678,554 +2016,419 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>keine Verbindung zum Hintergrunddienst. Bitte stelle sicher, dass der Hintergrunddienst läuft.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation>RPC-Fehler: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation>Aktualisierungsfehler: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation>Interner Fehler: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation>Aktualisieren fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation>Empfangene Blöcke: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation>Gegenwärtig ausgewähltes Konto: [</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation>] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation>(Keine Markierung zugewiesen)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation>Markierung: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation>Guthaben: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation>Entsperrtes Guthaben: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation>Guthaben pro Adresse:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation>Guthaben</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation>Verfügbares Guthaben</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation>Outputs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation>%8u %6s %21s %21s %7u %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation>Schlüsselbild</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation>verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation>Ring-CT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation>globaler Index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation>Transaktions-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation>Adress-Index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation>gesperrt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation>Ring-CT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation>Keine eingehenden Überweisungen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation>Keine eingehenden verfügbaren Überweisungen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation>Keine eingehenden nicht verfügbaren Überweisungen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation>Zahlung</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation>Transaktion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation>Höhe</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation>Freigabedauer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation>Keine Zahlungen mit der ID </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>Zahlungs-ID hat ein ungültiges Formal, muss eine Hexadezimalreihung mit 16 oder 64 Zeichen sein: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation>Abrufen der Höhe der Blockchain fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation>
 Transaktion %llu/%llu: txid=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation>Fehler beim Abrufen des Outputs: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation>die ursprüngliche Blockhöhe des Output-Keys sollte nicht höher als die Höhe der Blockchain sein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation>
 Ursprüngliche Blockhöhen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation>dieselbe Transaktion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation>, was die Anonymität der Ringsignatur zerstören kann. Stelle sicher, dass dies beabsichtigt ist!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation>Die Ringgröße darf nicht 0 sein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation>die Ringgröße %u ist zu klein, das Minimum ist %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation>die Ringgröße %u ist zu groß, das Maximum ist %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation>Verschlüsseln der Zahlungs-ID fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation>eine einzelne Transaktion kann nicht mehr als eine Zahlungs-ID nutzen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation>Fehler beim Parsen der Anzahl der Outputs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation>Betrag der Outputs sollte größer als 0 sein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>die Zahlungs-ID hat ein ungültiges Format, eine Hexadezimalreihe mit 16 oder 64 Zeichen wird erwartet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>eine einzelne Transaktion kann nicht mehr als eine Zahlungs-ID nutzen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>Fehler beim Einrichten der Zahlungs-ID, wenngleich diese korrekt decodiert wurde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation>Sende diese Multisig-Informationen an andere Beteiligte, nutze dann exchange_multisig_keys &lt;info1&gt; [&lt;info2...] mit den Informationen Anderer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation>Mutisig-Wallet wurde erfolgreich erstellt. Aktueller Wallet-Typ: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation>Ausführen des Austauschs der Multisig-Schlüssel fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation>Fehler beim Laden der Multisig-Transaktion aus MMS</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation>Bitte bestätige die Transaktion auf dem Gerät</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation>Gerätename nicht angegeben</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation>Erneute Verbindung zum Gerät fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation>Erneute Verbindung zum Gerät fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3239,42 +2442,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3283,73 +2478,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation>Zeige aktuelle MMS-Konfiguration</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation>Liste alle Nachrichten auf</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation>Lösche eine einzelne Nachricht, indem du die dazugehörige ID angibst, oder lösche alle Nachrichten, indem du &apos;all&apos; nutzt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation>Sende eine einzelne Nachricht, indem du ihre ID angibst, oder sende alle Nachrichten in der Warteschleife</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation>Schreibe den Inhalt einer Nachricht auf eine Datei &quot;mms_message_content&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation>Zeige detaillierte Informationen über eine einzelne Nachricht</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3357,1764 +2538,1347 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation>&lt;device_name[:device_spec]&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation>falscher Zahlenbereich, nutze: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation>NOTIZ: Die folgenden %s können zur Wiederherstellung des Zugriffs auf deine Wallet genutzt werden. Notiere sie und bewahre sie an einem sicheren, geschützten Ort auf. Bitte speichere sie nicht in deinem E-Mail-Konto oder mithilfe von Datensicherungsdiensten außerhalb deiner direkten Kontrolle.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation>25 Wörter</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation>Geheimer Spend-Key (%u von %u)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation>Ist dies in Ordnung?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation>Wiederherstellungshöhe weiterhin übernehmen?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation>Gebe die zu deiner ausgewählten Sprache gehörige Zahl ein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation>Gerät benötigt Aufmerksamkeit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation>Gebe Geräte-PIN ein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation>Lesen der Geräte-PIN fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation>Bitte gebe die Geräte-Passphrase auf dem Gerät ein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation>Gebe Passphrase des Geräts ein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation>Lesen der Geräte-Passphrase fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation>Das Nutzen eines Hintergrunddienstes eines Drittanbieters kann schädlich für deine Sicherheit und Privatsphäre sein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation>Solltest du oder jemand, dem du vertraust, diesen Hintergrunddienst betreiben, kannst du --trusted-daemon nutzen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation>Fehler beim Erstellen der Wallet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation>Abfragen des Mining-Status fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation>Einrichten des Hintergrund-Minings fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation>Hintergrund-Mining aktiviert. Danke, dass du das Monero-Netzwerk unterstützt.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation>Hintergrund-Mining deaktiviert. Führe &quot;set setup-background-mining 1&quot; aus, um dies zu ändern.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation>Indem du dies einschaltest, unterstützt du das von dir genutzte Netzwerk, und du bist dadurch berechtigt, neue Monero zu erhalten</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation>Hintergrund-Mining nicht eingeschaltet. Setze setup-background-mining auf 1, um dies zu ändern.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation>NOTIZ: Diese Transaktion ist gesperrt, sieh Details mit: show_transfer </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation>hw_key_images_sync übersprungen. Führe den Befehl manuell vor einem Transfer aus.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation>Ungültiges Schlüsselwort: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation>
 Eingabe &amp;llu/%llu (%s): Betrag=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation>Betrag ist falsch: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished">Schreiben der Transaktion(en) in eine Datei fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation>Fehler beim Importieren der Schlüsselbilder: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished">Dies ist eine View-Only-Wallet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished">Signieren der Transaktion fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished">Fehler beim Laden der Transaktion aus Datei</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished">keine Transaktionsschlüssel für diese Transaktions-ID gefunden</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation>Adresse darf keine Unteradresse sein</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation>Ungültiger Output: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation>Unteradresse: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation>Standardadresse: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation type="unfinished">%s Wechselgeld nach %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5122,65 +3886,50 @@ Grand total:
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5188,93 +3937,74 @@ Grand total:
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5282,149 +4012,120 @@ Grand total:
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5432,320 +4133,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished">Lesen des Wallet-Passworts fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation type="unfinished">RPC-Fehler: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished">Nicht genügend Geld im verfügbaren Guthaben</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished">nicht genügend Outputs für festgelegte Ringgröße</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation type="unfinished">Betrag des Outputs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation type="unfinished">verwendbare Outputs gefunden</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished">Transaktion wurde nicht erstellt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished">eines der Ziele ist null</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished">keine geeignete Möglichkeit zur Aufteilung der Transaktionen gefunden</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished">unbekannter Transaktionsfehler: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation type="unfinished">Multisig-Fehler: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation>Interner Fehler: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation>Unerwarteter Fehler: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation>Unbekannter Befehl: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation>Fehler: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5753,313 +4390,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished">Hintergrunddienst ist lokal, als vertrauenswürdig betrachtet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished">View-Key stimmt nicht mit Standardadresse überein</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation>Spend-Key stimmt nicht mit Standardadresse überein</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation>Generieren einer neuen Wallet fehlgeschlagen: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation>Fehler beim Lesen der Datei </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6067,125 +4637,99 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation>Wallet wird geladen...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation>Wallet wird gespeichert...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation>Erfolgreich gespeichert</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation>Erfolgreich geladen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation>Fehler beim Ausführen der Wallet: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation>Fehler beim Speichern der Wallet: </translation>
     </message>
@@ -6193,80 +4737,63 @@ daemon to work correctly.</source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation>Wallet-Optionen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_es.ts
+++ b/translations/monero_es.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Dirección de destino inválida</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation>Intentado guardar la transacción en un archivo, pero el archivo ya existe. Saliendo para evitar el riesgo de sobreescribir. Archivo:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Fallo al escribir la transacción o transacciones al archivo.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>El daemon está ocupado. Inténtelo más tarde.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>No hay conexión con el daemon. Asegúrese de que el daemon está ejecutándose.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>La transacción %s fue rechazada por el daemon con estado: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation>. Motivo:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>Excepción desconocida: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>Excepción no controlada</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation>No se pudo aplicar firma múltiple sobre los datos:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation>No se pudo firmar la transacción multifirma: </translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation>Este es un monedero de solo lectura</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation>Fallo al firmar transacción</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>El cambio solicitado no va a una dirección de pago</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>El cambio solicitado es mayor al pago a la dirección de cambio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation>El cambio va a más de una dirección</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation>enviando %s a %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation>sin destinos</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation>%s cambio a %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation>sin cambio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation>Cargando %lu de transacciones, por %s, comisiones %s, %s, %s, con tamaño mínimo de círculo %lu. %s</translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>el daemon esta ocupado. Intenta más tarde.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>no hay conexión con el daemon. Asegúrate que el daemon se esta ejecutando.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation>Error en el RPC: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation>fallo al hacer mezlcar las salidas: %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation>no hay salidas suficientes para el tamaño de círculo especificado</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation>se encontraron salidas para utilizar</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation>Limpiar salidas sin poder mezclar.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>sin dinero suficiente para transferir, solamente disponible %s, cantidad enviada %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>fallo el análisis de la dirección</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>fallo al analizar la clave secreta de gasto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation>Ni la clave de visualización ni la clave de gasto suministrados, cancelado</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>fallo al analizar la clave secreta de visualización</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>fallo al verificar la clave secreta de gasto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>la clave de gasto no coincide con la dirección</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>fallo al verificar la clave secreta de visualización</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>la clave de visualización no coincide con la dirección</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>fallo al generar nuevo monedero: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation>Semilla Electrum está vacía</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation>La lista de palabras del estilo Electrum fallo en la verificación</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>Fallo al envío de solicitud de la importación del monedero</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Fallo al cargar transacciones sin firmar</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation>Fallo al cargar la transacción del archivo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation>Monedero es solo de visualización</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation>Fallo al guardar archivo </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>Las imagenes de las claves solo pueden ser importadas con un daemon de confianza</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation>Fallo al importar imagenes de las claves: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation>Fallo al obtener etiqueta de la subdirección: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation>Fallo al asignar etiqueta de la subdirección: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation>Fallo al obtener información de la multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation>Fallo al hacer multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation>Fallo al finalizar la creación del monedero multifirma</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation>Fallo al finalizar la creación del monedero multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation>Fallo al exportar imagenes de multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation>Fallo al analizar las imagenes de la multifirma importada</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation>Fallo al importar imagenes de la multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation>Fallo al validar por las imagenes parciales de las claves multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation>Fallo al restaurar la transacción multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation>Dirección de destino inválida</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation>Salida inválida: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation>Fallo al marcar salidas como gastadas</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation>Fallo al marcar salida como gastada</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation>Fallo al marcar salida como no gastada</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation>sin dinero suficiente para transferir, balance global solamente %s, cantidad enviada %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>sin dinero suficiente para transferir, disponible solamente %s, cantidad de la transacción %s = %s + %s (comisión)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation>cantidad de la salida</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation>la transacción no se construyó</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transacción %s fue rechazada por el daemon con status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation>uno de los destinos es cero</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>fallo al encontrar una manera adecuada de dividir las transacciones</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation>error desconocido al transferir: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation>error interno: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation>error inesperado: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation>error desconocido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation>fallo al hacer mezclar las salidas</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation>Fallo al analizar ID de transacción</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation>no se encontraron claves de transacción para ésta ID de transacción</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation>Fallo al analizar la clave de la transacción</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation>Fallo al analizar dirección</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation>La dirección no debe ser una subdirección</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation>El monedero debe estar en un estado listo de multifirma</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation>La cadena dada no es una clave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>El reescaneo del gasto solo puede ser utilizado con un daemon de confianza</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation>Fallo al analizar cantidad de salida</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation>Fallo al analizar la salida desplazada</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation>Fallo al analizar la imagen de la clave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation>Fallo al obtener círculo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation>Fallo al obtener círculos</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation>Fallo al asignar círculo</translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation>Fallo al analizar dirección</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation>Fallo al analizar la clave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation>fallo al verificar la clave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation>la clave no coincide con la dirección</translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation>si</translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation>no</translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation>Permitír IPv6 para RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation>Ignorar unión IPv4 no exitosa para RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation type="unfinished"></translation>
     </message>
@@ -661,941 +505,687 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished">El cambio solicitado no va a una dirección de pago</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished">El cambio solicitado es mayor al pago a la dirección de cambio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished">El cambio va a más de una dirección</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation type="unfinished">enviando %s a %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation type="unfinished">sin destinos</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation type="unfinished">sin cambio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation type="unfinished">Fallo al guardar archivo </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation type="unfinished">error desconocido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation type="unfinished">error inesperado: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1603,57 +1193,46 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1664,224 +1243,180 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -1889,489 +1424,340 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished">La lista de palabras del estilo Electrum fallo en la verificación</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation type="unfinished">fallo el análisis de la dirección</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished">fallo al analizar la clave secreta de visualización</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished">fallo al verificar la clave secreta de visualización</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished">fallo al generar nuevo monedero: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2383,218 +1769,170 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2665,550 +2003,415 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation type="unfinished">Error en el RPC: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation type="unfinished">error interno: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished">el id de pago tiene un formato inválido, se espera una cadena de 16 o 64 caracteres: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3222,42 +2425,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3266,73 +2461,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3340,1762 +2521,1345 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished">Fallo al escribir la transacción o transacciones al archivo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished">Fallo al importar imagenes de las claves: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished">Este es un monedero de solo lectura</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished">Fallo al firmar transacción</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished">Fallo al cargar la transacción del archivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished">no se encontraron claves de transacción para ésta ID de transacción</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished">La dirección no debe ser una subdirección</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation type="unfinished">Salida inválida: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation type="unfinished">%s cambio a %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5103,65 +3867,50 @@ Grand total:
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5169,93 +3918,74 @@ Grand total:
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5263,149 +3993,120 @@ Grand total:
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,320 +4114,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation type="unfinished">Error en el RPC: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished">no hay salidas suficientes para el tamaño de círculo especificado</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation type="unfinished">cantidad de la salida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation type="unfinished">se encontraron salidas para utilizar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished">la transacción no se construyó</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished">uno de los destinos es cero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished">fallo al encontrar una manera adecuada de dividir las transacciones</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished">error desconocido al transferir: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation type="unfinished">error interno: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation type="unfinished">error inesperado: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5734,313 +4371,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished">La lista de palabras del estilo Electrum fallo en la verificación</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished">fallo al generar nuevo monedero: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6048,125 +4618,99 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6174,80 +4718,63 @@ daemon to work correctly.</source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_fr.ts
+++ b/translations/monero_fr.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Adresse de destination invalide</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation>Tentative d&apos;enregistrement d&apos;une transaction dans un fichier, mais le fichier spécifié existe déjà. Sortie pour ne pas risquer de l&apos;écraser. Fichier :</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Échec de l&apos;écriture de(s) transaction(s) dans le fichier</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transaction %s a été rejetée par le démon avec le statut : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation>. Raison : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>Exception inconnue : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>Exception non gérée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation>Signature multisig des données impossible : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation>Signature multisig de la transaction impossible : </translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation>Ceci est un portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation>Échec de signature de transaction</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>La monnaie réclamée ne va pas à une adresse payée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>La monnaie réclamée est supérieure au paiement à l&apos;adresse de monnaie</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation>La monnaie rendue va à plus d&apos;une adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation>envoi de %s à %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation>sans destination</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation>%s de monnaie rendue à %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation>sans monnaie rendue</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation>%lu transactions chargées, pour %s, frais %s, %s, %s, taille de cercle minimum %lu, %s</translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation>Erreur RPC : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation>pas assez de sorties pour la taille de cercle spécifiée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation>sorties à utiliser trouvées</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation>Veuillez balayer les sorties non mélangeables.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>pas assez de fonds pour le transfert, montant disponible %s, montant envoyé %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>échec de l&apos;analyse de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>échec de la vérification de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>la clé de dépense ne correspond pas à l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>la clé d&apos;audit ne correspond pas à l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>échec de la génération du nouveau portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>Échec de l&apos;envoi de la requête d&apos;importation de portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Échec du chargement des transaction non signées</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation>Échec du chargement de la transaction du fichier</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation>Portefeuille d&apos;audit uniquement</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation>échec de l&apos;enregistrement du fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>Les images de clé ne peuvent être importées qu&apos;avec un démon de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation>Échec de l&apos;importation des images de clé : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation>Échec de la récupération de l&apos;étiquette de sous-adresse : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation>Échec de l&apos;affectation de l&apos;étiquette de sous-adresse : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation>Ni clé d&apos;audit ni clé de dépense fournie, annulation</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation>La phrase Electrum est vide</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Échec de la vérification de la liste de mots de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation>Échec de la récupération des infos multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation>Échec de la création multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation>Échec de la finalisation de la création du portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation>Échec de la finalisation de la création du portefeuille multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation>Échec de l&apos;exportation des images multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation>Échec de l&apos;analyse des images multisig importées</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation>Échec de l&apos;importation des images multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation>Échec de la vérification des images de clé multisig partielles : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation>Échec de la restauration de la transaction multisig : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation>Tout envoyer nécessite une adresse de destination</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation>Les destinations et montants ne sont pas égaux</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation>le format de l&apos;ID de paiement est invalide, 64 caractères hexadécimaux sont attendus : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation>Adresse de destination invalide</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation>une unique transaction ne peut pas utiliser plus d&apos;un ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>échec de la définition de l&apos;ID de paiement, bien qu&apos;il ait été décodé correctement</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation>échec de la récupération de sorties à mélanger : %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation>pas assez de fonds pour le transfer, solde global disponible %s, montant envoyé %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>pas assez de fonds pour le transfert, montant disponible %s, montant envoyé %s = %s + %s (frais)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation>montant de la sortie</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation>la transaction n&apos;a pas été construite</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transaction %s a été rejetée par le démon avec le statut : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation>une des destinations est zéro</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>échec de la recherche d&apos;une façon adéquate de scinder les transactions</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation>erreur de transfert inconnue : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation>erreur interne : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation>erreur inattendue : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation>erreur inconnue</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation>échec de la récupération de sorties à mélanger</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation>Échec de l&apos;analyse de l&apos;ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation>aucune clé de transaction trouvée pour cet ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation>Échec de l&apos;analyse de la clé de transaction</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation>Échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation>L&apos;adresse ne doit pas être une sous-adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation>Le portefeuille doit être multisig et prêt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation>La chaîne entrée n&apos;est pas une clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>Réexaminer les dépenses ne peut se faire qu&apos;avec un démon de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation>Sortie invalide : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation>Échec du marquage des sorties comme dépensées</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation>Échec du marquage de la sortie comme dépensée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation>Échec du marquage de la sortie comme non dépensée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation>Échec de l&apos;analyse du montant de la sortie</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation>Échec de l&apos;analyse de l&apos;offset de la sortie</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation>Échec de l&apos;analyse de l&apos;image de clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation>Échec de la récupération du cercle</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation>Échec de la récupération des cercles</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation>Échec de l&apos;affectation du cercle</translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation>Échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation>Échec de l&apos;analyse de la clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation>Échec de la vérification de la clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation>la clé ne correspond pas à l&apos;adresse</translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation>oui</translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation>non</translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation>Spécifier l&apos;IP à laquelle lier le serveur RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation>Autoriser l&apos;IPv6 pour le RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation>Spécifier le nom_utilisateur[:mot_de_passe] requis pour le serveur RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation>Confirmer que la valeur de rpc-bind-ip n&apos;est PAS une IP de bouclage (locale)</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation>Spécifier une liste d&apos;origines séparées par des virgules pour autoriser le partage de ressource de différentes origines (CORS)</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation>Activer SSL pour les connexions RPC : enabled|disabled|autodetect</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation>Chemin vers une clé privée au format PEM</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation>Chemin vers un certificat au format PEM</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation>Chemin vers un fichier contenant le(s) certificat(s) au format PEM concaténé(s) pour remplacer l(es) AC(s) du système.</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation>Liste des empreintes de certificat à autoriser</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation>Autoriser une chaîne de certificats utilisateur (via --rpc-ssl-certificates)</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation>Autoriser tous les certificats pairs</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation>Adresse IP invalide fournie pour --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation> autorise les connexions entrantes non cryptées venant de l&apos;extérieur. Considérez plutôt un tunnel SSH ou un proxy SSL. Outrepasser avec --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation>Le nom d&apos;utilisateur spécifié avec --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation> ne peut pas être vide</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation> nécessite le mot de passe du serveur RPC --</translation>
     </message>
@@ -661,300 +505,222 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation>Commandes : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation>échec de la lecture du mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation>mot de passe invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation>set seed : requiert un argument. options disponibles : language</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation>set : argument(s) non reconnu(s)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation>chemin du fichier portefeuille non valide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation>Tentative de génération ou de restauration d&apos;un portefeuille, mais le fichier spécifié existe déjà. Sortie pour ne pas risquer de l&apos;écraser.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation>requiert un argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation>0 ou 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation>entier non signé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-deterministic-wallet utilise --generate-new-wallet, pas --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation>spécifiez un paramètre de récupération avec --electrum-seed=&quot;liste de mots ici&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation>spécifiez un chemin de portefeuille avec --generate-new-wallet (pas --wallet-file)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation>échec de la connexion du portefeuille au démon : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation>Le démon utilise une version majeure de RPC (%u) différente de celle du portefeuille (%u) : %s. Mettez l&apos;un des deux à jour, ou utilisez --allow-mismatched-daemon-version.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation>Liste des langues disponibles pour la phrase mnémonique de votre portefeuille :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation>Vous avez utilisé une version obsolète du portefeuille. Veuillez dorénavant utiliser la nouvelle phrase mnémonique que nous fournissons.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation>Nouveau portefeuille généré : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation>échec de la génération du nouveau portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation>Ouverture du portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation>Ouverture du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation>Vous avez utilisé une version obsolète du portefeuille. Veuillez procéder à la mise à jour de votre portefeuille.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation>Vous avez utilisé une version obsolète du portefeuille. Le format de votre fichier portefeuille est en cours de mise à jour.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation>échec du chargement du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation>Utilisez la commande &quot;help&quot; pour voir la liste des commandes disponibles.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation>Données du portefeuille sauvegardées</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation>La mine a démarré dans le démon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation>la mine n&apos;a PAS démarré : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation>La mine a été stoppée dans le démon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation>la mine n&apos;a PAS été stoppée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation>Chaîne de blocs sauvegardée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation>Hauteur </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation>dépensé </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation>Démarrage du rafraîchissement...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation>Rafraîchissement effectué, blocs reçus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation>mauvais paramètre locked_blocks :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>une unique transaction ne peut pas utiliser plus d&apos;un ID de paiement : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>échec de la définition de l&apos;ID de paiement, bien qu&apos;il ait été décodé correctement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation>Envoyez ces infos multisig à tous les autres participants, puis utilisez exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] avec les infos multisig des autres</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation>Le portefeuille multisig a été créé avec succès. Type du portefeuille actuel : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation>Échec de l&apos;échange de clés multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation>Échec du chargement de la transaction multisig à partir du MMS</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation>Échec du marquage de la sortie comme dépensée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation>Échec du marquage de la sortie comme non dépensée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation>Dépensé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation>Non dépensé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation>Impossible de vérifier si la sortie est dépensée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation>Veuillez confirmer la transaction sur l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation>Nom de l&apos;appareil non spécifié</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation>Échec de la reconnexion à l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation>Échec de la reconnexion à l&apos;appareil : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -977,37 +743,30 @@ En attente ou Échoué:                        &quot;failed&quot;|&quot;pending&
 ** Jeux d&apos;indices d&apos;adresse utilisé en entrées dans ce transfert.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;hauteur_min&gt; [&lt;hauteur_max&gt;]] [output=&lt;chemin_de_fichier&gt;]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation>Exporter en CSV les transfers entrants/sortants dans une plage de hauteur optionnelle.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation>Exporter un jeux d&apos;images de clé signé dans un &lt;fichier&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation>Synchroniser les images de clé avec le portefeuille matériel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation>Génère un nouvel ID de paiement long (obsolète).  Il se sera pas chiffré sur la chaîne de blocs, voir integrated_address pour des IDs de paiement court et chiffrés.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation>Réalise des échanges de clés multisignatures supplémentaires. Nécessaire pour des portefeuilles multisignatures M/N arbitraires</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -1016,73 +775,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation>Initialise et configure le MMS pour M/N = nombre de signataires requis / nombre de signataires multisignature autorisés</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation>Afficher la configuration MMS actuelle</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation>Lister tous les messages</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation>Vérifier tout de suite les nouveaux messages à recevoir</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation>Écrire le contenu d&apos;un message dans un fichier &quot;mms_message_content&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation>Envoyer un message d&apos;une ligne à un signataire autorisé, identifié par son étiquette, ou afficher une note non lue en attente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -1090,1492 +835,1125 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation>Envoyer la configuration de signataire complétée à tous les autres signataires autorisés</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation>Marquer les sorties comme dépensées pour qu&apos;elles ne soient jamais sélectionnées comme leurre dans un cercle</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation>Marquer une sortie comme non dépensée pour qu&apos;elle puisse être sélectionnée comme leurre dans un cercle</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation>Vérifie si une sortie est marquée comme dépensée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation>&lt;nom_périphérique[:spec_périphérique]&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation>mauvaise plage de nombres, utilisez: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation>chaîne</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation>phrase mnémonique de 25 mots</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation>Clef secrète de dépense (%u de %u)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation>Utilisez --restore-height ou --restore-date si vous voulez restaurer un compte déjà configuré à partir d&apos;une hauteur spécifique.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation>Est-ce correct ?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation>Le périphérique demande votre attention</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation>Entrer le code PIN du périphérique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation>Veuillez entrer le mot de passe du périphérique sur le périphérique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation>Entrer le mot de passe du périphérique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation>Le premier rafraîchissement du portefeuille matériel s&apos;est terminé avec de l&apos;argent reçu. hw_key_images_sync est requis. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation>Voulez vous le faire maintenant . (Y/Yes/N/No) : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation>hw_key_images_sync ignoré. Lancez la commande manuellement avant un transfert.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation>Mot clef invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation>transaction annulée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation>Échec de la vérification du backlog : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation>
 Transaction </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation>Dépense depuis l&apos;adresse d&apos;index %d
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation>ATTENTION : Des sorties de multiples adresses sont utilisées ensemble, ce qui pourrait potentiellement compromettre votre confidentialité.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation>Envoi de %s.  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>Votre transaction doit être scindée en %llu transactions. Il en résulte que des frais de transaction doivent être appliqués à chaque transaction, pour un total de %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation>Les frais de transaction sont de %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation>, dont %s est de la poussière de monnaie rendue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation>Un total de %s de poussière de monnaie rendue sera envoyé à une adresse de poussière</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation>Transaction(s) non signée(s) écrite(s) avec succès vers MMS</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Échec de l&apos;écriture de(s) transaction(s) dans le fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation>Transaction(s) non signée(s) écrite(s) dans le fichier avec succès : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation>Échec de la signature à froid de la transaction avec le portefeuille matériel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation>Aucune sortie non mélangeable trouvée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation>Aucune adresse fournie</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation>échec de l&apos;analyse de l&apos;image de clé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation>Pas de sorties trouvées</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation>De multiples transactions sont crées, ce qui n&apos;est pas supposé arriver</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation>La transaction utilise aucune ou de multiples entrées, ce qui n&apos;est pas supposé arriver</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation>montant seuil manquant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation>montant seuil invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation>%lu transactions chargées, pour %s, %s de frais, %s, %s, avec taille de cercle minimum de %lu, %s. %sEst-ce correct ?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation>Rescanner quand même ?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation>verrouillé pour cause d&apos;inactivité</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation> (Y/Yes/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation>Choisissez comment procéder :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation>Signer la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation>Envoyer la transaction à soumettre à </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation>Envoyer la transaction à signer à </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation>Soumettre la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation>inconnu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation>Choix : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation>Mauvais choix</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation>E/S</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation>Signataire autorisé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation>Type de message</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation>État du message</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation>Depuis</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation>#</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation>Adresse de transport</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation>Adresse Monero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation>&lt;non défini&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation>Message </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation>Entrant/sortant : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation>État : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation>%s depuis %s, il y a %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation>Envoyé : Jamais</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation>Envoyé : %s, il y a %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation>Signataire autorisé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation>Taille du contenu : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation> octets</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation>Contenu : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation>(données binaires)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation>Envoyer ces messages maintenant ?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation>Mis en file d&apos;attente pour l&apos;envoi.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation>ID de message invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation>usage: mms init &lt;signataires_requis&gt;/&lt;signataires_autorisés&gt; &lt;mon_étiquette&gt; &lt;mon_adresse_de_transport&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation>MMS est déjà initialisé. Réinitialiser en supprimer toutes les informations des signataires et les messages ?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation>Erreur dans le nombre de signataires requis et/ou de signataires autorisés</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation>MMS n&apos;est pas activé.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation>Nombre de signataires invalide </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation>mms signer [&lt;nombre&gt; &lt;étiquette&gt; [&lt;adresse_de_transport&gt; [&lt;adresse_monero&gt;]]]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation>Adresse Monero invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation>L&apos;état du portefeuille ne permet plus de changer les adresses Monero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation>Usage : mms list</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation>Usage : mms next [sync]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation>Pas d&apos;étape suivante : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation>prepare_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation>make_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation>exchange_multisig_keys</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation>export_multisig_info</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation>import_multisig_info</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation>sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation>submit_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation>Envoyer la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation>Traiter la configuration de signataire</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation>Traiter les données d&apos;auto configuration</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation>Rien n&apos;est prêt à être traité</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation>Usage : mms sync</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation>Usage : mms delete (&lt;ID_message&gt; | all)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation>Supprimer tous les messages ?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation>Usage : mms send [&lt;ID_message&gt;]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation>Usage : mms receive</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation>Usage : mms export &lt;ID_message&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation>Contenu du message sauvegardé dans : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation>Échec de la sauvegarde du contenu du message</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation>Usage : mms note [&lt;étiquette&gt; &lt;texte&gt;]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation>Usage : mms show &lt;ID_message&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation>Usage : mms set &lt;nom_option&gt; [&lt;valeur_option&gt;]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation>Mauvaise valeur d&apos;option</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation>Option inconnue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation>Usage : mms help [&lt;sous_commande&gt;]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation>Usage : mms send_signer_config</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation>Configuration de signataire pas encore complète</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation>Usage : mms start_auto_config [&lt;étiquette&gt; &lt;étiquette&gt; ...]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation>Il y a des signataire sans étiquette définie. Définissez les étiquettes avant l&apos;auto configuration ou spécifiez les en paramêtre ici.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation>Usage : mms stop_auto_config</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation>Auto configuration déjà en cours. Annuler et recommencer ?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation>MMS non disponible pour ce portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation>Sous-commande MMS invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation>Erreur dans la commande MMS : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>La monnaie réclamée ne va pas à une adresse payée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>La monnaie réclamée est supérieure au paiement à l&apos;adresse de monnaie</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation>envoi de %s à %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation> sortie(s) factice(s)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation>sans destination</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation>Ceci est un portefeuille multisig, il ne peut signer qu&apos;avec sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation>Échec de signature de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation>Échec de signature de transaction : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation>Données brutes hex de la transaction exportées vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation>Échec du chargement de la transaction du fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation>Erreur RPC : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il n&apos;a pas de clé de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation>Votre mot de passe original est incorrect.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation>Erreur avec la réécriture du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation>unité invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation>nombre invalide : un entier non signé est attendu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation>valeur invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation>mauvais paramètre m_restore_height : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation>La hauteur de restauration est : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Le démon est local, supposons qu&apos;il est de confiance</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation>Mot de passe pour le nouveau portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation>erreur interne : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation>erreur inattendue : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation>erreur inconnue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation>échec du rafraîchissement : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation>Blocs reçus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation>solde débloqué : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation>montant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation>faux</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation>Commande inconnue : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation>Usage de la commande : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation>Description de la commande : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation>le portefeuille est multisig mais pas encore finalisé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation>Échec de la récupération de la phrase mnémonique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation>le portefeuille est multisig et n&apos;a pas de phrase mnémonique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation>Erreur : échec de l&apos;estimation de la taille du tableau d&apos;arriéré : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation>Erreur : mauvaise estimation de la taille du tableau d&apos;arriéré</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation> (actuel)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation>arriéré de %u bloc(s) (%u minutes) à la priorité %u%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation>arriéré de %u à %u bloc(s) (%u à %u minutes) à la priorité %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation>Pas d&apos;arriéré à la priorité </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation>Le portefeuille est déjà multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas être tranformé en multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation>Ce portefeuille a été utilisé auparavant, veuillez utiliser un nouveau portefeuille pour créer un portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation>Envoyez ces infos multisig à tous les autres participants, ensuite utilisez make_multisig &lt;seuil&gt; &lt;info1&gt; [&lt;info2&gt;...] avec les infos multisig des autres</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation>Ceci inclut la clé PRIVÉE d&apos;audit, donc ne doit être divulgué qu&apos;aux participants de ce portefeuille multisig </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation>Seuil invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation>Une autre étape est nécessaire</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation>Erreur de création multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation>Erreur de création multisig : le nouveau portefeuille n&apos;est pas multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation> adresse multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation>Ce portefeuille n&apos;est pas multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation>Ce portefeuille est déjà finalisé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation>Échec de finalisation multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation>Échec de finalisation multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation>Ce portefeuille multisig n&apos;est pas encore finalisé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation>Erreur d&apos;importation des infos multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation>Infos multisig exportées vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation>Infos multisig importées</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation>Échec de l&apos;importation des infos multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation>Échec de la mise à jour de l&apos;état des dépenses après l&apos;importation des infos multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation>Pas un démon de confiance, l&apos;état des dépenses peut être incorrect. Utilisez un démon de confiance et executez &quot;rescan_spent&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation>Ceci n&apos;est pas un portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation>Échec de la signature de la transaction multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation>Erreur multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation>Échec de la signature de la transaction multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation>Elle peut être transmise au réseau avec submit_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation>Échec du chargement de la transaction multisig du fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation>Transaction multisig signée par %u signataire(s) seulement, nécessite %u signature(s) de plus</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation>Transaction transmise avec succès, transaction </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation>Vous pouvez vérifier son statut en utilisant la commane &apos;show_transfers&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation>Échec de l&apos;exportation de la transaction multisig vers le fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation>Transaction multisig enregistrée dans le(s) fichier(s) : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation>Image de clef ou ID de transaction invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation>échec de la déconstruction du cercle</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation>usage : %s &lt;image_clef&gt;|&lt;clef_publique&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation>Gelé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation>Non gelé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation> octets envoyés</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation> octets reçus</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation>Bienvenue dans Monero, la crypto-monnaie confidentielle.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation>Monero, comme Bitcoin, est une crypto-monnaie. C&apos;est à dire que c&apos;est une monnaie numérique.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation>aucune technologie de confidentialité n&apos;est parfaite à 100%, Monero inclus.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation>Des failles dans Monero pourraient être découvertes dans le futur, et des attaques pourraient être développées pour jeter un coup d&apos;oeil sous certaines</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation>des couches de confidentialité que Monero fournit. Soyez prudent et pratiquez la défense en profondeur.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation>la taille de cercle doit être un nombre entier &gt;= </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation>échec du changement de la taille de cercle par défaut</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation>Hauteur invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation>argument invalide : doit être 1/yes ou 0/no</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation>Démarrer la mine dans le démon (mine_arrière_plan et ignorer_batterie sont des booléens facultatifs).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation>Arrêter la mine dans le démon.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation>Spécifier un autre démon auquel se connecter.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation>Sauvegarder les données actuelles de la châine de blocs.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation>Synchroniser les transactions et le solde.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation>Afficher le solde du compte actuellement sélectionné.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -2583,47 +1961,38 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation>Afficher les paiements pour les IDs de paiement donnés.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation>Afficher la hauteur de la chaîne de blocs.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation>Envoyer toutes les sorties non mélangeables à vous-même avec une taille de cercle de 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation>Envoyer toutes les sorties débloquées d&apos;un montant inférieur au seuil à une adresse.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation>Envoyer une unique sortie ayant une image de clé donnée à une adresse sans rendu de monnaie.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation>Donner &lt;montant&gt; à l&apos;équipe de développement (donate.getmonero.org).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation>Transmettre une transaction signée d&apos;un fichier.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation>Changer le niveau de détail du journal (le niveau doit être &lt;0-4&gt;).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -2640,42 +2009,34 @@ Si l&apos;argument &quot;untag&quot; est spécifié, les mots clés assignés au
 Si l&apos;argument &quot;tag_description&quot; est spécifié, le texte arbitraire &lt;description&gt; est assigné au mot clé &lt;mot_clé&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation>Encoder un ID de paiement dans une adresse intégrée pour l&apos;adresse publique du portefeuille actuel (en l&apos;absence d&apos;argument un ID de paiement aléatoire est utilisé), ou décoder une adresse intégrée en une adresse standard et un ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation>Afficher toutes les entrées du carnet d&apos;adresses, optionnellement en y ajoutant/supprimant une entrée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation>Sauvegarder les données du portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation>Sauvegarder un fichier de clés d&apos;audit.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation>Afficher la clé privée d&apos;audit.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation>Afficher la clé privée de dépense.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation>Afficher la phrase mnémonique de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2746,47 +2107,38 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation>Afficher la phrase mnémonique de style Electrum chiffrée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation>Rescanner la chaîne de blocs pour trouver les sorties dépensées.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation>Obtenir la clé de transaction (r) pour un &lt;ID_transaction&gt; donné.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation>Vérifier le montant allant à &lt;adresse&gt; dans &lt;ID_transaction&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation>Générer une signature prouvant l&apos;envoi de fonds à &lt;adresse&gt; dans &lt;ID_transaction&gt;, optionnellement avec un &lt;message&gt; comme challenge, en utilisant soit la clé secrète de transaction (quand &lt;adresse&gt; n&apos;est pas l&apos;adresse de votre portefeuille) soit la clé secrète d&apos;audit (dans le cas contraire), tout en ne divulguant pas la clé secrète.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation>Vérifier la validité de la preuve de fonds allant à &lt;adresse&gt; dans &lt;ID_transaction&gt; avec le &lt;message&gt; de challenge s&apos;il y en a un.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Générer une signature prouvant que vous avez créé &lt;ID_transaction&gt; en utilisant la clé secrète de dépense, optionnellement avec un &lt;message&gt; comme challenge.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Vérifier la validité de la preuve que le signataire a créé &lt;ID_transaction&gt;, optionnellement avec un &lt;message&gt; comme challenge.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
@@ -2795,301 +2147,238 @@ Si &apos;all&apos; est spécifié, vous prouvez la somme totale des soldes de to
 Sinon, vous prouvez le plus petit solde supérieur à &lt;montant&gt; dans votre compte actuel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Vérifier la validité d&apos;une signature prouvant que le propriétaire d&apos;une &lt;adresse&gt; détient au moins un montant, optionnellement avec un &lt;message&gt; comme challenge.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation>Afficher les sorties non dépensées d&apos;une adresse spécifique dans un interval de montants facultatif.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation>Rescanner la chaîne de blocs depuis le début. Si &quot;hard&quot; est spécifié, vous perdrez toute information qui ne peut être récupérée à partir de la chaîne de blocs elle-même.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation>Définir un texte arbitraire comme note pour &lt;ID_transaction&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation>Obtenir le texte de la note pour un ID de transaction.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation>Définir un texte arbitraire comme description du portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation>Obtenir la description du portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation>Afficher l&apos;état du portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation>Afficher les informations du portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation>Signer le contenu d&apos;un fichier.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation>Vérifier la signature du contenu d&apos;un fichier.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation>Importer un ensemble signé d&apos;images de clé et vérifier si elles correspondent à des dépenses.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation>Exporter un ensemble de sorties possédées par ce portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation>Importer un ensemble de sorties possédées par ce portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation>Afficher les information à propos d&apos;un transfert vers/depuis cette adresse.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation>Changer le mot de passe du portefeuille.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation>Afficher les informations à propos des frais et arriéré de transactions actuels.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation>Exporter les données nécessaires pour créer un portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation>Transformer ce portefeuille en portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation>Transformer ce portefeuille en portefeuille multisig, étape supplémentaire pour les portefeuilles N-1/N</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation>Exporter les infos multisig pour les autres participants</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation>Importer les infos multisig des autres participants</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation>Signer une transaction multisig d&apos;un fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation>Transmettre une transaction multisig signée d&apos;un fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation>Exporter une transaction multisig signée vers un fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation>Déconstruire le cercle utilisé pour une image de clé ou une transaction donnée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation>Geler une sortie par image de clé pour qu&apos;elle ne soit pas utilisée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation>Vérifie si une sortie est actuellement gelée par image de clé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation>Affiche des informations basiques à propos de Monero pour les nouveaux utilisateurs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation>Afficher la section d&apos;aide ou la documentation d&apos;une &lt;commande&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation>entier &gt;= </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation>hauteur de bloc</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation>1/yes ou 0/no</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation>Aucun portefeuille avec ce nom trouvé. Confirmer la création d&apos;un nouveau portefeuille nommé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation>impossible de spécifier à la fois --restore-deterministic-wallet ou --restore-multisig-wallet et --non-deterministic</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-multisig-wallet utilise --generate-new-wallet, pas --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation>spécifiez un paramètre de récupération avec --electrum-seed=&quot;phrase mnémonique multisig ici&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation>Échec de la vérification de la phrase mnémonique multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation>Cette adresse est une sous-adresse qui ne peut pas être utilisée ici.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation>Erreur : M/N attendu, mais lu : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation>Erreur : N &gt; 1 et N &lt;= M attendu, mais lu : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation>Erreur : M/N n&apos;est actuellement pas supporté. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation>Génération du portefeuille principal à partir de %u de %u clés de portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation>Erreur : M/N n&apos;est actuellement pas supporté</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation>Hauteur de restauration </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation>Si vous êtes nouveau dans Monero, tapez &quot;welcome&quot; pour un bref aperçu.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation>Le démon n&apos;est pas lancé ou un mauvais port a été fourni. Veuillez vous assurer que le démon fonctionne ou changez l&apos;adresse de démon avec la commande &apos;set_daemon&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation>Erreur lors de la création du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -3108,828 +2397,624 @@ votre portefeuille à nouveau (mais les clés de votre portefeuille ne risquent 
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation>échec de la génération du nouveau portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation>Nouveau portefeuille multisig %u/%u généré : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation>Portefeuille multisig %u/%u ouvert%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation>Utilisez &quot;help &lt;commande&gt;&quot; pour voir la documentation d&apos;une commande.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation>c&apos;est un portefeuille multisig et il ne peut pas sauvegarder une version d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation>Échec de la requête du statut de l&apos;extraction minière : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation>Échec de la configuration de l&apos;extraction minière en arrière-plan : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation>Taille de tableau inattendue - Sortie de simple_wallet::set_daemon()</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation>Ceci semble ne pas être une URL de démon valide.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation>ID transaction </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation>index </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation>NOTE : Cette transaction est verrouillée, voir les détails avec : show_transfer </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation>Nouveau transfert reçu depuis que l&apos;analyse a été lancée. Les images de clé sont incomplètes.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation> (Certaines sorties ont des images de clé partielles - import_multisig_info requis)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation>Compte actuellement sélectionné : [</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation>] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation>Mot clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation>(Pas de mot clé assigné)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation>Solde par adresse :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation>Solde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation>Solde débloqué</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation>Sorties</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation>Étiquette</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation>%8u %6s %21s %21s %7u %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation>dépensé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation>index global</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation>ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation>index adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation>Utilisé aux hauteurs : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation>[gelé]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation>Aucun transfert entrant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation>Aucun transfert entrant disponible</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation>Aucun transfert entrant non disponible</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation>paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation>transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation>hauteur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation>durée de déverrouillage</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation>Aucun paiement avec l&apos;ID </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation>échec de la récupération de la hauteur de la chaîne de blocs : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation>
 Transaction %llu/%llu : ID=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation>échec de la récupération de la sortie : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation>la hauteur du bloc d&apos;origine de la clé de la sortie ne devrait pas être supérieure à celle de la chaîne de blocs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation>
 Hauteurs des blocs d&apos;origine : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation>
 Attention : Certaines clés d&apos;entrées étant dépensées sont issues de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation>, ce qui peut casser l&apos;anonymat du cercle de signature. Assurez-vous que c&apos;est intentionnel !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation>La taille de cercle ne doit pas être 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation>la taille de cercle %u est trop petite, le minimum est %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation>mauvais nombre d&apos;arguments</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation>Aucune sortie trouvée, ou le démon n&apos;est pas prêt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation> 
 Cette transaction (%s de monnaie rendue inclue) sera déverrouillée au bloc %llu, dans approximativement %s jours (en supposant 2 minutes par bloc)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation>Échec de l&apos;analyse de l&apos;adresse de don : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation>Don de %s %s à %s.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;hauteur_min&gt; [&lt;hauteur_max&gt;]] [output=&lt;chemin&gt;]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation>direction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation>horodatage</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation>solde courant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation>hachage</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation>ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation>frais</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation>destination</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation>note</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation>CSV exporté vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation>Attention : votre hauteur de restauration est supérieure à celle du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation>Rescanner quand même ? (Y/Yes/N/No) : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation>MMS a reçu un nouveau message</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation>commande supportée uniquement par un portefeuille matériel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation>le portefeuille matériel ne supporte pas la synchronisation des images de clé à froid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation>Veuillez confirmer la synchronisation des images de clé sur le périphérique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation>Images de clé synchronisées à la hauteur </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation>Utilisation d&apos;un démon dans lequel on n&apos;a pas entièrement confiance, impossible de déterminer quelle sortie de transaction est dépensée. Utilisez un démon de confiance avec --trusted-daemon et exécutez rescan_spent</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation> dépensé, </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation> non dépensé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation>Échec de l&apos;importation des images de clé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation>Échec de l&apos;import des images de clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation>Échec de la reconnexion à l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation>Échec de la reconnexion à l&apos;appareil : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation>Transaction sauvegardée avec succès dans </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation>, ID transaction </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation>Échec de la sauvegarde de la transaction dans </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation>Ceci est un portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation>Double dépense détectée sur le réseau : cette transaction sera peut-être invalidée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation>ID de transaction non trouvé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation>vrai</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation>échec de l&apos;analyse du type de rafraîchissement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation>commande non supportée par le portefeuille matériel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il n&apos;a pas de phrase mnémonique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation>c&apos;est un portefeuille non déterministe et il n&apos;a pas de phrase mnémonique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation>Entrer une phrase de passe facultative pour le décalage de la phrase mnémonique, effacer pour voir la phrase mnémonique brute</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation>Mot de passe invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation>Les frais sont actuellement de %s %s par %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation>Image de clé invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation>ID de transaction invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation>Image de clé soit non dépensée, soit dépensée avec 0 mélange</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation>Échec de la récupération du cercle de l&apos;image de clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation>Le fichier d&apos;existe pas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation>Spécification de cercle invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation>Image de clé invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation>Type de cercle invalide, &quot;relative&quot; ou &quot;absolute&quot; attendu : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation>Erreur lors de la lecture de la ligne : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation>Cercle invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation>Cercle relatif invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation>Cercle absolu invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation>Échec de l&apos;affectation du cercle pour l&apos;image de clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation>On continue.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation>Mot clé &quot;absolute&quot; ou &quot;relative&quot; manquant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation>index invalide : doit être un nombre entier strictement positif</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation>index invalide : boucle des indices</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation>index invalide : les indices doivent être en ordre strictement croissant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation>échec de l&apos;affectation du cercle</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation>La première ligne n&apos;est pas un montant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation>Sortie invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation>Mauvais argument : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation>devrait être &quot;add&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation>Échec de l&apos;ouverture du fichier</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation>Clé de sortie invalide, et le fichier n&apos;existe pas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation>Sortie invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation>Échec de la sauvegarde des cercles connus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation>Commande &apos;%s&apos; inconnue, essayez &apos;help&apos;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas transférer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation>ATTENTION : ceci c&apos;est pas la taille de cercle par défaut, ce qui peut nuire à votre confidentialité. La valeur par défaut est recommandée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation>ATTENTION : ) partir de v8, la taille de cercle sera fixée et ce paramètre sera ignoré.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation>la priorité doit être 0, 1, 2, 3, 4 ou l&apos;une de : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation>échec du changement de la priorité par défaut</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation>argument invalide : doit être soit 0/never, 1/action, ou 2/encrypt/decrypt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation>Nombre de secondes invalide</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation>Format d&apos;export non spécifié</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation>Format d&apos;export non reconnu.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation>Transférer &lt;montant&gt; à &lt;adresse&gt; Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par les adresses de ces indices. Si il est omis, le portefeuille choisit les indices d&apos;adresse à utiliser aléatoirement. Dans tous les cas, il essaye de ne pas combiner des sorties de multiples adresses. &lt;priorité&gt; est la priorité de la transaction. Plus la priorité est haute, plus les frais de transaction sont élevés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont : unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité. De multiples paiements peuvent être réalisés d&apos;un coup en ajoutant &lt;URI_2&gt; ou &lt;adresse_2&gt; &lt;montant_2&gt; et cetera (avant l&apos;ID de paiement, si il est inclus)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation>Transférer &lt;montant&gt; à &lt;adresse&gt; et le verrouiller pendant &lt;blocs_verrou&gt; (max 1000000). Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par les adresses de ces indices. Si il est omis, le portefeuille choisit les indices d&apos;adresse à utiliser aléatoirement. Dans tous les cas, il essaye de ne pas combiner des sorties de multiples adresses. &lt;priorité&gt; est la priorité de la transaction. Plus la priorité est haute, plus les frais de transaction sont élevés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont : unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité. De multiples paiements peuvent être réalisés d&apos;un coup en ajoutant &lt;URI_2&gt; ou &lt;adresse_2&gt; &lt;montant_2&gt; et cetera (avant l&apos;ID de paiement, si il est inclus)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation>Transférer tout le solde débloqué à une adresse et le verrouiller pendant &lt;blocs_verrou&gt; (max 1000000). Si le paramètre &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille utilise les sorties reçues par ces indices d&apos;adresse. Si il est omis, le portefeuille choisit un index d&apos;adresse à utiliser aléatoirement. &lt;priorité&gt; est la priorité du balayage. Plus la priorité est haute, plus les frais de transaction sont élevés. Les valeurs valides par ordre de priorité (de la plus basse à la plus haute) sont : unimportant, normal, elevated, priority. Si elle est omise, la valeur par défaut (voir la commande &quot;set priority&quot;) est utilisée. &lt;taille_cercle&gt; est le nombre d&apos;entrées à inclure pour l&apos;intraçabilité.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation>Envoyer tout le solde débloqué à une adresse. Si le paramètre &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; est spécifié, le portefeuille balaye les sorties reçues par ces indices d&apos;adresse. Si il est omis, le portefeuille choisit un index d&apos;adresse à utiliser aléatoirement. Si le paramètre &quot;outputs=&lt;N&gt;&quot; est spécifié et N &gt; 0, le portefeuille scinde la transaction en N sorties égales.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation>Signer une transaction à partir d&apos;un fichier. Si le paramètre &quot;export_raw&quot; est spécifié, les données brutes hexadécimales adaptées au RPC /sendrawtransaction du démon sont exportées.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation>Si aucun argument n&apos;est spécifié ou si &lt;index&gt; est spécifié, le portefeuille affiche l&apos;adresse par défaut ou l&apos;adresse spécifiée. Si &quot;all&quot; est spécifié, le portefeuille affiche toutes les adresses existantes dans le comptes actuellement sélectionné. Si &quot;new&quot; est spécifié, le portefeuille crée une nouvelle adresse avec le texte d&apos;étiquette fourni (qui peut être vide). Si &quot;label&quot; est spécifié, le portefeuille affecte le texte fourni à l&apos;étiquette de l&apos;adresse spécifiée par &lt;index&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation>Afficher la hauteur de restauration</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation>Définir la clé de transaction (r) pour un &lt;ID_transaction&gt; donné au cas où cette clé ait été créée par un appareil ou portefeuille tiers.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation>Essayer de se reconnecter à un portefeuille matériel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -3940,778 +3025,566 @@ Format de sortie :
 Image de clé, &quot;absolue&quot;, liste de cercles</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation>Définir le cercle utilisé pour une image de clé donnée, afin de pouvoir le réutiliser dans un fork</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation>Sauvegarder les cercles connus dans la base de données des cercles partagés</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation>Retourne les informations de version</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation>full (le plus lent, aucune supposition); optimize-coinbase (rapide, suppose que la récompense de bloc est payée à une unique adresse); no-coinbase (le plus rapide, suppose que l&apos;on ne reçoit aucune récompense de bloc), default (comme optimize-coinbase)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation>0, 1, 2, 3, 4 ou l&apos;une de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation>0|1|2 (ou never|action|decrypt)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation>monero, millinero, micronero, nanonero, piconero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation>&lt;majeur&gt;:&lt;mineur&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation>entier non signé (secondes, 0 pour désactiver)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation>&quot;binary&quot; ou &quot;ascii&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation>Nom de portefeuille non valide. Veuillez réessayer ou utilisez Ctrl-C pour quitter.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation>Fichier portefeuille et fichier de clés trouvés, chargement...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation>Fichier de clés trouvé mais pas le fichier portefeuille. Régénération...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation>Fichier de clés non trouvé. Échec de l&apos;ouverture du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation>Génération du nouveau portefeuille...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation>Impossible de spécifier plus d&apos;une option parmis --testnet et --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation>impossible de spécifier plus d&apos;une option parmis --generate-new-wallet=&quot;nom_portefeuille&quot;, --wallet-file=&quot;nom_portefeuille&quot;, --generate-from-view-key=&quot;nom_portefeuille&quot;, --generate-from-spend-key=&quot;nom_portefeuille&quot;, --generate-from-keys=&quot;nom_portefeuille&quot;, --generate-from-multisig-keys=&quot;nom_portefeuille&quot;, --generate-from-json=&quot;nom_fichier_json&quot; et --generate-from-device=&quot;nom_portefeuille&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Échec de la vérification de la liste de mots de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation>Entrer une phrase de passe pour le décalage de la phrase mnémonique, vide si aucun</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation>Pas de données fournies, annulation</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation>échec de l&apos;analyse de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation>la clé d&apos;audit ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation>échec de la création du compte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation>échec de la vérification de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation>la clé de dépense ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation>Aucune hauteur de restauration n&apos;est spécifiée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation>Nous supposons que vous créez un nouveau compte, la restauration sera faite à partir d&apos;une hauteur de la chaîne de blocs estimée.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation>création du compte annulée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation>Impossible de spécifier --subaddress-lookahead et --wallet-file en même temps</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation>échec de l&apos;ouverture du compte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation>portefeuille est nul</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation>Attention : utilisation d&apos;un démon dans lequel on n&apos;a pas entièrement confiance à %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation>Utiliser le démon d&apos;un tiers peut nuire à votre sécurité et à votre confidentialité</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation>Utiliser le votre sans SSL expose votre trafic RPC à la surveillance</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation>Si vous ou quelqu&apos;un en qui vous avez confiance gère ce démon, vous pouvez utiliser --trusted-daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation>Impossible d&apos;initialiser la base de données des cercles : les fonctions d&apos;amélioration de la confidentialité seront inactives</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation>Si votre affichage se bloque, quittez en aveugle avec ^C, puis lancer à nouveau en utilisant --use-english-language-names</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation>choix de langue passé invalide. Veuillez réessayer.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation>Clé d&apos;audit : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation>Nouveau portefeuille généré sur l&apos;appareil : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation>Fichier des clés non trouvé. Échec d&apos;ouverture du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation>Vous pourriez vouloir supprimer le fichier &quot;%s&quot; et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation>échec de la désinitialisation du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation>Portefeuille d&apos;audit sauvegardé vers : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation>Échec de la sauvegarde du portefeuille d&apos;audit : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>cette commande requiert un démon de confiance. Activer avec --trusted-daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation>&quot;trusted&quot; ou &quot;untrusted&quot; attendu, mais lu </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation>de confiance</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation>non fiable</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation>la chaîne de blocs ne peut pas être sauvegardée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation>Mot de passe requis (%s) - utilisez la commande refresh</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation>Entrez le mot de passe</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation>erreur du rafraîchissement : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation> (Il manque les images de clé de certaines sorties - import_key_images requis)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation>Solde : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation>clé publique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation>image de clé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation>déverrouillé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation>vérrouillé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>format d&apos;identifiant de paiement invalide, 16 ou 64 caractères hexadécimaux attendus : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation>échec de la récupération du statut de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation>échec de la recherche des données pour contruire l&apos;entrée de la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation>
 Entrée %llu/%llu (%s): montant=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation>la même transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation>blocs très proches dans le temps</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation>Verrouillé pour cause d&apos;inactivité. Le mot de passe du portefeuille est requis pour déverrouiller la console.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation>la taille de cercle %u est trop grande, le maximum est %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation>échec de l&apos;encodage de l&apos;ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement court à partir de l&apos;URI</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation>Dernier argument invalide : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation>une unique transaction ne peut pas utiliser plus d&apos;un ID de paiement</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement, bien qu&apos;il ait été détecté</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation>Pas assez de fonds dans le solde débloqué</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation>paramètre blocs_verrou manquant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation>mauvais paramètre blocs_verrou</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation>Échec de l&apos;analyse du nombre de sorties</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation>Le nombre de sorties doit être supérieur à 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation>Don de %s %s à The Monero Project (donate.getmonero.org ou %s).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation>échec de l&apos;analyse de la clé de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation>Clé de transaction sauvegardée avec succès.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation>Échec de la sauvegarde de la clé de transaction : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation>Bonne signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation>Mauvaise signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation>usage : show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;hauteur_min&gt; [&lt;hauteur_max&gt;]]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation>bloc</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation>Attention : ceci pedra toute information qui ne peut pas être retrouvée à partir de la chaîne de blocs.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation>Ceci inclut les adresses de destination, les clé secrètes de transaction, les notes de transaction, etc</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation>Adresse standard : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation>échec de l&apos;analyse de l&apos;ID de paiement ou de l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation>échec de l&apos;analyse de l&apos;index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation>Le carnet d&apos;adresses est vide.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation>Index : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation>Adresse : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation>Description : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation>Type de réseau : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation>Stagenet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation>Mainnet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas signer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation>échec de la lecture du fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation>Nombre de blocs de verrouillage trop élevé, 1000000 maximum (~ 4 ans)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation>Est-ce correct quand même ?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation>Il y a actuellement un arriéré de %u blocs à ce niveau de frais. Est-ce acceptable ?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation>échec du chargement du fichier signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut générer de preuve</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation>La preuve de réserve ne peut être généré que par un portefeuille complet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation>L&apos;adresse ne doit pas être une sous-adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation>Bonne signature -- total : %s, dépensé : %s, non dépensé : %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation>[Double dépense détectée sur le réseau : cette transaction sera peut-être invalidée] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation>Il n&apos;y a pas de sortie non dépensée pour l&apos;adresse spécifiée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation> (pas de démon)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation> (désynchronisé)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation>(compte sans nom)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation>échec de l&apos;analyse de l&apos;index : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation>specifiez un index entre 0 et </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
@@ -4720,386 +3593,286 @@ Somme finale :
   Solde : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation>, solde débloqué : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation>Comptes sans mot clé :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation>Le mot clé %s n&apos;est pas enregistré.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation>Comptes avec mot clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation>Description du mot clé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation>Compte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation> %c%8u %6s %21s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation>----------------------------------------------------------------------------------</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation>%15s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation>Adresse primaire</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation>(utilisé)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation>(adresse sans nom)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation>&lt;index_min&gt; est déjà hors limite</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation>&lt;index_max&gt; excède la limite</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation>Les adresses intégrées ne peuvent être créées que pour le compte 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation>Adresse intégrée : %s, ID de paiement : %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation>Sous-adresse : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation>pas de description trouvée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation>description trouvée : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation>Fichier : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation>Audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation>Multisig %u/%u%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation>Type : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation>C&apos;est un portefeuille multisig et il ne peut pas signer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation>Mauvaise signature de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation>Bonne signature de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>c&apos;est un portefeuille d&apos;audit et il ne peut pas exporter les images de clé</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation>échec de l&apos;enregistrement du fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation>Images de clé signées exportées vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation>Sorties exportées vers </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation>montant erroné : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation>attend un nombre de 0 à </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation>Balayage de </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Fonds envoyés avec succès, transaction : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation>La monnaie rendue va à plus d&apos;une adresse</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation>%s de monnaie rendue à %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation>sans monnaie rendue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transaction signée avec succès dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation>échec de l&apos;analyse de l&apos;ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation>Clé de transaction : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation>aucune clé de transaction trouvée pour cet ID de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation>fichier signature sauvegardé dans : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation>échec de la sauvegarde du fichier signature</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation>échec de l&apos;analyse de la clé de transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation>erreur : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation>a reçu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation>dans la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation>n&apos;a rien reçu dans la transaction</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation>ATTENTION : cette transaction n&apos;est pas encore inclue dans la chaîne de blocs !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation>Cette transaction a %u confirmations</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation>ATTENTION : échec de la détermination du nombre de confirmations !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation>mauvais paramètre hauteur_minimum :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation>mauvais paramètre hauteur_maximum :</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation>reçu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation>&lt;montant_minimum&gt; doit être inférieur à &lt;montant_maximum&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation>
 Montant : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation>, nombre de clés : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation>
 Hauteur de bloc minimum : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation>
 Hauteur de bloc maximum : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation>
 Montant minimum trouvé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation>
 Montant maximum trouvé : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation>
 Compte total : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation>
 Taille de classe : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation>
 Sorties par * : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
@@ -5108,51 +3881,42 @@ Sorties par * : </translation>
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation>+--&gt; hauteur de bloc
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation>  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation>portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation>ID de paiement aléatoire : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation>Adresse intégrée correspondante : </translation>
     </message>
@@ -5160,65 +3924,50 @@ Sorties par * : </translation>
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5226,93 +3975,74 @@ Sorties par * : </translation>
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation>Nom de fichier de base (des suffixes -1, -2 etc seront ajoutés si nécessaire)</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation>Indiquer le seuil et les participants sous la forme M/N</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation>Combien de participants partageront des parts du portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation>Combien de signataires sont requis pour signer une transaction valide</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation>Créer des portefeuilles multisig testnet</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation>Créer des portefeuilles multisig stagenet</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation>Créer un fichier d&apos;adresse pour les nouveaux portefeuilles</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation>Génération de %u portefeuilles multisig %u/%u</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation>Échec de la vérification des infos multisig</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation>Erreur de vérification des infos multisig supplémentaires</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation>Portefeuilles multisig générés pour l&apos;adresse </translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation>Erreur de création des portefeuilles multisig : </translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation>Ce programme génère un ensemble de portefeuilles multisig - n&apos;utilisez cette méthode plus simple que si tous les participants se font confiance</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation>Erreur: Impossible de spécifier plus d&apos;une option parmis --testnet et --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation>Erreur : N/M attendu, mais lu : </translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation>Erreur : soit --scheme soit --threshold et --participants doivent être indiqués</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation>Erreur : N &gt; 1 et N &lt;= M attendu, mais lu N==%u et M==%d</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation>Erreur : --filename-base est requis</translation>
     </message>
@@ -5320,151 +4050,122 @@ Sorties par * : </translation>
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation>Utiliser l&apos;instance de PyBitmessage à l&apos;URL &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation>Spécifier &lt;arg&gt; comme utilisateur:mot_de_passe pour l&apos;API PyBitmessage</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation>Le portefeuille ne peut pas commencer une autre ronde d&apos;échange de clés car l&apos;ensemble des clés des autres signataires est manquant ou incomplet.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation>Il y a des messages en attente, mais rien n&apos;est prêt à être traité dans des circonstances normales</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation>
 Utilisez &quot;mms next sync&quot; si vous voulez forcer le traitement des données de synchronisation en attente</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation>
 Utilisez &quot;mms note&quot; pour afficher les notes en attente</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation>Il n&apos;y a pas de message en attente de traitement.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation>ensemble de clés</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation>ensemble de clés additionnel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation>transaction partiellement signée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation>transaction complètement signée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation>note</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation>configuration de signataire</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation>type de message inconnu</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation>entrant</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation>sortant</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation>direction de message inconnue</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation>prêt à envoyer</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation>envoyé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation>en attente</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation>traité</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation>annulé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation>état de message inconnu</translation>
     </message>
@@ -5472,238 +4173,190 @@ Utilisez &quot;mms note&quot; pour afficher les notes en attente</translation>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation>Générer un nouveau portefeuille et le sauvegarder dans &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation>Générer un nouveau portefeuille à partir de l&apos;appareil et le sauvegarder dans &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation>Générer un portefeuille d&apos;audit à partir d&apos;une clé d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation>Générer un portefeuille déterministe à partir d&apos;une clé de dépense</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation>Générer un portefeuille à partir de clés privées</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation>Générer un portefeuille principal à partir de clés de portefeuille multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation>Langue de la phrase mnémonique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation>Spécifier la phrase mnémonique Electrum pour la récupération/création d&apos;un portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation>Récupérer un portefeuille en utilisant une phrase mnémonique de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation>Récupérer un portefeuille multisig en utilisant une phrase mnémonique de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation>Générer des clés d&apos;audit et de dépense non déterministes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation>Restaurer depuis la hauteur estimée de la chaîne de blocs à la date spécifiée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation>argument invalide : doit être soit 0/1, true/false, y/n, yes/no</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation>Validation DNSSEC réussie</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation>ATTENTION: la validation DNSSEC a échoué, cette adresse n&apos;est peut être pas correcte !</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation>Pour l&apos;URL : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation> Adresse Monero = </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation>vous avez annulé la demande de transfert</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation>échec de l&apos;analyse de l&apos;index : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation>format invalide pour l&apos;anticipation des sous-addresses; doit être &lt;majeur&gt;:&lt;mineur&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>pas de connexion au démon. Veuillez vous assurer que le démon fonctionne.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation>Erreur RPC : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation>échec de la récupération de sorties aléatoires à mélanger : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation>Pas assez de fonds dans le solde débloqué</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation>Impossible de trouver une façon de créer les transactions. Ceci est souvent dû à de la poussière si petite qu&apos;elle ne peut pas payer ses propres frais, ou à une tentative d&apos;envoi d&apos;un montant supérieur au solde débloqué, ou à un montant restant insuffisant pour payer les frais</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation>pas assez de sorties pour la taille de cercle spécifiée</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation>montant de la sortie</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation>sorties à utiliser trouvées</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation>Veuillez utiliser sweep_unmixable.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation>la transaction n&apos;a pas été construite</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation>Raison : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation>une des destinations est zéro</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>échec de la recherche d&apos;une façon adéquate de scinder les transactions</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation>erreur de transfert inconnue : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation>Erreur multisig : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation>erreur interne : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation>erreur inattendue : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation>Il y a eu une erreur, ce qui pourrait signifier que le noeud essaye de vous faire réessayer de créer une transaction, pour tenter d&apos;identifier quelles sorties sont les votres. Ou il pourrait s&apos;agir d&apos;une erreur de bonne foi. Il pourrait être prudent de se déconnecter de ce noeud, et de ne pas essayer d&apos;envoyer une transaction immédiatement. Ou sinon, se connecter à un autre noeud pour que le noeud original ne puisse pas corréler les informations.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation>Le fichier %s contient probablement des clés privées de portefeuille ! Utilisez un nom de fichier différent.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation> secondes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation> minutes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation> heures</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation> jours</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation> mois</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation>longtemps</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
@@ -5712,82 +4365,66 @@ Il a besoin de se connecter à un démon monero pour fonctionner correctement.
 ATTENTION : Ne réutilisez pas vos clés Monero avec un autre fork, À MOINS QUE ce fork inclue des mitigations contre la réutilisation des clés. Faire ceci nuira à votre confidentialité.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation>Commande inconnue : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation>Autoriser la communication avec un démon utilisant une version de RPC différente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation>Restaurer à partir d&apos;une hauteur de bloc spécifique</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation>La transaction nouvellement créée ne sera pas transmise au réseau monero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation>Créer un fichier d&apos;adresse pour les nouveaux portefeuilles</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation>Afficher les noms de langue en anglais</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation>échec de la lecture du mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation>Entrer un nouveau mot de passe pour le portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation>Mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>le démon est occupé. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation>connexion avec le démon peut-être perdue</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation>Erreur : </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation>Est-ce correct ?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation>la transaction %s a été rejetée par le démon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation>Le fichier %s existe déjà. Êtes-vous sûr de vouloir l&apos;écraser ?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation>Échec de l&apos;initialisation du portefeuille</translation>
     </message>
@@ -5795,313 +4432,246 @@ ATTENTION : Ne réutilisez pas vos clés Monero avec un autre fork, À MOINS QUE
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>Utiliser l&apos;instance de démon située à &lt;hôte&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>Utiliser l&apos;instance de démon située à l&apos;hôte &lt;arg&gt; au lieu de localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation>Fichier mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>Utiliser l&apos;instance de démon située au port &lt;arg&gt; au lieu de 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>Pour testnet, le démon doit aussi être lancé avec l&apos;option --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>impossible de spécifier l&apos;hôte ou le port du démon plus d&apos;une fois</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>impossible de spécifier plus d&apos;une option parmis --password et --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation>le fichier mot de passe spécifié n&apos;a pas pu être lu</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation>Échec du chargement du fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Mot de passe du portefeuille (échapper/citer si nécessaire)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation>[&lt;ip&gt;:]&lt;port&gt; proxy socks à utiliser pour les connexions du démon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation>Activer les commandes qui dépendent d&apos;un démon de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation>Désactiver les commandes qui dépendent d&apos;un démon de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Spécifier le nom_utilisateur:[mot_de_passe] pour le client RPC du démon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation>Activer SSL pour les connexions RPC au démon : enabled|disabled|autodetect</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation>Liste des empreintes des serveurs RPC autorisés</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation>Autoriser une chaîne de certificats utilisateurs (via --daemon-ssl-ca-certificates)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation>Pour stagenet, le démon doit aussi être lancé avec l&apos;option --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation>Définir le chemin de la base de donnée de cercles partagés</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation>Nombre de rondes de la fonction de dérivation de clé</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation>Portefeuille matériel à utiliser</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation>Chemin de dérivation du périphérique de portefeuille matériel (e.g. SLIP-10)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation>Ne pas utiliser DNS</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation>Ne pas se connecter à un démon, ni utiliser DNS</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation>Fichier contenant de l&apos;entropie supplémentaire pour initialiser le PRNG (n&apos;importe quelles données, visez 256 bits d&apos;entropie pour que cela soit utile, ce qui signifie typiquement plus de 256 bits de données)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation>Argument invalide pour </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation>Activer --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation> requiert --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation> ou --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation> ou utilisez un domaine .onion/.i2p</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation>--trusted-daemon et --untrusted-daemon présents simultanément, --untrusted-daemon choisi</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Le démon est local, supposons qu&apos;il est de confiance</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation>pas de mot de passe spécifié; utilisez --prompt-for-password pour demander un mot de passe</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation>Entrer un nouveau mot de passe pour le portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation>Mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation>Échec de l&apos;analyse JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>Version %u trop récente, on comprend au mieux %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation>échec de la vérification de la clé secrète d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation>échec de l&apos;analyse de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation>échec de la vérification de la clé secrète de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Échec de la vérification de la liste de mots de style Electrum</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation>Il faut spécifier au moins une des options parmis la liste de mots de style Electrum, la clé privée d&apos;audit et la clé privée de dépense</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Liste de mots de style Electrum et clé privée spécifiées en même temps</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation>adresse invalide</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation>la clé d&apos;audit ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation>la clé de dépense ne correspond pas à l&apos;adresse standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Impossible de générer un portefeuille obsolète à partir de JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation>échec de l&apos;analyse de l&apos;adresse : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation>L&apos;adresse doit être spécifiée afin de créer un portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation>échec de la génération du nouveau portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation>Le mot de passe est requis pour calculer l&apos;image de clé pour les moneros entrants</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation>Mot de passe invalide : le mot de passe est requis pour calculer l&apos;image de clé pour les moneros entrants</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation>Compte primaire</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation>Aucun fonds n&apos;a été reçu dans cette transaction.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation>échec de la lecture du fichier </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation>Définir les tailles d&apos;anticipation des sous-addresses à &lt;majeur&gt;:&lt;mineur&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation>Chemin vers une clé privée au format PEM</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation>Chemin vers un certificat au format PEM</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation>Chemin vers un fichier contenant le(s) certificat(s) concaténé(s) au format PEM pour remplacer le(s) CA(s) du système.</translation>
     </message>
@@ -6109,126 +4679,100 @@ ATTENTION : Ne réutilisez pas vos clés Monero avec un autre fork, À MOINS QUE
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation>Échec de la création du répertoire </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation>Échec de la création du répertoire %s : %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation>Impossible de spécifier --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation> et --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation>Échec de la création du fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation>. Vérifiez les permissions ou supprimez le fichier</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation>Erreur d&apos;écriture dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation>nom_utilisateur/mot_de_passe RPC sauvegardé dans le fichier </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation>Le mot clé %s n&apos;est pas enregistré.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>Transaction impossible. Solde disponible : %s, montant de la transaction %s = %s + %s (frais)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation>Ceci est le portefeuille monero par RPC. Il a besoin de se
 connecter à un démon monero pour fonctionner correctement.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Impossible de spécifier plus d&apos;une option parmis --wallet-file et --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation>Impossible de spécifier plus d&apos;une option parmis --testnet et --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>--wallet-file, --generate-from-json ou --wallet-dir doit être spécifié</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation>Chargement du portefeuille...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation>Sauvegarde du portefeuille...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation>Sauvegardé avec succès</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation>Chargé avec succès</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation>Échec de l&apos;initialisation du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>Échec de l&apos;initialisation du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation>Démarrage du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation>Échec du lancement du portefeuille : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation>Arrêt du serveur RPC du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation>Échec de la sauvegarde du portefeuille : </translation>
     </message>
@@ -6236,81 +4780,64 @@ connecter à un démon monero pour fonctionner correctement.</translation>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation>Options du portefeuille</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation>Générer un portefeuille à partir d&apos;un fichier au format JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation>Utiliser le portefeuille &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation>Nombre maximum de threads à utiliser pour les travaux en parallèle</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation>Spécifier le fichier journal</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation>Fichier de configuration</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation>Options générales</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation>Ceci est le portefeuille monero en ligne de commande. Il a besoin de se
 connecter à un démon monero pour fonctionner correctement.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation>Impossible de trouver le fichier de configuration </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation>Journalisation dans : </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation>Journalisation dans %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation>ATTENTION : Vous pourriez ne pas avoir une limite de mémoire verrouillable assez élevée</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation>voir ulimit -l</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation>Usage :</translation>
     </message>

--- a/translations/monero_hi.ts
+++ b/translations/monero_hi.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>अवैध गंतव्य पता</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation>लेनदेन को फ़ाइल सहेजने की कोशिश कर रहा है, लेकिन फ़ाइल(लें) पहले से मौजूद। अधिलेखन के जोखिम की वजह से बाहर निकला। फ़ाइल:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>फ़ाइल में लेनदेन लिखने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>कार्यकर्ता व्यस्त है। बाद में पुन: प्रयास करें।</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>कार्यकर्ता से कोई संपर्क नहीं। कृपया सुनिश्चित करें कि कार्यकर्ता चल रहा है।</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>लेन-देन %s को कार्यकर्ता द्वारा अस्वीकार कर दिया गया, स्थिति: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation> कारण: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>अज्ञात अपवाद: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>अनियंत्रित अपवाद</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation>साइन डेटा को मल्टीसिग नहीं कर सका: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation>मल्टीसिग लेनदेन पर हस्ताक्षर नहीं कर सकते: </translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation>यह वॉलेट केवल देख सकते हैं</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation>लेन-देन पर हस्ताक्षर करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>दावा किया गया परिवर्तन भुगतान किए गए पते पर नहीं जा सका</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>दावा किया गया परिवर्तन परिवर्तन पते के भुगतान से बड़ा है</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation>परिवर्तन एक से अधिक पते पर जाता है</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation>%s को %s पर भेज रहा है</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation>कोई गंतव्य नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation>%s बदलकर %s करें</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation>कोई परिवर्तन नहीं</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation>लेन-देन %lu लोड, %s के लिए, शुल्क %s, %s,%s, न्यूनतम रिंग आकार %lu के साथ। %s</translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>कार्यकर्ता व्यस्त है। बाद में पुन: प्रयास करें।</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>कार्यकर्ता से कोई कनेक्शन नहीं। कृपया सुनिश्चित करें कि कार्यकर्ता चल रहा है।</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation>RPC त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation>आउटपुट को मिश्रण करने में विफल: %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation>निर्दिष्ट रिंग आकार के लिए पर्याप्त आउटपुट नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation>उपयोग करने के लिए आउटपुट मिले</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation>गैर मिश्रण योग्य उत्पाद को बदलें</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>हस्तांतरण के लिए पर्याप्त धनराशि नहीं, उपलब्ध राशि %s, केवल %s भेजे</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>पते की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>गुप्त खर्च कुंजी की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation>न तो दर्शन कुंजी और न ही खर्च कुंजी की आपूर्ति की गई, खर्च रद्द किया</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>गुप्त दर्शन कुंजी की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>गुप्त खर्च कुंजी की पुष्टि करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>खर्च की कुंजी पते से मेल नहीं खाती</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>गुप्त दर्शन कुंजी की पुष्टि करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>दर्शन की कुंजी पते से मेल नहीं खाती</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>नया बटुआ उत्पन्न करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation>एलेक्ट्रम बीज खाली है</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation>एलेक्ट्रम-शैली शब्द सूची सत्यापन विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>वॉलेट आयात अनुरोध भेजने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>अहस्ताक्षरित लेनदेन लोड करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation>लेनदेन को फ़ाइल से लोड करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation>बटुआ केवल दर्शनीय योग्य है</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation>फ़ाइल सहेजने में विफल </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>मुख्य छवियों को केवल एक विश्वसनीय कार्यकर्ता के माध्यम से आयात किया जा सकता है</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation>मुख्य छवि आयात करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation>उप-पता नामांकन प्राप्त करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation>उप पता नामांकन लगाने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation>मल्टीसिग जानकारी प्राप्त करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation>मल्टीसिग बनाने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation>मल्टीसिग वॉलेट निर्माण को अंतिम रूप देने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation>मल्टीसिग वॉलेट निर्माण को अंतिम रूप देने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation>मल्टीसिग छवियों को निर्यात करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation>आयातित मल्टीसिग छवियों की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation>मल्टीसिग छवियों को आयात करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation>आंशिक मल्टीसिग कुंजी छवियों की जांच करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation>मल्टीसिग लेनदेन को बहाल करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation>गन्तव्य पता अवैध</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation>अवैध उत्पाद: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation>उत्पादों को बतौर खर्च चिह्नित करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation>उत्पाद को बतौर खर्च चिह्नित करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation>उत्पाद को बतौर अव्ययित चिह्नित करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation>हस्तांतरण के लिए पर्याप्त धन नहीं, कुल मिलाकर केवल %s, भेजी गयी राशि %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>हस्तांतरण के लिए पर्याप्त धन नहीं, कुल मिलाकर केवल %s, लेनदेन राशि %s = %s + %s (शुल्क)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation>उत्पादित राशि</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation>लेन-देन का निर्माण नहीं किया गया था</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>लेन-देन %s को कार्यकर्ता द्वारा अस्वीकार कर दिया गया, स्थिति: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation>एक गंतव्य शून्य है</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>लेनदेन को विभाजित करने का एक उपयुक्त तरीका खोजने में विफल रहा</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation>अनजान स्थानांतरण त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation>आंतरिक त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation>अप्रत्याशित त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation>अनजान त्रुटि</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation>मिश्रण करने के लिए उत्पाद पाने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation>Txid की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation>इस txid के लिए कोई tx कुंजियाँ नहीं मिलीं</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation>Tx कुंजी की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation>पते की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation>पता एक उप-पता नहीं होना चाहिए</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation>वॉलेट मल्टीसिग तैयार अवस्था में होना चाहिए</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation>दिया गया स्ट्रिंग एक कुंजी नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>खर्च का पुनः आंकलन केवल एक विश्वसनीय कार्यकर्ता के साथ किया जा सकता है</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation>उत्पादित राशि की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation>उत्पादित ओफ़्सेट की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation>मुख्य छवि की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation>रिंग पाने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation>रिंग्स पाने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation>रिंग निर्धारित करने में विफल</translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation>पते की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation>कुंजी व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation>कुंजी सत्यापित करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation>कुंजी पते से मेल नहीं खाती</translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation>हाँ</translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation>नहीं</translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation>RPC सर्वर को बाँधने के लिए IP निर्दिष्ट करें</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation>RPC सर्वर के लिए उपयोगकर्ता नाम [: पासवर्ड] निर्दिष्ट करें</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation>Rpc-bind-ip के मान की पुष्टि करें की वह लूपबैक (स्थानीय) IP तो नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation>पार उत्पत्ति संसाधन साझा करने की अनुमति देने के लिए एक कॉमा से अलग की गई सूची को निर्दिष्ट करें</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation>-- के लिए दिया गया अमान्य IP पता</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation>आवक अकूटलेखित बाहरी संपर्क की अनुमति देता है। इसके बजाय SSH सुरंग या SSL प्रॉक्सी पर विचार करें। ओवरराइड के साथ -</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation>उपयोगकर्ता नाम के साथ निर्दिष्ट --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation>खाली नहीं हो सकता</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation>RPC सर्वर पासवर्ड की आवश्यकता है --</translation>
     </message>
@@ -661,941 +505,687 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished">दावा किया गया परिवर्तन भुगतान किए गए पते पर नहीं जा सका</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished">दावा किया गया परिवर्तन परिवर्तन पते के भुगतान से बड़ा है</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished">परिवर्तन एक से अधिक पते पर जाता है</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation type="unfinished">%s को %s पर भेज रहा है</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation type="unfinished">कोई गंतव्य नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation type="unfinished">कोई परिवर्तन नहीं</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation type="unfinished">फ़ाइल सहेजने में विफल </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation type="unfinished">अनजान त्रुटि</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation>अप्रत्याशित त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation>अमान्य कुंजी छवि</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation>अवैध लेनदेन-आईडी</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation>मुख्य छवि या तो खर्च नहीं हुई, या 0 मिश्रण के साथ खर्च की गई</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation>मुख्य छवि रिंग प्राप्त करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation>फ़ाइल मौजूद नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation>अमान्य रिंग विनिर्देश: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation>अवैध कुंजी छवि: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation>अमान्य रिंग प्रकार, सापेक्ष या पूर्ण की उम्मीद: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation>पढ़ने की पंक्ति में त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation>अवैध रिंग: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1603,57 +1193,46 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1664,224 +1243,180 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -1889,489 +1424,340 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished">एलेक्ट्रम-शैली शब्द सूची सत्यापन विफल</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation type="unfinished">पते की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished">गुप्त दर्शन कुंजी की व्याख्या करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished">गुप्त दर्शन कुंजी की पुष्टि करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished">नया बटुआ उत्पन्न करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2383,218 +1769,170 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished">कार्यकर्ता व्यस्त है। बाद में पुन: प्रयास करें।</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2665,550 +2003,415 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation type="unfinished">RPC त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation type="unfinished">आंतरिक त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished">भुगतान पहचान में अमान्य प्रारूप है, 16 या 64 वर्ण हेक्स स्ट्रिंग: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3222,42 +2425,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3266,73 +2461,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3340,1762 +2521,1345 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished">फ़ाइल में लेनदेन लिखने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation>मुख्यनेट</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation>(ह/हाँ/न/नहीं): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation>प्रसंस्करण चुनें:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation>लेन-देन हस्ताक्षर करें</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished">मुख्य छवि आयात करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished">यह वॉलेट केवल देख सकते हैं</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished">लेन-देन पर हस्ताक्षर करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished">लेनदेन को फ़ाइल से लोड करने में विफल</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished">इस txid के लिए कोई tx कुंजियाँ नहीं मिलीं</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished">पता एक उप-पता नहीं होना चाहिए</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation type="unfinished">अवैध उत्पाद: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation type="unfinished">%s बदलकर %s करें</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5103,65 +3867,50 @@ Grand total:
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5169,93 +3918,74 @@ Grand total:
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5263,149 +3993,120 @@ Grand total:
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,320 +4114,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation type="unfinished">RPC त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished">निर्दिष्ट रिंग आकार के लिए पर्याप्त आउटपुट नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation type="unfinished">उत्पादित राशि</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation type="unfinished">उपयोग करने के लिए आउटपुट मिले</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished">लेन-देन का निर्माण नहीं किया गया था</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished">एक गंतव्य शून्य है</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished">लेनदेन को विभाजित करने का एक उपयुक्त तरीका खोजने में विफल रहा</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished">अनजान स्थानांतरण त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation type="unfinished">आंतरिक त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation type="unfinished">अप्रत्याशित त्रुटि: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished">कार्यकर्ता व्यस्त है। बाद में पुन: प्रयास करें।</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5734,313 +4371,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished">एलेक्ट्रम-शैली शब्द सूची सत्यापन विफल</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished">नया बटुआ उत्पन्न करने में विफल: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6048,125 +4618,99 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6174,80 +4718,63 @@ daemon to work correctly.</source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_it.ts
+++ b/translations/monero_it.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Indirizzo destinatario non valido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation>Sto tentando di salvare la transazione nel file, ma il file specificato è già esistente. Sto uscendo per non rischiare di sovrascriverlo. File:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Impossibile scrivere transazione/i su file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è impegnato. Prova più tardi.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>nessuna connessione con il daemon. Controlla che sia operativo.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transazione %s è stata respinta dal daemon con status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation>. Motivo: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>Eccezione sconosciuta: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>Eccezione non gestita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation>Impossibile firmare dati multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation>Impossibile firmare la transazione multifirma: </translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation>Questo è un portafoglio solo-vista</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation>Firma transazione fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Il cambiamento richiesto non porta a un indirizzo pagato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Il cambiamento richiesto è più largo del pagamento all&apos;indirizzo di cambio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation>Il cambiamento ha effetto su più di un indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation>inviando %s a %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation>senza destinazioni</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation>%s cambia in %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation>nessuna modifica</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation>Caricate %lu transazioni, per %s, commissione %s, %s, %s, con ring size minimo %lu. %s</translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è impegnato. Riprova più tardi.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>nessuna connessione con il daemon. Accertati che sia operativo.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation>errore RPC: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation>insufficiente numero di output per il ring size specificato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation>trovati output che possono essere usati</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation>Pulisci gli output non mixabili.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>non hai abbastanza fondi da trasferire, sono disponibili solo %s, ammontare inviato %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>parsing indirizzo fallito</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>impossibile effettuare il parsing della chiave segreta di spesa</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>impossibile effettuare il parsing della chiave segreta di visualizzazione</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>impossibile verificare la chiave segreta di spesa</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>la chiave di spesa non corrisponde all&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>verifica chiave segreta di visualizzazione fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>la chiave di visualizzazione non corrisponde all&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>impossibile generare il nuovo portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>Impossibile inviare la richiesta di importazione portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Impossibile caricare transazioni non firmate</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation>Impossibile caricare la transazione da file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation>Il portafoglio è di tipo solo visualizzazione</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation>impossibile salvare il file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>Le key image possono essere importate solo con un daemon fidato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation>Impossibile importare le key images: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation>Impossibile recuperare l&apos;etichetta del sottoindirizzo: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation>Impossibile assegnare l&apos;etichetta del sottoindirizzo: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation>Nessuna chiave di visualizzazione né chiave di spesa fornita, operazione annullata</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation>Il seed Electrum è vuoto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Verifica dell&apos;elenco parole in stile Electrum non riuscita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation>Impossibile ottenere informazioni multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation>Impossibile eseguire multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation>Impossibile finalizzare la creazione di un portafoglio multifirma</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation>Impossibile finalizzare la creazione di un portafoglio multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation>Impossibile esportare immagini multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation>Impossibile analizzare le immagini multifirma importate</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation>Impossibile importare immagini multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation>Impossibile controllare le immagini della chiave multifirma parziali: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation>Impossibile ripristinare la transazione multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation>L&apos;invio di tutto richiede un indirizzo di destinazione</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation>Le destinazioni e gli importi non corrispondono</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation>id pagamento ha un formato non valido, è prevista una stringa esadecimale di 64 caratteri:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation>Indirizzo destinatario non valido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation>una singola transazione non può utilizzare più di un id di pagamento</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>impossibile impostare id pagamento, anche se è stato decodificato correttamente</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation>impossibile ottenere gli output da mixare: %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation>fondi non sufficienti per il trasferimento, saldo totale %s, importo inviato %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>fondi non sufficienti per il trasferimento, disponibili solo %s, ammontare transazione %s = %s + %s (commissione)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation>ammontare output</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation>transazione non costruita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>la transazione %s è stata rifiutata dal daemon con status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation>una delle destinazioni è zero</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>impossibile trovare un modo per dividere le transazioni</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation>errore trasferimento sconosciuto: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation>errore interno: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation>errore inaspettato: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation>errore sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation>impossibile ottenere gli output da mixare</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation>Impossibile effettuare parsing del txid</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation>nessuna chiave tx trovata per questo txid</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation>Impossibile effettuare parsing della chiave tx</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation>Impossibile effettuare parsing dell&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation>L&apos;indirizzo non può essere un sottoindirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation>Il portafoglio deve essere in stato multifirma</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation>La stringa inserita non è una chiave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>&quot;Riscannerizza spesi&quot; può essere utilizzato solo da un daemon fidato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation>Output non valido: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation>Impossibile contrassegnare gli outputs come spesi</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation>Impossibile analizzare la quantità di output</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation>Impossibile analizzare l&apos;offset di output</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation>Impossibile contrassegnare l&apos;output come speso</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation>Impossibile contrassegnare l&apos;output come non speso</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation>Impossibile analizzare l&apos;immagine della chiave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation>Impossibile ottenere l&apos;anello</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation>Impossibile ottenere gli anelli</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation>Impossibile impostare l&apos;anello</translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation>Impossibile effettuare parsing dell&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation>Impossibile effettuare parsing della chiave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation>impossibile effettuare la verifica della chiave</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation>la chiave non corrisponde all&apos;indirizzo</translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation>sì</translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation>no</translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation>Specificare IP da associare al server RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation>Specificare l&apos;indirizzo IPv6 da associare al server RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation>Consenti IPv6 per RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation>Specifica username[:password] richiesta per server RPC</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation>Conferma valore rpc-bind-ip NON è un loopback IP (locale)</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation>Specificare una lista di origini i cui elementi sono separati da virgola al fine di consentire la condivisione incrociata fra le origini</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation>Abilita SSL su connessioni RPC: abilitato|disabilitato|rilevamento automatico</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation>Percorso della chiave privata in formato PEM</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation>Percorso del certificato in formato PEM</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation>Percorso del file contenente i certificati concatenati in formato PEM per sostituire le CA di sistema.</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation>Indirizzo IP non valido dato per --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation>permette connessioni esterne non criptate in entrata. Considera in alternativa un tunnel SSH o un proxy SSL. Sovrascrivi con --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation>Nome utente specificato con --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation> non può essere vuoto</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation> richiede la password del server RPC --</translation>
     </message>
@@ -661,930 +505,666 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation>Comandi: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation>impossibile leggere la password del portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation>password non valida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation>imposta seed: richiede un argomento. opzioni disponibili: lingua</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation>imposta: argomento/i non riconosciuto/i</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation>percorso file portafoglio non valido: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation>Sto tentando di generare o ripristinare il portafoglio, ma i(l) file specificato/i esiste/esistono già. Sto uscendo per non rischiare di sovrascrivere.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation>ha bisogno di un argomento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation>0 o 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation>intero senza segno</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation>specificare un parametro di ripristino con --electrum-seed=&quot;lista parole qui&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation>impossibile connettere il portafoglio al daemon: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation>Il daemon usa una versione principale RPC (%u) diversa da quella del portafoglio (%u): %s. Aggiorna una delle due, o usa --allow-mismatched-daemon-version.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation>Lista delle lingue disponibili per il seed del tuo portafoglio:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation>Hai usato una versione obsoleta del portafoglio. Per favore usa il nuovo seed che ti abbiamo fornito.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation>Nuovo portafoglio generato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation>impossibile generare nuovo portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation>Portafoglio solo-vista aperto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation>Portafoglio aperto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation>Stai utilizzando una versione disapprovata del portafoglio. Per favore procedi nell&apos;upgrade del portafoglio.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation>Stai utilizzando una versione disapprovata del portafoglio. Il formato del tuo portafoglio sta per essere aggiornato.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation>impossibile caricare portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation>Usa il comando &quot;help&quot; per visualizzare la lista dei comandi disponibili.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation>Dati del portafoglio salvati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation>Mining avviato nel daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation>il mining NON è stato avviato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation>Mining nel daemon interrotto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation>il mining NON è stato interrotto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation>Blockchain salvata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation>Blocco </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation>speso/i </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation>Sto iniziando il refresh...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation>Refresh finito, blocchi ricevuti: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>l&apos;id pagamento ha un formato invalido, dovrebbe essere una stringa hex di 16 o 64 caratteri: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation>parametro locked_blocks non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>una singola transazione non può usare più di un id pagamento: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>impossibile impostare id pagamento, anche se è stato decodificado correttamente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation>la dimensione dell&apos;anello %u è troppo grande, il massimo è %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation>codifica dell&apos;ID di pagamento non riuscita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation>impossibile analizzare l&apos;ID di pagamento breve dall&apos;URI</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation>Ultimo argomento non valido: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation>una singola transazione non può utilizzare più di un ID di pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation>errore nell&apos;analisi dell&apos;ID di pagamento, anche se è stato rilevato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation>transazione cancellata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation>Sto inviando %s. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>La tua transazione deve essere divisa in %llu transazioni. Una commissione verrà applicata per ogni transazione, per un totale di %s commissioni</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation>La commissione per la transazione è %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation>, della quale %s è polvere dovuta allo scambio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation>Un totale di %s in polvere verrà inviato all&apos;indirizzo della polvere</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation>Transazione(i) senza firma scritta(e) con successo su MMS</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Impossibile scrivere transazione/i su file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation>Transazioni/e non firmata/e scritte/a con successo su file: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation>Impossibile firmare transazioni a freddo con il portafoglio hardware</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation>Nessun output non-mixabile trovato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation>Fondi insufficienti in saldo sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation>Non è stato fornito nessun indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation>parametro lockedblocks mancante</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation>parametro locked_blocks errato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation>Impossibile analizzare il numero di outputs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation>La quantità di outputs deve essere maggiore di 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation>Impossibile analizzare l&apos;indirizzo di donazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation>Donare %s %s a The Monero Project (donate.getmonero.org o %s).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation>Donare %s %s a %s.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Il cambiamento richiesto non porta a un indirizzo pagato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Il cambiamento richiesto è più largo del pagamento all&apos;indirizzo di cambio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation>sto mandando %s a %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation> output dummy</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation>senza destinazioni</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation>Questo è un portafoglio multisig, può firmare solo con sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation>Impossibile firmare la transazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation>Impossibile firmare la transazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation>Dati esadecimali grezzi della transazione esportati su </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation>Impossibile caricare la transazione da file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation>errore RPC: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation>il portafoglio è solo-vista e non ha una chiave di spesa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation>La tua password originale era scorretta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation>Errore riscrittura wallet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation>unità invalida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation>conteggio invalido: deve essere un intero senza segno</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation>valore invalido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation>parametro m_restore_height non corretto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation>Ripristina altezza è: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Il daemon è locale, viene considerato fidato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation>Password per il nuovo portafoglio solo-vista</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation>errore interno: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation>errore inaspettato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation>errore sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation>refresh fallito: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation>Blocchi ricevuti: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation>bilancio sbloccato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation>ammontare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation>Comando sconosciuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation>Uso del comando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation>Descrizione del comando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation>il portafoglio è multisig ma ancora non finalizzato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation>Impossibile recuperare il seed</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation>il portafoglio è multisig e non ha seed</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation>Errore: impossibile stimare la dimensione dell&apos;array di backlog: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation>Errore: errata stima della dimensione dell&apos;array di backlog</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation> (attuale)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation>Backlog blocco %u (%u minuti) a priorità %u%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation>Backlog blocco %u a %u (%u a %u minuti) a priorità %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation>Nessun backlog a priorità </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation>Questo portafoglio è già multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation>il portafoglio è sola-visualizzazione e non può essere reso multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation>Questo portafoglio è stato usato precedentmente, per cortesia utilizza un nuovo portafoglio per creare un portafoglio multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation>Invia queste informazioni multisig a tutti gli altri partecipanti, poi utilizza make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] con le informazioni multisig degli altri</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation>Questo include la chiave PRIVATA di visualizzazione, pertanto deve essere comunicata solo ai partecipanti di quel portafoglio multisig </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation>Soglia invalida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation>Ancora un ultimo passo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation>Impossibile creare multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation>Impossibile creare multisig: il nuovo portafoglio non è multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation> indirizzo multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation>Questo portafoglio non è multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation>Questo portafoglio è già finalizzato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation>Impossibile finalizzare multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation>Impossibile finalizzare multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation>Indirizzo multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation>Questo portafoglio multisig non è ancora finalizzato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation>Impossibile esportare informazioni sul multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation>Informazioni sul multisig esportate su </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation>Informazioni su multisig importate</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation>Impossibile importare informazioni sul multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation>Impossibile aggiornare lo stato di spesa dopo aver importato le informazioni sul multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation>Daemon non fidato, lo stato di spesa potrebbe non essere corretto. Usare un daemon fidato ed eseguire &quot;rescan_spent&quot; </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation>Questo non è un portafoglio multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation>Impossibile firmare la transazione multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation>Errore multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation>Impossibile firmare la transazione multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation>Potrebbe essere trasmesso alla rete con submit_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation>Impossibile caricare la transazione multisig da file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation>Transazione multisig firmata da solo %u firmatari, necessita di altre %u firme</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation>Transazione inviata con successo, transazione </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation>E&apos; possibile controllare il suo stato mediante il comando `show_transfers`.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation>Impossibile esportare la transazione multisig su file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation>Transazioni esportate salvate su(i) file: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation>Immagine della chiave o &apos;&apos;txid&apos;&apos; non valida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation>utilizzo: %s &lt;key_image&gt;|&lt;pubkey&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation>Congelato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation>Non Congelato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation> byte inviati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation>Benvenuto/a in Monero, la cryptovaluta privata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation>Monero, come Bitcoin, è una criptovaluta. Cioè, è denaro digitale.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation>nessuna tecnologia per la privacy può essere perfetta al 100%, incluso Monero.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation>il ring size deve essere un intero &gt;= </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation>impossibile modificare il ring size di default</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation>Altezza invalida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation>Avvia il mining sul daemon (bg_mining e ignore_battery sono booleani opzionali).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation>Arresta il mining sul daemon.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation>Seleziona un altro daemon cui connettersi.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation>Salva i dati blockchain correnti.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation>Sincronizza le transazioni ed il saldo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation>Mostra il saldo del portafoglio del conto attualmente selezionato.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1592,47 +1172,38 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation>Mostra i pagamenti per gli id pagamento specificati.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation>Mostra l&apos;altezza della blockchain.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation>Invia tutti gli output non mixabili a te stesso usando ring_size 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation>Invia tutti gli output sbloccati sotto la soglia ad un indirizzo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation>Invia un singolo output della key image specificata ad un indirizzo senza modifica.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation>Dona &lt;amount&gt; al team di sviluppo (donate.getmonero.org).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation>Invia una transazione firmata da file.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation>Modifica il dettaglio di log (il livello deve essere &lt;0-4&gt;).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1649,358 +1220,284 @@ Se viene specificato l&apos;argomento &quot;untag&quot;, i tag assegnati agli ac
 Se viene specificato l&apos;argomento &quot;tag_description&quot;, al tag &lt;tag_name&gt; viene assegnato un testo arbitrario &lt;description&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation>Codifica un ID di pagamento in un indirizzo integrato per l&apos;indirizzo pubblico del portafoglio corrente (nessun argomento utilizza un ID di pagamento casuale) o decodifica un indirizzo integrato per l&apos;indirizzo standard e l&apos;ID di pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation>Stampa tutte le voci nella rubrica, opzionalmente aggiungendo/eliminando una voce a/da esso.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation>Salva i dati del portafoglio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation>Salva un file di chiavi in sola lettura.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation>Mostra la chiave privata di visualizzazione.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation>Mostra la chiave di spesa privata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation>Mostra il seed mnemonico di tipo Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation>Mostra il seed mnemonico criptato di tipo Electrum.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation>Riscansiona la blockchain per gli outputs spesi.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation>Ottieni la chiave di transazione (r) per il dato &lt;txid&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation>Generare una firma che provi l&apos;invio dei fondi da &lt;address&gt; in &lt;txid&gt;, facoltativamente con una stringa di verifica &lt;message&gt;, utilizzando la chiave segreta della transazione (quando &lt;address&gt; non è l&apos;indirizzo del tuo portafoglio) o (in alternativa) la chiave di visualizzazione segreta, che non riveli la chiave segreta.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Genera una firma che dimostri che hai generato &lt;txid&gt; usando la chiave segreta di spesa, opzionalmente con una stringa di verifica &lt;message&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Controlla la firma dimostrando che il firmatario ha generato &lt;txid&gt;, opzionalmente con una stringa di verifica &lt;message&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Controlla una firma che dimostri che il proprietario di &lt;address&gt; conserva questo valore, opzionalmente con una stringa di verifica &lt;message&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation>Mostra gli outputs non spesi di uno specifico indirizzo all&apos;interno di un intervallo di quantità opzionale.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation>Scansiona la blockchain da zero. Se &quot;hard&quot; è specificato, perderai tutte le informazioni che non possono essere recuperate dalla blockchain stessa.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation>Imposta una nota arbitraria per un &lt;txid&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation>Ottieni una nota di stringa per un txid.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation>Imposta una descrizione arbitraria per il portafoglio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation>Ottieni la descrizione del portafoglio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation>Mostra lo stato del portafoglio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation>Mostra le informazioni del portafoglio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation>Firma il contenuto di un file.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation>Verifica una firma sul contenuto di un file.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation>Esporta un set di output posseduto da questo portafoglio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation>Importa un set di outputs posseduto da questo portafoglio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation>Mostra informazioni su un trasferimento da/verso questo indirizzo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation>Cambia la password del portafoglio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation>Stampa le informazioni sulla commissione corrente e sul backlog della transazione.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation>Esportare i dati necessari per creare un portafoglio multifirma</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation>Trasforma questo portafoglio in un portafoglio multifirma</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation>Trasforma questo portafoglio in un portafoglio multifirma, passo aggiuntivo per i portafogli N-1/N</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation>Esporta informazioni multifirma per altri partecipanti</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation>Importa informazioni multifirma da altri partecipanti</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation>Firma una transazione multifirma da un file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation>Invia una transazione multifirma firmata da un file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation>Esporta una transazione multifirma firmata in un file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation>Congela un singolo output per immagine chiave in modo che non venga utilizzato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation>Stampa semplici statistiche di rete</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation>Mostra la sezione di aiuto o la documentazione su un &lt;command&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation>intero &gt;= </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation>altezza del blocco</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation>1/si o 0/no</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation>Nessun portafoglio trovato con quel nome. Conferma la creazione di un nuovo portafoglio chiamato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation>non è possibile specificare sia --restore-deterministic-wallet o --restore-multisig-wallet e --non-deterministic</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-multisig-wallet utilizza --generate-new-wallet, non --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation>specifica un parametro di recupero con --electrum-seed=&quot; seed multifirma qui&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation>Verifica seed mulitfirma fallita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation>Questo indirizzo è un sottoindirizzo che non può essere utilizzato qui.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation>Errore: atteso M/N, ma ottenuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation>Errore: M/N non è attualmente supportato. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation>Generazione del portafoglio principale da %u di %u chiavi del portafoglio multifirma</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation>impossibile fare l&apos;analisi  (parsing) della chiave segreta di visualizzazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation>verifica chiave segreta di visualizzazione fallita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation>Errore: M/N non è attualmente supportato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation>Altezza di ripristino </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation>Se non conosci Monero, digita &quot;welcome&quot; per una breve panoramica.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation>Il daemon non è stato avviato o la porta è errata. Assicurati che il daemon sia in esecuzione oppure cambia l&apos;indirizzo del daemon usando il comando &apos;set_daemon&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation>Inserire il numero corrispondente alla lingua desiderata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2019,1078 +1516,819 @@ di nuovo il tuo portafoglio (le chiavi del tuo portafoglio NON sono in nessun ca
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation>impossibile generare un nuovo portafoglio multifirma</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation>Generato nuovo portafoglio %u/%u multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation>Aperto %u/%u portafoglio multifirma%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation>Usa &quot;help &lt;command&gt;&quot; per vedere la documentazione di un comando.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation>il portafoglio è multifirma e non è possibile salvarne una versione in sola lettura</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation>Lunghezza array imprevista - Exited simple_wallet:: set_daemon ()</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation>Questo URL del daemon non sembra essere valido.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation>txid </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation>idx </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation> (Alcuni output contengono immagini chiave parziali - import_multisig_info necessario)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation>Account attualmente selezionato: [</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation>] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation>Etichetta: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation>(Nessuna etichetta assegnata)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation>Saldo per indirizzo:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation>Indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation>Saldo sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation>Outputs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation>Etichetta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation>%8u %6s %21s %21s %7u %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation>spesi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation>indice globale</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation>tx id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation>indice indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation>[congelato]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation>Nessun trasferimento in entrata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation>Nessun trasferimento in entrata disponibile</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation>Nessun trasferimento indisponibile in entrata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation>pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation>transazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation>altezza</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation>tempo sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation>Nessun pagamento con id </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation>impossibile recuperare altezza blockchain: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation>
 Transazione %llu/%llu: txid=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation>impossibile recuperare output: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation>l&apos;altezza del blocco di origine della chiave di output non dovrebbe essere più alta dell&apos;altezza della blockchain</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation>
 Originando blocchi: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation>
 Avviso: alcune chiavi di input spese vengono da </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation>, che potrebbe compromettere l&apos;anonimità della ring signature. Assicurati di farlo intenzionalmente!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation>Il ring size non può essere 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation>il ring size %u è troppo piccolo, il minimo è %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation>numero di argomenti errato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation>Nessun output trovato, o il daemon non è pronto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation>impossibile analizzare tx_key</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation>Tx key memorizzata con successo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation>Impossibile memorizzare la chiave tx: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation>blocco</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation>utilizzo: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation>utilizzo: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation>direzione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation>timestamp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation>bilancio corrente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation>hash</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation>ID di pagamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation>tassa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation>destinazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation>indice</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation>nota</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation>CSV esportato in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation>Attenzione: questo farà perdere ogni informazione che non può essere recuperata dalla blockchain.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation>Questo include gli indirizzi di destinazione, le chiavi segrete di tx, le note di tx, ecc</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation>ricevuto un nuovo messaggio MMS</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation>Tipo di rete: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation>Stagenet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation>Mainnet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation>comando supportato solo dal portafoglio HW</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation>Il portafoglio hardware non supporta la sincronizzazione cold KI</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation>Si prega di confermare la sincronizzazione della chiave immagine sul dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation>Immagini della chiave sincronizzate all&apos;altezza </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation>L&apos;esecuzione di un daemon non fidato non può determinare quale output di transazione viene speso. Utilizzare un daemon fidato con --trusted-daemon ed eseguire rescan_spent</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation> speso, </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation> non speso</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation>Impossibile importare le immagini della chiave</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation>Impossibile importare le key images: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation>Impossibile ricollegare il dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation>Impossibile ricollegare il dispositivo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation>Transazione salvata correttamente in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation>, txid </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation>Impossibile salvare la transazione in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation>Questo è un portafoglio solo-vista</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation>ID transazione non trovato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation>vero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation>impossibile fare il parsing del tipo di refresh</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation>comando non supportato dal portafoglio HW</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation>il portafoglio è solo-vista e non possiede un seed</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation>il portafoglio è non-deterministico e non possiede un seed</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation>Password errata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation>La commissione attuale è %s %s per %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation>Invia queste informazioni multifirma a tutti i partecipanti, quindi utilizza exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] con le informazioni multifirma degli altri partecipanti</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation>Il portafoglio multifirma è stato creato con successo. Tipo di portafoglio corrente: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation>Impossibile eseguire lo scambio di chiavi multifirma: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation>Impossibile caricare la transazione multifirma da MMS</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation>Immagine della chiave non valida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation>Txid non valido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation>Immagine della chiave non spesa o spesa con mixin 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation>Impossibile ottenere l&apos;anello della chiave immagine: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation>Il file non esiste</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation>Specifica dell&apos;anello non valida: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation>Immagine della chiave non valida: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation>Tipo di anello non valido, previsto relativo o assoluto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation>Errore durante la lettura della riga: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation>Anello non valido: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation>Anello relativo non valido: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation>Anello assoluto non valido: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation>Impossibile impostare l&apos;anello per l&apos;immagine della chiave: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation>Continuando.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation>Parola chiave assoluta o relativa mancante</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation>indice non valido: deve essere un numero intero senza segno e positivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation>indice non valido: indici wrap</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation>indice non valido: gli indici devono essere rigorosamente in ordine crescente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation>impossibile impostare l&apos;anello</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation>La prima riga non è un importo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation>Output non valido: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation>Argomento non valido: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation>dovrebbe essere &quot;add&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation>Impossibile aprire il file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation>Chiave di output non valida, il file non esiste</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation>Impossibile contrassegnare l&apos;output come speso: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation>Output non valido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation>Impossibile contrassegnare l&apos;output non speso: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation>Speso: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation>Non speso: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation>Impossibile verificare se l&apos;output è stato speso: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation>Impossibile salvare gli anelli conosciuti: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation>Si prega di confermare la transazione sul dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation>il portafoglio è solo-vista e non può eseguire trasferimenti</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation>ATTENZIONE: impostazione dell&apos;anello non default, la tua privacy potrebbe essere compromessa. Si consiglia di utilizzare l&apos;impostazione predefinita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation>ATTENZIONE: dalla v8, la dimensione dell&apos;anello sarà fissa e questa impostazione verrà ignorata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation>la priorità deve essere 0, 1, 2, 3 o 4 o una di: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation>impossibile cambiare priorità standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation>argomento non valido: deve essere 0/never, 1/action, or 2/encrypt/decrypt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation>Nome del dispositivo non specificato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation>Riconnessione del dispositivo fallita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation>Riconnessione del dispositivo fallita: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation>Formato di esportazione non specificato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation>Formato di esportazione non riconosciuto.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation>Trasferisci &lt;amount&gt; in &lt;address&gt;. Se viene specificato il parametro &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; il portafoglio utilizza le uscite ricevute dagli indirizzi di tali indici. Se omesso, il portafoglio sceglie casualmente gli indici dell&apos;indirizzo da utilizzare. In ogni caso, fa del suo meglio per non combinare gli output su più indirizzi. &lt;priority&gt; è la priorità della transazione. Maggiore è la priorità, maggiore è la commissione di transazione. I valori validi in ordine di priorità (dal più basso al più alto) sono: non importante, normale, elevata, priorità. Se omesso, viene utilizzato il valore predefinito (consultare il comando &quot;set priority&quot;). &lt;ring_size&gt; è il numero di input da includere per la non tracciabilità. È possibile effettuare pagamenti multipli contemporaneamente aggiungendo URI_2 o &lt;address_2&gt; &lt;amount_2&gt; eccetera (prima dell&apos;ID pagamento, se questo è incluso)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation>Trasferisci &lt;amount&gt; in &lt;address&gt; e bloccalo per &lt;lockblocks&gt; (massimo 1000000). Se viene specificato il parametro &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot;, il portafoglio utilizza le uscite ricevute dagli indirizzi di tali indici. Se omesso, il portafoglio sceglie casualmente gli indici dell&apos;indirizzo da utilizzare. In ogni caso, fa del suo meglio per non combinare gli output su più indirizzi. &lt;priority&gt; è la priorità della transazione. Maggiore è la priorità, maggiore è la commissione di transazione. I valori validi in ordine di priorità (dal più basso al più alto) sono: non importante, normale, elevata, priorità. Se omesso, viene utilizzato il valore predefinito (consultare il comando &quot;set priority&quot;). &lt;ring_size&gt; è il numero di input da includere per la non tracciabilità. È possibile effettuare pagamenti multipli contemporaneamente aggiungendo URI_2 o &lt;address_2&gt; &lt;amount_2&gt; eccetera (prima dell&apos;ID pagamento, se questo è incluso)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation>Invia tutto il saldo sbloccato a un indirizzo e bloccalo per &lt;lockblocks&gt; (massimo 1000000). Se viene specificato il parametro &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot;, le uscite sweep del portafoglio vengono ricevute da tali indici dell&apos;indirizzo. Se omesso, il portafoglio sceglie casualmente un indice dell&apos;indirizzo da utilizzare. &lt;priority&gt; è la priorità dello sweep. Maggiore è la priorità, maggiore è la commissione di transazione. I valori validi in ordine di priorità (dal più basso al più alto) sono: non importante, normale, elevata, priorità. Se omesso, viene utilizzato il valore predefinito (consultare il comando &quot;set priority&quot;). &lt;ring_size&gt; è il numero di input da includere per la non tracciabilità.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation>Invia tutto il saldo sbloccato a un indirizzo. Se viene specificato il parametro &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot;, le uscite sweep del portafoglio vengono ricevute da tali indici dell&apos;indirizzo. Se omesso, il portafoglio sceglie casualmente un indice dell&apos;indirizzo da utilizzare. Se il parametro &quot;outputs=&lt;N&gt;&quot; è specificato e  N &gt; 0, il portafoglio divide la transazione in N uscite pari.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation>Firma una transazione da un file. Se viene specificato il parametro &quot;export_raw&quot;, vengono esportati i dati esadecimali grezzi della transazione adatti al daemon RPC /sendrawtransaction.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation>Se non viene specificato alcun argomento o viene specificato &lt;index&gt;, il portafoglio mostra l&apos;indirizzo predefinito o specificato. Se è specificato &quot;all&quot;, il portafoglio mostra tutti gli indirizzi esistenti nell&apos;account attualmente selezionato. Se viene specificato &quot;new&quot;, il portafoglio crea un nuovo indirizzo con il testo dell&apos;etichetta fornito (che può essere vuoto). Se si specifica &quot;label&quot;, il portafoglio imposta l&apos;etichetta dell&apos;indirizzo specificato da &lt;index&gt; sul testo dell&apos;etichetta fornito.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -3161,12 +2399,10 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation>Imposta la chiave di transazione (r) per un dato &lt;txid&gt; nel caso in cui il tx sia stato creato da qualche altro dispositivo o portafoglio di terze parti.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3180,42 +2416,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation>Esporta in CSV i trasferimenti in entrata/uscita all&apos;interno di un intervallo di altezza opzionale.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation>Esporta un set firmato di immagini chiave in un &lt;filename&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation>Sincronizza le immagini chiave con il portafoglio hw.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation>Tenta di ricollegare il portafoglio HW.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation>Genera un nuovo ID di pagamento lungo casuale (obsoleto). Questi non saranno crittati sulla blockchain, vedere integrated_address per gli ID di pagamento brevi crittografati.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation>Esegue scambi extra di chiavi multifirma. Necessario per portafogli multisig M/N arbitrari</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3224,74 +2452,60 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation>Inizializza e configura MMS per M/N = numero di firmatari richiesti/numero di multifirma dei firmatari autorizzati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation>Mostra la configurazione MMS corrente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation>Imposta o modifica le informazioni del firmatario autorizzato (etichetta con una sola parola, indirizzo di trasporto, indirizzo Monero) oppure elenca tutti i firmatari</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation>Elenca tutti i messaggi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation>Valuta le azioni multifirma successive secondo lo stato del portafoglio, esegui o proponi una scelta
 Utilizzando l&apos;elaborazione &apos;sync&apos; dei messaggi in attesa con le informazioni di sincronizzazione multifirma, è possibile forzare indipendentemente dallo stato del wallet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation>Generazione forzata di informazioni di sincronizzazione multifirma indipendente dallo stato del wallet, per il ripristino da situazioni speciali come errori di &quot;stale data&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation>Elimina un singolo messaggio inserendo il suo id, o cancella tutti i messaggi usando &apos;all&apos;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation>Invia un singolo messaggio inserendo il suo id o inviando tutti i messaggi in attesa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation>Controlla subito i nuovi messaggi da ricevere</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation>Scrivi il contenuto di un messaggio in un file &quot;mms_message_content&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation>Invia un messaggio di una linea a un firmatario autorizzato, identificato dalla sua etichetta, o mostra eventuali note non lette in attesa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation>Mostra informazioni dettagliate su un singolo messaggio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3299,27 +2513,22 @@ Utilizzando l&apos;elaborazione &apos;sync&apos; dei messaggi in attesa con le i
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation>Invia la configurazione completa del firmatario a tutti gli altri firmatari autorizzati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation>Avvia auto-config sul portafoglio del gestore automatico di configurazione emettendo i token di auto-configurazione e opzionalmente imposta le etichette degli altri</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation>Elimina tutti i token di configurazione automatica e interrompi il processo di configurazione automatica</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation>Avviare la configurazione automatica utilizzando il token ricevuto dal gestore di configurazione automatica</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -3327,1809 +2536,1364 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation>Imposta l&apos;anello utilizzato per una determinata immagine chiave, in modo che possa essere riutilizzato in un fork</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation>Salva gli anelli noti nel database degli anelli condivisi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation>Contrassegna gli output come spesi in modo che non vengano mai selezionati come output falsi in un anello</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation>Contrassegna un output come non speso in modo che possa essere selezionato come un falso output in un anello</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation>Controlla se un output è contrassegnato come speso</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation>Restituisce informazioni sulla versione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation>completo (più lento, nessuna ipotesi); optimize-coinbase (veloce, ipotizza che l&apos;intero coinbase viene pagato ad un indirizzo singolo); no-coinbase (il più veloce, ipotizza di non ricevere una transazione coinbase), default (come optimize-coinbase)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation>0, 1, 2, 3 o 4 o uno di </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation>0|1|2 (o never|action|decrypt)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation>monero, millinero, micronero, nanonero, piconero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation>&lt;major&gt;:&lt;minor&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation>&lt;device_name[:device_spec]&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation>intervallo di numeri errato, utilizzare: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation>Nome del portafoglio non valido. Prova di nuovo o usa Ctrl-C per uscire</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation>Portafoglio e chiavi trovate, sto caricando...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation>Ho trovato la chiave ma non il portafoglio. Sto rigenerando...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation>Chiave non trovata. Impossibile aprire portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation>Sto generando un nuovo portafoglio...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation>NOTA: il seguente %s può essere utilizzato per recuperare l&apos;accesso al tuo portafoglio. Scrivili e salvali in un posto sicuro e protetto. Si prega di non archiviarli nella propria e-mail o in servizi di archiviazione di file al di fuori del proprio immediato controllo.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation>stringa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation>25 parole</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation>Non è possibile specificare più di un --testnet e --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation>non è possibile specificare più di un --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-deterministic-wallet usa --generate-new-wallet, non --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation>La lista di parole stile Electrum ha fallito la verifica</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation>Nessun dato fornito, cancellato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation>impossibile fare il parsing dell&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation>impossibile fare il parsing chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation>impossibile verificare chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation>la chiave di visualizzazione non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation>creazione dell&apos;account fallita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation>impossibile fare il parsing chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation>impossibile verificare chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation>la chiave di spesa non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation>Chiave di spesa segreta (%u di %u)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation>Nessuna altezza di ripristino specificata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation>Supponendo che si stia creando un nuovo account, il ripristino verrà effettuato dall&apos;attuale altezza stimata sulla blockchain.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation>creazione account interrotta</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation>specifica un percorso per il portafoglio con --generate-new-wallet (non --wallet-file)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation>non è possibile specificare --subaddress-lookahead e --wallet-file nello stesso momento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation>impossibile aprire account</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation>il portafoglio è nullo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation>Impossibile inizializzare il database degli anelli: le funzionalità di miglioramento della privacy non saranno attive</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation>la lingua selezionata non è corretta. Prova di nuovo.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation>Chiave di visualizzazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation>Generato un nuovo portafoglio sul dispositivo hw: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation>File della chiave non trovato. Impossibile aprire il portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation>Potresti voler rimuovere il file &quot;%s&quot; e provare di nuovo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation>deinizializzazione portafoglio fallita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation>Portafoglio solo-lettura salvato come: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation>Impossibile salvare il portafoglio in sola lettura: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>questo comando richiede un daemon fidato. Abilita questa opzione con --trusted-daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation>Previsto fidato o non fidato, ottenuto </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation>fidato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation>non fidato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation>impossibile salvare la blockchain: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation>Password necessaria (%s) - usa il comando refresh</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation>Inserisci la password</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation>Il dispositivo richiede attenzione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation>Inserisci il PIN del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation>Impossibile leggere il PIN del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation>Inserisci la passphrase del dispositivo sul dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation>Immettere la passphrase del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation>Impossibile leggere la passphrase del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation>Vuoi procedere adesso? (Y/Yes/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è impegnato. Prova più tardi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>nessuna connessione con il daemon. Assicurati che sia in funzione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation>errore refresh: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation>Bilancio: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation>Parola chiave non valida: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation>pubkey</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation>immagine chiave</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation>sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation>bloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>l&apos;id pagamento è in un formato invalido, dovrebbe essere una stringa hex di 16 o 64 caratteri</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation>impossibile recuperare status spesi</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation>impossibile trovare i dati di costruzione per l&apos;input tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation>la stessa transazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation>i blocchi che sono temporalmente molto vicini</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation>Vuoi procedere comunque?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation>Ripetere comunque la scansione?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation> (Y/Yes/N/No): </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation>Scegli l&apos;elaborazione:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation>Firma tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation>Invia tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation>sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation>Scelta: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation>Scelta errata</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation>Id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation>I/O</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation>Firmatario autorizzato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation>Tipo di messaggio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation>Altezza</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation>Stato del messaggio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation>Da</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation> fa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation>#</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation>Indirizzo di trasporto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation>Auto-Config Token</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation>Indirizzo Monero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation>&lt;not set&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation>Messaggio </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation>In/out: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation>Stato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation>%s da %s, %s fa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation>Inviati: mai</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation>inviato/i: %s, %s fa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation>Firmatario autorizzato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation>Dimensione del contenuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation> bytes</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation>Contenuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation>(dati binari)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation>Vuoi inviare questi messaggi adesso?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation>In coda per l&apos;invio.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation>ID messaggio non valido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation>utilizzo: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation>L&apos;MMS è già inizializzato. Reinizializzare eliminando tutte le informazioni e i messaggi del firmatario?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation>Errore nel numero di firmatari richiesti e/o firmatari autorizzati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation>L&apos;MMS non è attivo.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation>Numero del firmatario non valido </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation>Indirizzo Monero non valido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation>Lo stato del portafoglio non consente più di modificare gli indirizzi Monero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation>Utilizzo: mms next [sync]</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation>Nessun passo successivo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation>prepare_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation>make_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation>exchange_multisig_keys</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation>export_multisig_info</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation>import_multisig_info</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation>sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation>submit_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation>Invia tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation>Sostituire la configurazione attuale del firmatario con quella visualizzata sopra?</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation>Elabora dati di configurazione automatica</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation>manca la soglia massima dell&apos;ammontare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation>ammontare soglia invalido</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation>Il cambiamento va a più di un indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation>Firma valida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation>Firma invalida</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation>Indirizzo standard: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation>impossibile fare il parsing di ID pagamento o indirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation>impossibile fare il parsing dell&apos;indice</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation>La rubrica è vuota.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation>Indice: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation>Indirizzo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation>Descrizione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>il portafoglio è di tipo solo-visualizzazione e non può firmare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation>impossibile leggere il file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation>L&apos;indirizzo non può essere un sottoindirizzo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation>Firma non valida da </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation>Firma valida da </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>il portafoglio è solo-vista e non può esportare immagini chiave</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation>impossibile salvare file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation>Chiave immagine firmata esportata in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation>Outputs esportati in </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation>l&apos;ammontare non è corretto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation>deve essere un numero da 0 a </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation>Eseguendo lo sweeping </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Fondi inviati con successo, transazione: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation>%s cambia in %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation>nessun cambiamento</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transazione firmata con successo nel file </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation>parsing txid fallito</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation>Chiave Tx: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation>nessuna chiave tx trovata per questo txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation>impossibile fare il parsing della chiave tx</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation>errore: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation>ricevuto/i</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation>in txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation>nulla ricevuto in txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation>AVVISO: questa transazione non è ancora inclusa nella blockchain!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation>Questa transazione ha %u conferme</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation>AVVISO: impossibile determinare il numero di conferme!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation>parametro min_height non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation>parametro max_height non corretto:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation>in</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation>&lt;min_amount&gt; dovrebbe essere più piccolo di &lt;max_amount&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation>
 Ammontare: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation>, numero di chiavi: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation>
 Altezza minima blocco: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation>
 Altezza massima blocco: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation>
 Ammontare minimo trovato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation>
 Ammontare massimo trovato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation>
 Conto totale: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation>
 Dimensione Bin: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation>  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation>portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation>ID pagamento casuale: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation>Indirizzo integrato corrispondente: </translation>
     </message>
@@ -5137,65 +3901,50 @@ Outputs per *: </source>
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5203,93 +3952,74 @@ Outputs per *: </source>
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5297,149 +4027,120 @@ Outputs per *: </source>
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation>nota</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation>in</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation>out</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5447,320 +4148,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation>Genera un nuovo portafoglio e salvalo in &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation>Genera un portafoglio solo-ricezione da chiave di visualizzazione</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation>Genera portafoglio da chiavi private</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation>Specifica il seed stile Electrum per recuperare/creare il portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation>Recupera portafoglio usando il seed mnemonico stile-Electrum</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation>Crea chiavi di visualizzione e chiavi di spesa non-deterministiche</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation>errore RPC: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation>Fondi insufficienti in saldo sbloccato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation>insufficiente numero di output per il ring size specificato</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation>ammontare output</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation>trovati output che possono essere usati</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation>transazione non costruita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation>una delle destinazioni è zero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>impossibile trovare un modo per dividere le transazioni</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation>errore trasferimento sconosciuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation>Errore multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation>errore interno: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation>errore inaspettato: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation>Comando sconosciuto: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation>Permetti comunicazioni con un daemon che usa una versione RPC differente</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation>Ripristina da specifico blocco</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation>impossibile leggere la password del portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>il daemon è occupato. Prova più tardi.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation>possibile perdita di connessione con il daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation>Errore: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation>Inizializzazione wallet fallita</translation>
     </message>
@@ -5768,313 +4405,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>Usa instanza daemon in &lt;host&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>Usa istanza daemon all&apos;host &lt;arg&gt; invece che localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation>File password portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>Usa istanza daemon alla porta &lt;arg&gt; invece che alla 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>Per testnet. Il daemon può anche essere lanciato con la flag --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>non puoi specificare la porta o l&apos;host del daemon più di una volta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>non puoi specificare più di un --password e --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation>il file password specificato non può essere letto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation>Impossibile caricare file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Wallet password (escape/quote se necessario)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation>Abilita comandi dipendenti da un daemon fidato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Specificare username[:password] per client del daemon RPC</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Il daemon è locale, viene considerato fidato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation>Impossibile fare il parsing di JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>La versione %u è troppo recente, possiamo comprendere solo fino alla versione %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation>impossibile fare il parsing di chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation>impossibile verificare chiave di visualizzazione chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation>impossibile fare il parsing chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation>impossibile verificare chiave di spesa chiave segreta</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Verifica lista di parole stile-Electrum fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Specificate entrambe lista parole stile-Electrum e chiave/i privata/e </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation>indirizzo invalido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation>la chiave di visualizzazione non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation>la chiave di spesa non corrisponde all&apos;indirizzo standard</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Impossibile creare portafogli disapprovati da JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation>impossibile generare nuovo portafoglio: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation>lettura file fallita</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished">Percorso della chiave privata in formato PEM</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished">Percorso del certificato in formato PEM</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished">Percorso del file contenente i certificati concatenati in formato PEM per sostituire le CA di sistema.</translation>
     </message>
@@ -6082,125 +4652,99 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation>Impossibile specificare --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation> e --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation>Impossibile creare file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation>. Controlla permessi o rimuovi il file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation>Errore durante scrittura su file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation>Username/password RPC conservato nel file </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Non puoi specificare più di un --wallet-file e --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation>Non è possibile specificare più di un --testnet e --stagenet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>Devi specificare --wallet-file o --generate-from-json o --wallet-dir</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation>Sto caricando il portafoglio...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation>Sto salvando il portafoglio...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation>Inizializzazione portafoglio fallita: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>Inizializzazione server RPC portafoglio fallita</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation>Server RPC portafoglio in avvio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation>Server RPC portafoglio arrestato</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation>Impossibile salvare portafoglio: </translation>
     </message>
@@ -6208,80 +4752,63 @@ daemon to work correctly.</source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation>Opzioni portafoglio</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation>Genera portafoglio da file JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation>Usa portafoglio &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation>Numero massimo di threads da utilizzare per un lavoro parallelo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation>Specificare file di log</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation>File configurazione</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation>Opzioni generali</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation>Impossibile trovare file configurazione </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation>Sto salvando il Log in: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation>Sto salvando il Log in %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>

--- a/translations/monero_ja.ts
+++ b/translations/monero_ja.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>不正な宛先アドレス</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation>ファイルは既に存在するのでファイルに取引を書き出せなかった。上書きしないにエグジットしてます。ファイル：</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>取引をファイルに書き込めませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>取引 %s がデーモンによって拒否しました。ステータス： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation>。 理由： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>未知の例外： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>未処理の例外</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation>これは閲覧専用ウォレットです</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation>取引を署名できませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>請求したお釣りはもうお金に送ったアドレス送りません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>請求したお釣りはお釣りのアドレスに送ったペイメントより大きいです</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation>お釣りは複数のアドレスに送ります</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation>%s を %s に送ってます</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation>目的地なし</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation>%s のお釣り %s に</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation>お釣りありません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation>取引は %lu ロードした、 %s に、%s のの手数料、 %s 、 %s 、最小リングサイズ %lu 。%s</translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation>RPCエラー： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation>指定したリングサイズのアウトプットが不十分です</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation>使うためにアウトプットを見つかれました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation>ミックス不能なアウトプットをスイープしてください。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>振替でMoneroを受け取ることできません。利用可能な金額： %s,  取引の金額： %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>秘密なスペンドキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>秘密なスペンドキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>スペンドキーがアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>ビューキーがアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>新しいウォレットの生成に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>インポートウォレットリクエストの送信に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>未署名の取引を読み込めませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation>ファイルからの取引のロードに失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation>閲覧専用ウォレットです</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation>ファイルを保存できませんでした </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>信頼できるデーモンしかでキーイメージをインポートしません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation>キーイメージをインポートできませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation>サブアドレスラベルを取得できませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation>サブアドレスラベルをセットできませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished">Electrumな単語表の検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation type="unfinished">不正な宛先アドレス</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation>振替でMoneroを受け取ることできません。利用可能な金額： %s,  取引の金額： %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>取引は無理です。利用可能な金額 %s、 取引の金額 %s = %s + %s (手数料)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation>アウトプットの金額</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation>取引を作りませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>取引 %s がデーモンによって拒否しました。ステータス： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation>宛先の1つはゼロです</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>取引を分割する適切な方法を見つけることができませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation>不明な転送エラー： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation>内部エラー： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation>予期せぬエラー： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation>不明なエラー</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation>txidの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation>このtxidのためにtxキーを見つかれませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation>txキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation>アドレスはサブアドレスであってはならないです</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>信頼できるデーモンしかで再スキャンしません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation>キーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation>キーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation>キーがアドレスと一致しませんでした</translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation>はい</translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation>いいえ</translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation>RPCサーバに接続するIPを指定してください</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation>RPCサーバを使うためにユーザー名[：パスワード]を指定してください</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation>rpc-bind-ipの価はループバック(ローカル)IPじゃないことを確認してください</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation>クロスオリジンリソース共同をできるためにコンマ区切りリストを指定してください</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation>このRPCサーバーのIPはだめです --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation> は暗号化されていない外部接続をできますがSSHトンネルやSSLプロキシの方がいいです。これでオーバーライド --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation>このRPCサーバのユーザー名につて --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation> 入力する必要があります</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation> のRPCサーバのパスワードありません --</translation>
     </message>
@@ -661,985 +505,706 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation>不正なパスワード</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation>０や１</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation>符号無しの整数</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation>新しいウォレットの生成に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation>ウォレットをロードできませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished">ペイメントIDのフォーマットは不正です。16文字または64文字の16進数の文字列が必要で： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation>
 取引 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation>。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished">取引をファイルに書き込めませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation>キーイメージの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished">請求したお釣りはもうお金に送ったアドレス送りません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished">請求したお釣りはお釣りのアドレスに送ったペイメントより大きいです</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation>%s を %s に送ってます</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation>目的地なし</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation>取引を署名できませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation>取引を署名できませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation>ファイルからの取引のロードに失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation>RPCエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation>不正なユニット</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation>不正な金額</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>デーモンはローカルです。信頼できるデーモン予期してます</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation>内部エラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation>予期せぬエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation>不明なエラー</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation>ロック解除された残高： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation>未知のコマンド： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation>コマンドの使用： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation>コマンドの記述： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation> マルチサインアドレス： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation>これはマルチシッグウォレットではありません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation>これはマルチシッグウォレットではありません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation>マルチサインエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1647,47 +1212,38 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1698,363 +1254,288 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation>エラー： N/Mを欲しかったでもこれを貰いました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation>エラー： N ＞ 1 と N ＜＝ M のこと欲しかったでもこれを貰いました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2066,1099 +1547,835 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation>新しいマルチシッグウォレットの生成に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation>txid </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation>idx </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation>] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation>タグ： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation>アドレス</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation>残高</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation>ロック解除された残高</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation>アウトプット</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation>ラベル</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation>tx id</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation>ペイメント</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation>取引</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished">キーイメージをインポートできませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation>、txid </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation>これは閲覧専用ウォレットです</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -3229,12 +2446,10 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3248,42 +2463,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3292,73 +2499,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3366,27 +2559,22 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -3394,1714 +2582,1290 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation>新しいウォレットを生じてます...</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Electrumな単語表の検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation>データをもらいませんでしたのでキャンセルしました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation>アドレスの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation>ビューキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation>秘密なスペンドキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation>秘密なスペンドキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation>スペンドキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation>ビューキー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation>残高： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation>キーイメージ</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation>同じ取引</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation>インデックス： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation>アドレス： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation>記述： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation>ファイルの読み込みに失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation>アドレスはサブアドレスであってはならないです</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation> (デーモンありません）</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation>インデックスの解析に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation>、ロック解除された残高： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished">タグ %s を登録してません。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation>タグを持ってるアカウント： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation>タグの記述： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation> %c%8u %6s %21s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation>----------------------------------------------------------------------------------</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation>%15s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation>プライマリアドレス</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation>サブアドレス： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation>記述を見つかれませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation>記述を見つかれました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation>ファイル名： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation>閲覧専用</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation>%u/%u マルチサイン%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation>ノーマル</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation>タイプ： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation>ファイルを保存できませんでした </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished">お釣りは複数のアドレスに送ります</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation>%s のお釣り %s に</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation>お釣りありません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation>txidの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation>txキー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished">このtxidのためにtxキーを見つかれませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation>txキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation>エラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation>貰いました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation>txidに</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation>
 金額： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation>、キーの数： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation>+--&gt; ブロック高
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation>  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation>ウォレット</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation>ランダムなペイメントID： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -5109,65 +3873,50 @@ Outputs per *: </source>
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5175,93 +3924,74 @@ Outputs per *: </source>
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation>ベースファイル名（必要があれば－１、－２、とかのサフィックスを追加します）</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation>M/Nってのフォーマットで同じ時に閾値と参加者をください</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation>マルチサインウォレットを分ける人はいくついますか</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation>有効な取引を署名するために必要な人いくついますか</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation>テストネットのマルチサインウォレットを作る</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation>%u %u/%u マルチサインウォレットを生じてます</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation>マルチサインの追加情報を検証中にエラーありました</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation>アドレスのためにマルチサインウォレットを生じなかった </translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation>マルチサインウォレットを樹立中にエラーありました： </translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation>このプログラムはマルチサインウォレットのセットを生じます　－　みんながみんなを信用する場合にだけこの単純なスキームを使ってください</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation>エラー： N/Mを欲しかったでもこれを貰いました： </translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation>エラー： --scheme あるいは--threshold と --participants を上げられる</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation>エラー： N ＞ 1 と N ＜＝ M のこと欲しかったでも N＝＝%u と M＝＝%d を貰いました</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation>エラー： --filename-baseを使う必要だがあります</translation>
     </message>
@@ -5269,149 +3999,120 @@ Outputs per *: </source>
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5419,320 +4120,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation>新しいウォレットを生じろ &lt;arg&gt; をこっちにセーブしてください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation>ビューキーで閲覧専用ウォレットを生じろください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation>スペンドキーで決定論的なウォレットを生じろください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation>秘密なキーでウォレットを生じろください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation>マルチシガーウォレットキーでマスターウォレットを生じろください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation>ニーモニックのための言語</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation>ウォレットの回収や作成のためにElectrumなニーモニックシードを指定してください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation>Electrumなニーモニックシードでウォレットを復元してください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation>Electrumなニーモニックシードでマルチシガーウォレットを復元してください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation>非決定論的のビューとスペンドキーを生じろください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation type="unfinished">インデックスの解析に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished">デーモンの接続が確立ありません。デーモンが実行中になっていることを確認してください。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation type="unfinished">RPCエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished">指定したリングサイズのアウトプットが不十分です</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation type="unfinished">アウトプットの金額</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation type="unfinished">使うためにアウトプットを見つかれました</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished">取引を作りませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished">宛先の1つはゼロです</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished">取引を分割する適切な方法を見つけることができませんでした</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished">不明な転送エラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation type="unfinished">マルチサインエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation type="unfinished">内部エラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation type="unfinished">予期せぬエラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation type="unfinished">未知のコマンド： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation>別のRPCバージョンを使用してるデーモンとの通信を許可してください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation>特定ブロックチェイン高で復元してください</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation>新しい取引をネットワークに中継しません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>デーモンは忙しいです。後でもう一度試してください。</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation>デモンの接続が切れましたかもしりません</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation>エラー： </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation>ウォレットを初期化できませんでした</translation>
     </message>
@@ -5740,313 +4377,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>&lt;host&gt;:&lt;port&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>localhostの代わりにホスト &lt;arg&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation>ウォレットのパスワードファイル</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>１８０８１の代わりにポート &lt;arg&gt;でデーモンインスタンスを使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>テストネットのためにデーモンは --testnet のフラグで開始する必要があります</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>デーモンのホストやポートを複数回指定することはできません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>--password と --passwordfile を1つしか指定しません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation>指定されたパスワードファイルを読み取れません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation>ファイルのロードに失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>ウォレットのパスワード(随時にエスケープ文字を使ってください)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished">必要な信用できるデーモンのコマンドをエネーブルしてください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>デーモンのRPCクライアントを使うためにユーザー名[：パスワード]を指定してください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished">デーモンはローカルです。信頼できるデーモン予期してます</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation>パスワードを指定しませんでした。パスワードプロンプトを見るために--prompt-for-password を使ってください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation>JSONを解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>バージョン %u 新しすぎるです。%u までグロークできます</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation>秘密なビューキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation>秘密なビューキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation>秘密なスペンドキーの解析に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation>秘密なスペンドキーの検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Electrumな単語表の検証に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Electrumな単語表と秘密なキーを指定しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation>不正なアドレス</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation>ビューキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation>スペンドキーが一般的なアドレスと一致しませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>JSONで非推奨のウォレットを生成することはできません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation>アドレスの解析に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation>閲覧専用ウォレットを作るためにアドレスを指定する必要があります</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation>新しいウォレットの生成に失敗しました： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation>プライマリア カウント</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation>この取引から資金貰いませんでした。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation>ファイルの読み込みに失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6054,126 +4624,100 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation>ディレクトリの作成に失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation>%s %s ディレクトリの作成に失敗しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation>これを指定しません： --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation> と --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation>ファイルの作成に失敗しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation>。 パーミッションを確認するか、ファイルを削除してください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation>ファイルへの書き込みエラー </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation>RPCユーザー名/パスワードはファイルに保存しました </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation>タグ %s を登録してません。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>取引は無理です。利用可能な金額 %s、 取引の金額 %s = %s + %s (手数料)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation>これはMoneroのRPCウォレットです。正しく動作させるには
 Moneroデーモンに接続する必要があります。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>--wallet-file と --generate-from-json を1つしか指定しません</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>--wallet-file や --generate-from-json や --wallet-dir を指定する必要があります</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation>ウォレットをロードしてます...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation>ウォレットを保存してます...</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation>保存しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation>ロードしました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation>ウォレットを初期化できませんでした: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>ウォレットのRPCサーバを初期化できませんでした</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation>ウォレットのRPCサーバを開始してます</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation>ウォレットを起動することできませんでした： </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation>ウォレットのRPCサーバを停止しました</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation>ウォレットを保存することできませんでした： </translation>
     </message>
@@ -6181,81 +4725,64 @@ Moneroデーモンに接続する必要があります。</translation>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation>ウォレットのオプション</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation>JSONフォーマットファイルでウォレットを生じてください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation>ウォレットの &lt;arg&gt; を使てください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation>並列ジョブのために最大スレッドの数</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation>ログファイルを指定してください</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation>設定ファイル</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation>ジェネラルオプション</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation>これはMoneroのコマンドラインウォレットです。正しく動作させるには
 Moneroデーモンに接続する必要があります。</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation>設定ファイルを見つかりませんでした </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation>こっちにログをしてます: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation>%s にログをしてます</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation>使用：</translation>
     </message>

--- a/translations/monero_nl.ts
+++ b/translations/monero_nl.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Ongeldig bestemmings adres</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation>Geprobeerd om de transactie in een bestand op te slaan, maar de betreffende bestand(en) bestaan al. Actie niet uitgevoerd om overschrijving te voorkomen. Bestand:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Het wegschrijven van de transactie(s) is mislukt voor bestand</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>deamon is bezig. Probeer het later opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>geen verbinding met deamon. Zorg ervoor dat de deamon wordt uitgevoerd.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>transactie %s werd geweigerd door deamon met status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation> Reden: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>Onbekende fout: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>Niet afgevangen fout</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation>Kan geen multisign toepassen op gegevens: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation>Kan geen multisign toepassen op transactie: </translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation>Dit is een alleen inzage portemonnee</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation>Signeren van transactie is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Wisselgeld gaat niet naar een betaald adres</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Opgevraagde wisselgeld is meer dan de betaling naar het wisselgeld adres</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation>Wisselgeld gaat naar meerdere adressen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation>%s versturen naar %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation>zonder bestemmingen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation>%s veranderen naar %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation>%lu transacties geladen voor %s, een vergoeding van %s, %s, %s, met ringgrootte %lu. %s</translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>deamon is bezig. Probeer het later opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>geen verbinding met de deamon. Zorg alstublieft dat de deamon wordt uitgevoerd.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation>RPC fout: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation>het ophalen van de uitvoeren voor het mixen is mislukt: %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation>niet genoeg uitvoeren voor opgegeven ring grootte</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation>gevonden uitvoeren om te gebruiken</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation>Veeg alstublieft de onmixbare uitvoeren.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>onvoldoende geld voor overdracht, alleen beschikbaar %s, verstuurde hoeveelheid %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>het parsen van het adres is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>het parsen van de geheime uitgave sleutel is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation>Zowel inzage sleutel als uitgave sleutel zijn niet opgegeven, geannuleerd</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>het parsen van de geheime inzage sleutel is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>het verifiëren van de geheime uitgave sleutel is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>uitgave sleutel komt niet overeen met adres</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>verifiëren van geheime inzage sleutel is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>inzage sleutel komt niet overeen met adres</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>Nieuwe portemonnee aanmaken mislukt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation>Electrum seed is leeg</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation>mislukte Electrum-style woordenlijst verificatie</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>Verzoek tot versturen van importeren van portomonnee is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Laden van ongesigneerde transacties is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation>Laden van transactie van bestand is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation>Portemonnee is alleen voor inzage</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation type="unfinished">het opslaan van het bestand is mislukt </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>Sleutel afbeeldingen kunnen alleen geïmporteerd worden met een vertrouwde deamon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation>Importeren van sleutel afbeeldingen is mislukt: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation>Ophalen van subadres label is mislukt: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation>Zetten van subadres label is mislukt: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation type="unfinished">Ongeldig bestemmings adres</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished">transactie %s werd geweigerd door deamon met status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation type="unfinished"></translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation type="unfinished"></translation>
     </message>
@@ -661,941 +505,687 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished">Wisselgeld gaat niet naar een betaald adres</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished">Opgevraagde wisselgeld is meer dan de betaling naar het wisselgeld adres</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished">Wisselgeld gaat naar meerdere adressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation type="unfinished">%s versturen naar %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation type="unfinished">zonder eindbestemmingen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation type="unfinished">het opslaan van het bestand is mislukt </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1603,57 +1193,46 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1664,224 +1243,180 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -1889,489 +1424,340 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished">mislukte Electrum-style woordenlijst verificatie</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation type="unfinished">het parsen van het adres is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished">het parsen van de geheime inzage sleutel is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished">verifiëren van geheime inzage sleutel is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished">Nieuwe portemonnee aanmaken mislukt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2383,218 +1769,170 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished">deamon is bezig. Probeer het later opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2665,550 +2003,415 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation type="unfinished">RPC fout: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished">betaling id heeft ongeldig formaat, een 16 of 64 lange hexadecimale tekenreeks wordt verwacht: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3222,42 +2425,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3266,73 +2461,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3340,1762 +2521,1345 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished">Het wegschrijven van de transactie(s) is mislukt voor bestand</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished">Importeren van sleutel afbeeldingen is mislukt: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished">Dit is een alleen inzage portemonnee</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished">Signeren van transactie is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished">Laden van transactie van bestand is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation type="unfinished">%s veranderen naar %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5103,65 +3867,50 @@ Grand total:
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5169,93 +3918,74 @@ Grand total:
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5263,149 +3993,120 @@ Grand total:
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,320 +4114,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation type="unfinished">RPC fout: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished">niet genoeg uitvoeren voor opgegeven ring grootte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation type="unfinished">gevonden uitvoeren om te gebruiken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished">deamon is bezig. Probeer het later opnieuw.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5734,313 +4371,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished">mislukte Electrum-style woordenlijst verificatie</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished">Nieuwe portemonnee aanmaken mislukt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6048,125 +4618,99 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6174,80 +4718,63 @@ daemon to work correctly.</source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_pl.ts
+++ b/translations/monero_pl.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Nieprawidłowy adres docelowy</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>demon jest zajęty. Proszę spróbować później.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>brak połączenia z demonem. Proszę sprawdzić czy demon jest uruchomiony.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation> Powód: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>Nieznany wyjątek: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>Nieobsłużony wyjątek</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished">demon jest zajęty. Proszę spróbować później.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished">brak połączenia z demonem. Proszę sprawdzić czy demon jest uruchomiony.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation type="unfinished">Nieprawidłowy adres docelowy</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation type="unfinished"></translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation type="unfinished"></translation>
     </message>
@@ -661,941 +505,687 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1603,57 +1193,46 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1664,224 +1243,180 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -1889,489 +1424,340 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2383,218 +1769,170 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished">demon jest zajęty. Proszę spróbować później.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2665,550 +2003,415 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished">brak połączenia z demonem. Proszę sprawdzić czy demon jest uruchomiony.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3222,42 +2425,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3266,73 +2461,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3340,1762 +2521,1345 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5103,65 +3867,50 @@ Grand total:
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5169,93 +3918,74 @@ Grand total:
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5263,149 +3993,120 @@ Grand total:
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,320 +4114,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished">brak połączenia z demonem. Proszę sprawdzić czy demon jest uruchomiony.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished">demon jest zajęty. Proszę spróbować później.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5734,313 +4371,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6048,125 +4618,99 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6174,80 +4718,63 @@ daemon to work correctly.</source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_pt-br.ts
+++ b/translations/monero_pt-br.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Endereço de destino inválido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Erro ao salvar transação/transações para o arquivo</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation type="unfinished">Endereço de destino inválido</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation type="unfinished"></translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation type="unfinished"></translation>
     </message>
@@ -661,941 +505,687 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1603,57 +1193,46 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1664,224 +1243,180 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -1889,489 +1424,340 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2383,218 +1769,170 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2665,550 +2003,415 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3222,42 +2425,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3266,73 +2461,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3340,1762 +2521,1345 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished">Erro ao salvar transação/transações para o arquivo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5103,65 +3867,50 @@ Grand total:
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5169,93 +3918,74 @@ Grand total:
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5263,149 +3993,120 @@ Grand total:
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,320 +4114,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5734,313 +4371,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6048,125 +4618,99 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6174,80 +4718,63 @@ daemon to work correctly.</source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_sk.ts
+++ b/translations/monero_sk.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Neplatná adresa príjemcu</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation>Pokúšam sa uložiť transakciu do súboru, ale súbor už existuje. Predchádzam prepisu súboru ukončením. Súbor:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation type="unfinished">Neplatná adresa príjemcu</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation type="unfinished"></translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation type="unfinished"></translation>
     </message>
@@ -661,941 +505,687 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1603,57 +1193,46 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1664,224 +1243,180 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -1889,489 +1424,340 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2383,218 +1769,170 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2665,550 +2003,415 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3222,42 +2425,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3266,73 +2461,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3340,1762 +2521,1345 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5103,65 +3867,50 @@ Grand total:
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5169,93 +3918,74 @@ Grand total:
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5263,149 +3993,120 @@ Grand total:
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,320 +4114,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5734,313 +4371,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6048,125 +4618,99 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6174,80 +4718,63 @@ daemon to work correctly.</source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero_sv.ts
+++ b/translations/monero_sv.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>Ogiltig måladress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation>Försöker spara transaktion till fil, men angiven fil finns redan. Avslutar för att inte riskera att skriva över någonting. Fil:</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Det gick inte att skriva transaktioner till fil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>transaktionen %s avvisades av daemonen med status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation>. Orsak: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation>Okänt undantag: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation>Ohanterat undantag</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation>Detta är en granskningsplånbok</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation>Det gick inte att signera transaktionen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Begärd växel går inte till en betald adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Begärd växel är större än betalning till växeladressen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation>Växel går till fler än en adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation>skickar %s till %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation>utan några mål</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation>%s växel till %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation>ingen växel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation>Läste in %lu transaktioner, för %s, avgift %s, %s, %s, med minsta ringstorlek %lu. %s</translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation>RPC-fel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation>inte tillräckligt med utgångar för angiven ringstorlek</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation>hittade utgångar att använda</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation>Svep upp omixbara utgångar.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation>inte tillräckligt med pengar för överföring, endast tillgängligt %s, skickat belopp %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation>det gick inte att parsa adressen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation>det gick inte att parsa hemlig spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation>det gick inte att parsa hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation>det gick inte att verifiera hemlig spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation>spendernyckel matchar inte adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation>det gick inte att verifiera hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation>granskningsnyckel matchar inte adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation>det gick inte att skapa ny plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation>Det gick inte att skicka begäran om att importera plånbok</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation>Det gick inte att läsa in osignerade transaktioner</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation>Det gick inte att läsa in transaktion från fil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation>Plånboken är endast för granskning</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation>det gick inte att spara fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation>Nyckelavbildningar kan bara importeras med en betrodd daemon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation>Det gick inte att importera nyckelavbildningar: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation>Det gick inte att hämta etikett för underadress: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation>Det gick inte att ange etikett för underadress: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Det gick inte att verifiera ordlista av Electrum-typ</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation>Ogiltig måladress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>det gick inte att upprätta betalnings-ID, trots att det avkodades korrekt</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation>inte tillräckligt med pengar för överföring, totalt saldo är bara %s, skickat belopp %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>ej tillräckligt med pengar för överföring, endast tillgängligt %s, transaktionsbelopp %s = %s + %s (avgift)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation>utgångens belopp</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation>transaktionen konstruerades inte</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation>transaktionen %s avvisades av daemonen med status: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation>ett av målen är noll</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>det gick inte att hitta ett lämpligt sätt att dela upp transaktioner</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation>okänt överföringsfel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation>internt fel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation>oväntat fel: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation>okänt fel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation>Det gick inte att parsa txid</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation>inga tx-nycklar kunde hittas för detta txid</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation>Det gick inte att parsa txnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation>Det gick inte att parsa adressen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation>Adressen får inte vara en underadress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation>Genomsök efter spenderade kan endast användas med en betrodd daemon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation>Det gick inte att parsa adressen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation>Det gick inte att parsa nyckeln</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation>det gick inte att verifiera nyckeln</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation>nyckeln matchar inte adressen</translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation>ja</translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation>nej</translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation>Ange IP-adress för att binda till RPC-server</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation>Ange användarnamn[:lösenord] som krävs av RPC-servern</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation>Bekräftelsevärde för rpc-bind-ip är INTE en lokal IP-adress (loopback)</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation>Ange en kommaseparerad lista av ursprung för att tillåta resursdelning för korsande ursprung (Cross-origin resource sharing)</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation>Ogiltig IP-adress angiven för --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation> tillåter inkommande okrypterade externa anslutningar. Överväg att använda SSH-tunnel eller SSL-proxy istället. Åsidosätt med --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation>Användarnamn angivet med --</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation> får inte vara tomt</translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation> kräver lösenord till RPC-server --</translation>
     </message>
@@ -661,991 +505,712 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation>Kommandon: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation>det gick inte att läsa lösenord för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation>ogiltigt lösenord</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation>set seed: kräver ett argument. tillgängliga alternativ: språk</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation>set: okända argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation>ogiltig sökväg till plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation>Försöker skapa eller återställa plånbok, men angivna filer finns redan.  Avslutar för att inte riskera att skriva över någonting.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation>kräver ett argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation>0 eller 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation>positivt heltal</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-deterministic-wallet använder --generate-new-wallet, inte --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation>ange en återställningsparameter med --electrum-seed=&quot;ordlista här&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation>ange sökväg till en plånbok med --generate-new-wallet (inte --wallet-file)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation>plånboken kunde inte ansluta till daemonen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation>Daemonen använder en högre version av RPC (%u) än plånboken (%u): %s. Antingen uppdatera en av dem, eller använd --allow-mismatched-daemon-version.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation>Lista över tillgängliga språk för din plånboks startvärde:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation>Du hade använt en inaktuell version av plånboken. Använd det nya startvärde som tillhandahålls.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation>Ny plånbok skapad: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation>det gick inte att skapa ny plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation>Öppnade plånbok för granskning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation>Öppnade plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation>Du hade använt en inaktuell version av plånboken. Fortsätt för att uppgradera din plånbok.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation>Du hade använt en inaktuell version av plånboken. Plånbokens filformat kommer nu att uppgraderas.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation>det gick inte att läsa in plånboken: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation>Använd kommandot &quot;help&quot; för att visa en lista över tillgängliga kommandon.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation>Plånboksdata sparades</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation>Brytning startad i daemonen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation>brytning har INTE startats: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation>Brytning stoppad i daemonen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation>brytning har INTE stoppats: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation>Blockkedjan sparades</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation>Höjd </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation>spenderat </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation>Startar uppdatering …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation>Uppdatering färdig, mottagna block: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation>betalnings-ID har ogiltigt format. En hexadecimal sträng med 16 eller 64 tecken förväntades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation>felaktig parameter för locked_blocks:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation>en enda transaktion kan inte använda fler än ett betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation>det gick inte att upprätta betalnings-ID, trots att det avkodades korrekt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation>transaktion avbruten.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation>Det gick inte att kontrollera eftersläpning: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation>
 Transaktion </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation>Spendera från adressindex %d
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation>VARNING: Utgångar från flera adresser används tillsammans, vilket möjligen kan kompromettera din sekretess.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation>Skickar %s.  </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation>Transaktionen behöver delas upp i %llu transaktioner.  Detta gör att en transaktionsavgift läggs till varje transaktion, med ett totalbelopp på %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation>Transaktionsavgiften är %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation>, varav %s är damm från växel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation>Ett totalt belopp på %s från växeldamm skickas till damm-adressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation>Det gick inte att skriva transaktioner till fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation>Osignerade transaktioner skrevs till fil: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation>Inga omixbara utgångar kunde hittas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation>Ingen adress har angivits</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation>det gick inte att parsa betalnings-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation>det gick inte att parsa nyckelavbildning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation>Inga utgångar kunde hittas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation>Flera transaktioner skapas, vilket inte ska kunna inträffa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation>Transaktionen använder flera eller inga ingångar, vilket inte ska kunna inträffa</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation>tröskelbelopp saknas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation>ogiltigt tröskelbelopp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation>Begärd växel går inte till en betald adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation>Begärd växel är större än betalning till växeladressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation>skickar %s till %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation> dummy-utgångar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation>utan några mål</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation>Detta är en multisig-plånbok, som endast kan signera med sign_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation>Det gick inte att signera transaktionen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation>Det gick inte att signera transaktionen: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation>Hexadecimala rådata för transaktionen exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation>Det gick inte att läsa in transaktion från fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation>RPC-fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation>plånboken är enbart för granskning och har ingen spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation>Ditt ursprungliga lösenord var fel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation>Ett fel uppstod vid återskrivning av plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation>ogiltig enhet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation>ogiltigt värde för count: måste vara ett heltal utan tecken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation>ogiltigt värde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation>felaktig parameter för m_restore_height: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation>Återställningshöjd är: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Daemonen är lokal, utgår från att den är betrodd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation>Lösenord för ny granskningsplånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation>internt fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation>oväntat fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation>okänt fel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation>det gick inte att uppdatera: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation>Mottagna block: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation>upplåst saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation>belopp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation>falskt</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation>Okänt kommando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation>Användning av kommando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation>Beskrivning av kommando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation>plånboken är multisig men är ännu inte slutförd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation>Det gick inte att hämta startvärde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation>plånboken är multisig och har inget startvärde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation>Fel: det gick inte att uppskatta eftersläpningsmatrisens storlek: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation>Fel: felaktigt uppskattat värde för eftersläpningsmatrisens storlek</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation> (aktuellt)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation>%u blocks (%u minuters) eftersläpning vid prioritet %u%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation>%u till %u blocks (%u till %u minuters) eftersläpning vid prioritet %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation>Ingen eftersläpning vid prioritet </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation>Denna plånbok är redan multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation>plånboken är enbart för granskning och kan inte göras om till multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation>Denna plånbok har använts tidigare. Använd en ny plånbok för att skapa en multisig-plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation>Skicka denna multisig-info till alla andra deltagare och använd sedan make_multisig &lt;tröskelvärde&gt; &lt;info1&gt; [&lt;info2&gt;…] med de andras multisig-info</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation>Detta innefattar den PRIVATA granskningsnyckeln, så den behöver endast lämnas ut till den multisig-plånbokens deltagare </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation>Ogiltigt tröskelvärde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation>Ytterligare ett steg krävs</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation>Ett fel uppstod när multisig skapades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation>Ett fel uppstod när multisig skapades: den nya plånboken är inte multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation> multisig-adress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation>Denna plånbok är inte multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation>Denna plånbok är redan slutförd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation>Det gick inte att slutföra multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation>Det gick inte att slutföra multisig: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation>Denna multisig-plånbok är inte slutförd ännu</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation>Ett fel uppstod när multisig-info exporterades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation>Multisig-info exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation>Multisig-info importerades</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation>Det gick inte att importera multisig-info: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation>Det gick inte att uppdatera spenderstatus efter import av multisig-info: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation>Ej betrodd daemon. Spenderstatus kan vara felaktig. Använd en betrodd daemon och kör &quot;rescan_spent&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation>Detta är inte en multisig-plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation>Det gick inte att signera multisig-transaktion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation>Multisig-fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation>Det gick inte att signera multisig-transaktion: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation>Den kan skickas vidare till nätverket med submit_multisig</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation>Det gick inte att läsa in multisig-transaktion från fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation>Multisig-transaktion har signerats av bara %u signerare. Den behöver %u ytterligare signaturer</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation>Transaktionen skickades, transaktion </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation>Du kan kontrollera dess status genom att använda kommandot &apos;show_transfers&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation>Det gick inte att exportera multisig-transaktion till fil </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation>Sparade filer med exporterade multisig-transaktioner: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation>ringstorlek måste vara ett heltal &gt;= </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation>det gick inte att ändra standardinställning för ringstorlek</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation>Ogiltig höjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation>Starta brytning i daemonen (bgbrytning och ignorera_batteri är valfri booleska värden).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation>Stoppa brytning i daemonen.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation>Ange en annan daemon att ansluta till.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation>Spara aktuella blockkedjedata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation>Synkronisera transaktionerna och saldot.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation>Visa plånbokens saldo för det aktiva kontot.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1653,47 +1218,38 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation>Visa betalningar för givna betalnings-ID.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation>Visa blockkedjans höjd.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation>Skicka alla omixbara utgångar till dig själv med ringstorlek 1</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation>Skicka alla upplåsta utgångar under tröskelvärdet till en adress.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation>Skicka en enda utgång hos den givna nyckelavbildningen till en adress utan växel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation>Donera &lt;belopp&gt; till utvecklingsteamet (donate.getmonero.org).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation>Skicka en signerad transaktion från en fil.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation>Ändra detaljnivån för aktuell logg (nivå måste vara 0-4).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1710,82 +1266,66 @@ Om argumentet &quot;untag&quot; anges, tas tilldelade taggar bort från de angiv
 Om argumentet &quot;tag_description&quot; anges, så tilldelas taggen &lt;taggnamn&gt; den godtyckliga texten &lt;beskrivning&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation>Koda ett betalnings-ID till en integrerad adress för den aktuella plånbokens publika adress (om inget argument anges används ett slumpmässigt betalnings-ID), eller avkoda en integrerad adress till en standardadress och ett betalnings-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation>Skriv ut alla poster i adressboken, och valfritt lägg till/ta bort en post i den.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation>Spara plånboksdata.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation>Spara en fil med granskningsnycklar.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation>Visa privat granskningsnyckel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation>Visa privat spendernyckel.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation>Visa det minnesbaserade startvärdet (Electrum-typ)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation>Visa det krypterade minnesbaserade startvärdet (Electrum-typ).</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation>Genomsök blockkedjan efter spenderade utgångar.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation>Hämta transaktionsnyckel (r) för ett givet &lt;txid&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation>Kontrollera belopp som går till &lt;adress&gt; i &lt;txid&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation>Skapa en signatur som bevisar att pengar skickades till &lt;adress&gt; i &lt;txid&gt;, valfritt med kontrollsträngen &lt;meddelande&gt;, genom att använda antingen transaktionens hemliga nyckel (när &lt;adress&gt; inte är din plånboks adress) eller den hemliga granskningsnyckeln (annars), vilket inte lämnar ut den hemliga nyckeln.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation>Kontrollera beviset för pengar som skickats till &lt;adress&gt; i &lt;txid&gt; med kontrollsträngen &lt;meddelande&gt;, om den angivits.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Skapa en signatur som bevisar att du skapade &lt;txid&gt; genom att använda den hemliga spendernyckeln, valfritt med kontrollsträngen &lt;meddelande&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Kontrollera en signatur som bevisar att signeraren skapade &lt;txid&gt;, valfritt med kontrollsträngen &lt;meddelande&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
@@ -1794,276 +1334,218 @@ Om &apos;all&apos; anges, bevisar du totalsumman av alla dina befintliga kontons
 Annars bevisar du reserven för det minsta möjliga belopp över &lt;belopp&gt; som är tillgängligt på ditt aktuella konto.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation>Kontrollera en signatur som bevisar att ägaren till &lt;adress&gt; har åtminstone så här mycket, valfritt med kontrollsträngen &lt;meddelande&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation>Visa de ej spenderade utgångarna hos en angiven adress inom ett valfritt beloppsintervall.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation>Ange en godtycklig stränganteckning för &lt;txid&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation>Hämta en stränganteckning för ett txid.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation>Ange en godtycklig beskrivning av plånboken.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation>Hämta plånbokens beskrivning.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation>Visa plånbokens status.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation>Visa information om plånboken.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation>Signera innehållet i en fil.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation>Verifiera en signatur av innehållet in en fil.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation>Importera en signerad lista av nyckelavbildningar och verifiera deras spenderstatus.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation>Exportera en uppsättning utgångar som ägs av denna plånbok.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation>Importera en uppsättning utgångar som ägs av denna plånbok.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation>Visa information om en transktion till/från denna adress.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation>Ändra plånbokens lösenord.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation>Skriv ut information om aktuell avgift och transaktionseftersläpning.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation>Exportera data som krävs för att skapa en multisig-plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation>Gör denna plånbok till en multisig-plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation>Gör denna plånbok till en multisig-plånbok, extra steg för plånböcker med N-1/N</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation>Exportera multisig-info för andra deltagare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation>Importera multisig-info från andra deltagare</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation>Signera en a multisig-transaktion från en fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation>Skicka en signerad multisig-transaktion från en fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation>Exportera en signerad multisig-transaktion till en fil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation>Visa hjälpavsnittet eller dokumentationen för &lt;kommando&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation>heltal &gt;= </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation>blockhöjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation>Ingen plånbok med det namnet kunde hittas. Bekräfta skapande av ny plånbok med namn: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation>det går inte att ange både --restore-deterministic-wallet eller --restore-multisig-wallet och --non-deterministic</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation>--restore-multisig-wallet använder --generate-new-wallet, inte --wallet-file</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation>ange en återställningsparameter med --electrum-seed=&quot;startvärde för multisig&quot;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation>Startvärde för multisig kunde inte verifieras</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation>Denna adress är en underadress som inte kan användas här.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation>Fel: förväntade M/N, men fick: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation>Fel: förväntade N &gt; 1 och N &lt;= M, men fick: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation>Fel: M/N stöds för närvarande inte. </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation>Skapar huvudplånbok från %u av %u multisig-plånboksnycklar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation>det gick inte att parsa hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation>det gick inte att verifiera hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation>Fel: M/N stöds för närvarande inte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation>Återställningshöjd </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation>Antingen har daemonen inte startat eller så angavs fel port. Se till att daemonen körs eller byt daemonadress med kommandot &apos;set_daemon&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2081,1108 +1563,843 @@ din plånbok igen (din plånboks nycklar är dock INTE hotade i vilket fall som 
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation>det gick inte att skapa ny multisig-plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation>Skapa ny %u/%u-multisig-plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation>Öppnade %u/%u-multisig-plånbok%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation>Använd &quot;help &lt;kommando&gt;&quot; för att visa dokumentation för kommandot.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation>plånboken är multisig och kan inte spara en granskningsversion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation>Oväntad matrislängd - Lämnade simple_wallet::set_daemon()</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation>Detta verkar inte vara en giltig daemon-URL.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation>txid </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation>idx </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation> (Några ägda utgångar har partiella nyckelavbildningar - import_multisig_info krävs)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation>Aktuellt valt konto: [</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation>] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation>Tagg: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation>(Ingen tagg tilldelad)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation>Saldo per adress:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation>Upplåst saldo</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation>Utgångar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation>Etikett</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation>%8u %6s %21s %21s %7u %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation>spenderat</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation>globalt index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation>tx-ID</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation>addr index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation>Inga inkommande överföringar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation>Inga inkommande tillgängliga överföringar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation>Inga inkommande otillgängliga överföringar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation>betalning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation>transaktion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation>höjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation>upplåsningstid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation>Inga betalningar med ID </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation>det gick inte att hämta blockkedjans höjd: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation>
 Transaktion %llu/%llu: txid=%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation>det gick inte att hämta utgång: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation>utgångsnyckelns ursprungsblockhöjd får inte vara högre än blockkedjans höjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation>
 Ursprungsblockhöjder: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation>
 |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation>|
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation>
 Varning: Några ingångsnycklar som spenderas kommer från </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation>, vilket kan bryta ringsignaturens anonymitet. Se till att detta är avsiktligt!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation>Ringstorlek för inte vara 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation>ringstorlek %uär för liten, minimum är %u</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation>fel antal argument</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation>Inga utgångar hittades, eller så är daemonen inte klar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation>Det gick inte att importera nyckelavbildningar: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation>Transaktionen sparades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation>, txid </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation>Det gick inte att spara transaktion till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation>Detta är en granskningsplånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation>En dubbelspendering upptäcktes på nätverket: denna transaktion kanske aldrig blir verifierad</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation>Transaktions-ID kunde inte hittas</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation>sant</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation>det gick inte att parsa uppdateringstyp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation>plånboken är enbart för granskning och har inget startvärde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation>plånboken är icke-deterministisk och har inget startvärde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation>plånboken är enbart för granskning och kan inte göra överföringar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation>det gick inte att ändra standardinställning för prioritet</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -3253,12 +2470,10 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3272,42 +2487,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3316,73 +2523,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3390,27 +2583,22 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -3418,1285 +2606,970 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation>full (långsammast, inga antaganden); optimize-coinbase (snabb, antar att hela coinbase-transaktionen betalas till en enda adress); no-coinbase (snabbast, antar att ingen coinbase-transaktion tas emot), default (samma som optimize-coinbase)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation>monero, millinero, micronero, nanonero, piconero</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation>Plånbokens namn ej giltigt. Försök igen eller använd Ctrl-C för att avsluta.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation>Plånbok och nyckelfil hittades, läser in …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation>Nyckelfilen hittades men inte plånboksfilen. Återskapar …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation>Nyckelfilen kunde inte hittas. Det gick inte att öppna plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation>Skapar ny plånbok …</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Det gick inte att verifiera ordlista av Electrum-typ</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation>Inga data angivna, avbryter</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation>det gick inte att parsa adressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation>det gick inte att parsa hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation>det gick inte att verifiera hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation>granskningsnyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation>det gick inte att skapa konto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation>det gick inte att parsa spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation>det gick inte att verifiera spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation>spendernyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation>det gick inte att öppna konto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation>plånbok är null</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation>ogiltigt språkval har angivits. Försök igen.
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation>Granskningsnyckel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation>Du kan också prova att bort filen &quot;%s&quot; och försöka igen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation>det gick inte att avinitiera plånboken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation>detta kommando kräver en betrodd daemon. Aktivera med --trusted-daemon</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation>blockkedjan kan inte sparas: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation>fel vid uppdatering: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation>Saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation>publik nyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation>nyckelavbildning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation>upplåst</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation>ringct</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation>låst</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation>RingCT</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation>betalnings-ID har ogiltigt format. En hexadecimal sträng med 16 eller 64 tecken förväntades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation>det gick inte att hämta spenderstatus</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation>samma transaktion</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation>block som ligger väldigt nära varandra i tiden</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation>Godkänd signatur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation>Felaktig signatur</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation>Standardadress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation>det gick inte att parsa betalnings-ID eller adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation>det gick inte att parsa index</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation>Adressboken är tom.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation>Index: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation>Adress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation>Beskrivning: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation>plånboken är enbart för granskning och kan inte signera</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation>det gick inte att läsa filen </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation>det gick inte att läsa in signaturfil</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation>plånboken är enbart för granskning och kan inte skapa beviset</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation>Beviset på reserv kan endast skapas av en standardplånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation>Adressen får inte vara en underadress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation>Godkänd signatur -- summa: %s, spenderat: %s, ej spenderat: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation>[En dubbelspendering upptäcktes på nätverket: denna transaktion kanske aldrig blir verifierad] </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation>Det finns ingen ej spenderad utgång i den angivna adressen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation> (ingen daemon)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation> (inte synkroniserad)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation>(Ej namngivet konto)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation>det gick inte att parsa index: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation>ange ett index mellan 0 och </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
@@ -4705,386 +3578,286 @@ Totalsumma:
   Saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation>, upplåst saldo: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation>Otaggade konton:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation>Taggen %s har inte registrerats.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation>Konton med tagg: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation>Taggens beskrivning: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation>Konto</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation> %c%8u %6s %21s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation>----------------------------------------------------------------------------------</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation>%15s %21s %21s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation>Primär adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation>(används)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation>(Ej namngiven adress)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation>&lt;index_min&gt; är redan utanför tillåtet intervall</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation>&lt;index_max&gt; är utanför tillåtet intervall</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation>Integrerade adresser kan bara skapas för konto 0</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation>Integrerad adress: %s, betalnings-ID: %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation>Underadress: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation>ingen beskrivning hittades</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation>beskrivning hittades: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation>Filnamn: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation>Endast granskning</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation>%u/%u multisig%s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation>Typ: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation>Plånboken är multisig och kan inte signera</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation>Felaktig signatur från </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation>Godkänd signatur från </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation>plånboken är enbart för granskning och kan inte exportera nyckelavbildningar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation>det gick inte att spara fil </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation>Signerade nyckelavbildningar exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation>Utgångar exporterades till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation>beloppet är fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation>förväntades: ett tal från 0 till </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation>Sveper upp </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation>Pengar skickades, transaktion: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation>Växel går till fler än en adress</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation>%s växel till %s</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation>ingen växel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation>Transaktionen signerades till fil </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation>det gick inte att parsa txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation>Tx-nyckel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation>inga tx-nycklar kunde hittas för detta txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation>signaturfilen sparades till: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation>det gick inte att spara signaturfilen</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation>det gick inte att parsa txnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation>fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation>mottaget</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation>i txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation>tog emot ingenting i txid</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation>VARNING: denna transaktion är ännu inte inkluderad i blockkedjan!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation>Denna transaktion har %u bekräftelser</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation>VARNING: det gick inte att bestämma antal bekräftelser!</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation>felaktig parameter för min_höjd:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation>felaktig parameter för max_höjd:</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation>in</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation>&lt;min_belopp&gt; måste vara mindre än &lt;max_belopp&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation>
 Belopp: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation>, antal nycklar: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation>
 Minblockhöjd: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation>
 Maxblockhöjd: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation>
 Minbelopp funnet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation>
 Maxbelopp funnet: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation>
 Totalt antal: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation>
 Storlek för binge: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation>
 Utgångar per *: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
@@ -5093,51 +3866,42 @@ Utgångar per *: </translation>
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation>  |</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation>  +</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation>+--&gt; blockhöjd
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation>   ^</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation>^
 </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation>plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation>Slumpmässigt betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation>Matchande integrerad adress: </translation>
     </message>
@@ -5145,65 +3909,50 @@ Utgångar per *: </translation>
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5211,93 +3960,74 @@ Utgångar per *: </translation>
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation>Basfilnamn (suffix -1, -2, osv. läggs till efter behov)</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation>Ange tröskelvärde och deltagare på en gång som M/N</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation>Hur många signerare krävs för att signera en giltig transaktion</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation>Skapa multisig-plånböcker för testnet</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation>Skapar %u %u/%u multisig-plånböcker</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation>Ett fel uppstod när extra multisig-info verifierades</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation>Skapade multisig-plånböcker för adress </translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation>Ett fel uppstod när multisig-plånböcker skapades: </translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation>Programmet skapar en uppsättning multisig-plånböcker - använd endast detta enklare system om alla deltagare litar på varandra</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation>Fel: förväntade N/M, men fick: </translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation>Fel: antingen --scheme eller både --threshold och --participants får anges</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation>Fel: förväntade N &gt; 1 och N &lt;= M, men fick N=%u och M=%d</translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation>Fel: --filename-base måste anges</translation>
     </message>
@@ -5305,149 +4035,120 @@ Utgångar per *: </translation>
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation>in</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation>ut</translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5455,320 +4156,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation>Skapa ny plånbok och spara den till &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation>Skapa granskningsplånbok från granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation>Skapa deterministisk plånbok från spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation>Skapa plånbok från privata nycklar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation>Skapa en huvudplånbok från multisig-plånboksnycklar</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation>Språk för minnesbaserat startvärde</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation>Ange Electrum-startvärde för att återställa/skapa plånbok</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation>Återställ plånbok genom att använda minnesbaserat startvärde (Electrum-typ)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation>Återställ multisig-plånbok genom att använda minnesbaserat startvärde (Electrum-typ)</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation>Skapa icke-deterministisk granskningsnyckel och spendernyckel</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation>det gick inte att parsa index: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation>ingen anslutning till daemonen. Se till att daemonen körs.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation>RPC-fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation>inte tillräckligt med utgångar för angiven ringstorlek</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation>utgångens belopp</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation>hittade utgångar att använda</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation>transaktionen konstruerades inte</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation>ett av målen är noll</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation>det gick inte att hitta ett lämpligt sätt att dela upp transaktioner</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation>okänt överföringsfel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation>Multisig-fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation>internt fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation>oväntat fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation>Okänt kommando: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation>Tillåt kommunikation med en daemon som använder en annan version av RPC</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation>Återställ från angiven blockkedjehöjd</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation>Den nyss skapade transaktionen kommer inte att skickas vidare till monero-nätverket</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation>det gick inte att läsa lösenord för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation>daemonen är upptagen. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation>anslutning till daemonen kan ha förlorats</translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation>Fel: </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation>Det gick inte att initiera plånbok</translation>
     </message>
@@ -5776,313 +4413,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation>Använd daemonen på &lt;värddator&gt;:&lt;port&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation>Använd daemonen på värddatorn &lt;arg&gt; istället för localhost</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation>Lösenordsfil för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation>Använd daemonen på port &lt;arg&gt; istället för 18081</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation>För testnet. Daemonen måste också startas med flaggan --testnet</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation>det går inte ange värd eller port för daemonen mer än en gång</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation>det går inte att ange fler än en av --password och --password-file</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation>det gick inte att läsa angiven lösenordsfil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation>Det gick inte att läsa in fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation>Lösenord för plånboken (använd escape-sekvenser eller citattecken efter behov)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation>Aktivera kommandon som kräver en betrodd daemon</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation>Ange användarnamn[:lösenord] för RPC-klient till daemonen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation>Daemonen är lokal, utgår från att den är betrodd</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation>inget lösenord har angivits; använd --prompt-for-password för att fråga efter lösenord</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation>Det gick inte att parsa JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation>Version %u är för ny, vi förstår bara upp till %u</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation>det gick inte att parsa hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation>det gick inte att verifiera hemlig granskningsnyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation>det gick inte att parsa spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation>det gick inte att verifiera spendernyckel hemlig nyckel</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation>Det gick inte att verifiera ordlista av Electrum-typ</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation>Både ordlista av Electrum-typ och privat nyckel har angivits</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation>ogiltig adress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation>granskningsnyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation>spendernyckel matchar inte standardadress</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation>Det går inte att skapa inaktuella plånböcker från JSON</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation>det gick inte att parsa adressen: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation>Adress måste anges för att kunna skapa granskningsplånbok</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation>det gick inte att skapa ny plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation>Primärt konto</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation>Inga pengar togs emot i denna tx.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation>det gick inte att läsa filen </translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6090,126 +4660,100 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation>Det gick inte att skapa mapp </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation>Det gick inte att skapa mapp %s: %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation>Det går inte att ange --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation> och --</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation>Det gick inte att skapa fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation>. Kontrollera behörigheter eller ta bort filen</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation>Ett fel uppstod vid skrivning till fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation>Användarnamn/lösenord för RPC har sparats i fil </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation>Taggen %s har inte registrerats.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation>Transaktion är inte möjlig. Endast tillgängligt %s, transaktionsbelopp %s = %s + %s (avgift)</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation>Detta är RPC-plånboken för monero. Den måste ansluta till en Monero-
 daemon för att fungera korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation>Det går inte att ange fler än en av --wallet-file och --generate-from-json</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation>Måste ange --wallet-file eller --generate-from-json eller --wallet-dir</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation>Läser in plånbok …</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation>Sparar plånbok …</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation>Plånboken sparades</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation>Plånboken lästes in</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation>Det gick inte att initiera plånbok: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation>Det gick inte att initiera RPC-servern för plånbok</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation>Startar RPC-server för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation>Det gick inte att köra plånboken: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation>Stoppade RPC-server för plånboken</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation>Det gick inte spara plånboken: </translation>
     </message>
@@ -6217,81 +4761,64 @@ daemon för att fungera korrekt.</translation>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation>Alternativ för plånbok</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation>Skapa plånbok från fil i JSON-format</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation>Använd plånbok &lt;arg&gt;</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation>Max antal trådar att använda för ett parallellt jobb</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation>Ange loggfil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation>Konfigurationsfil</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation>Allmänna alternativ</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation>Detta är kommandoradsplånboken för Monero. Den måste ansluta till en Monero-
 daemon för att fungera korrekt.</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation>Det gick inte att hitta konfigurationsfilen </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation>Loggar till: </translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation>Loggar till %s</translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation>Användning:</translation>
     </message>

--- a/translations/monero_tr.ts
+++ b/translations/monero_tr.ts
@@ -4,12 +4,10 @@
 <context>
     <name>Monero::AddressBookImpl</name>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="53"/>
         <source>Invalid destination address</source>
         <translation>geçersiz varış adresi</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/address_book.cpp" line="60"/>
         <source>Payment ID supplied: this is obsolete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,52 +15,42 @@
 <context>
     <name>Monero::PendingTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="91"/>
         <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="98"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="138"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="141"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="145"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="150"/>
         <source>. Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="152"/>
         <source>Unknown exception: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="155"/>
         <source>Unhandled exception</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="228"/>
         <source>Couldn&apos;t multisig sign data: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/pending_transaction.cpp" line="250"/>
         <source>Couldn&apos;t sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -70,53 +58,42 @@
 <context>
     <name>Monero::UnsignedTransactionImpl</name>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="75"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="92"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="168"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="174"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="184"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="197"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="203"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="209"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="212"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/unsigned_transaction.cpp" line="214"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -124,399 +101,294 @@
 <context>
     <name>Monero::WalletImpl</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1513"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1602"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1515"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1604"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1517"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1606"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1519"/>
         <source>failed to get outputs to mix: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1545"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1637"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1549"/>
         <source>Please sweep unmixable outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1523"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1613"/>
         <source>not enough money to transfer, available only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="589"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="600"/>
         <source>failed to parse secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="615"/>
         <source>Neither view key nor spend key supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="623"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="632"/>
         <source>failed to verify secret spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="636"/>
         <source>spend key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="642"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="646"/>
         <source>view key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="669"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="686"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="734"/>
         <source>Electrum seed is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="743"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="955"/>
         <source>Failed to send import wallet request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1125"/>
         <source>Failed to load unsigned transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1148"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1164"/>
         <source>Wallet is view only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1172"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1188"/>
         <source>Key images can only be imported with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1201"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1233"/>
         <source>Failed to get subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1246"/>
         <source>Failed to set subaddress label: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1263"/>
         <source>Failed to get multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1280"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1294"/>
         <source>Failed to make multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1309"/>
         <source>Failed to finalize multisig wallet creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1312"/>
         <source>Failed to finalize multisig wallet creation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1328"/>
         <source>Failed to export multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1346"/>
         <source>Failed to parse imported multisig images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1356"/>
         <source>Failed to import multisig images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1370"/>
         <source>Failed to check for partial multisig key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1398"/>
         <source>Failed to restore multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1439"/>
         <source>Sending all requires one destination address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1443"/>
         <source>Destinations and amounts are unequal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1451"/>
         <source>payment id has invalid format, expected 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1459"/>
         <source>Invalid destination address</source>
         <translation type="unfinished">geçersiz varış adresi</translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1465"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1491"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2307"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2314"/>
         <source>Failed to mark outputs as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2336"/>
         <source>Failed to mark output as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2358"/>
         <source>Failed to mark output as unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1530"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1621"/>
         <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1537"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1629"/>
         <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1547"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1639"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1552"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1643"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1555"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1646"/>
         <source>transaction %s was rejected by daemon with status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1560"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1651"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1562"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1653"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1564"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1655"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1566"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1657"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1568"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1659"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1570"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1661"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1608"/>
         <source>failed to get outputs to mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1749"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1785"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1833"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1861"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1889"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1910"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2386"/>
         <source>Failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1769"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1793"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1802"/>
         <source>Failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1811"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1840"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1868"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="1949"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1954"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="1994"/>
         <source>The wallet must be in multisig ready state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2016"/>
         <source>Given string is not a key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2258"/>
         <source>Rescan spent can only be used with a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2325"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2347"/>
         <source>Failed to parse output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2330"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2352"/>
         <source>Failed to parse output offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2369"/>
-        <location filename="../src/wallet/api/wallet.cpp" line="2408"/>
         <source>Failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2375"/>
         <source>Failed to get ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2393"/>
         <source>Failed to get rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="2414"/>
         <source>Failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
@@ -524,22 +396,18 @@
 <context>
     <name>Wallet</name>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="344"/>
         <source>Failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="351"/>
         <source>Failed to parse key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="359"/>
         <source>failed to verify key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/api/wallet.cpp" line="369"/>
         <source>key does not match address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -547,12 +415,10 @@
 <context>
     <name>command_line</name>
     <message>
-        <location filename="../src/common/command_line.cpp" line="54"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/command_line.cpp" line="68"/>
         <source>no</source>
         <translation type="unfinished"></translation>
     </message>
@@ -560,100 +426,78 @@
 <context>
     <name>cryptonote::rpc_args</name>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="92"/>
         <source>Specify IP to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="93"/>
         <source>Specify IPv6 address to bind RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="94"/>
         <source>Allow IPv6 for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="95"/>
         <source>Ignore unsuccessful IPv4 bind for RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="96"/>
         <source>Specify username[:password] required for RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="97"/>
         <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="98"/>
         <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="99"/>
         <source>Enable SSL on RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="100"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="101"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="102"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="103"/>
         <source>List of certificate fingerprints to allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="104"/>
         <source>Allow user (via --rpc-ssl-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="105"/>
         <source>Allow any peer certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="146"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="174"/>
         <source>Invalid IP address given for --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="154"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="182"/>
         <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
         <source>Username specified with --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="205"/>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> cannot be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/rpc/rpc_args.cpp" line="215"/>
         <source> requires RPC server password --</source>
         <translation type="unfinished"></translation>
     </message>
@@ -661,941 +505,687 @@
 <context>
     <name>cryptonote::simple_wallet</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4592"/>
         <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6529"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7004"/>
         <source>Spending from address index %d
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6533"/>
         <source>Sending %s.  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6536"/>
         <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6542"/>
         <source>The transaction fee is %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6545"/>
         <source>, of which %s is dust from change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>A total of %s from dust change will be sent to dust address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6768"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6808"/>
         <source>No address given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6869"/>
         <source>missing lockedblocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6879"/>
         <source>bad locked_blocks parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7173"/>
         <source>failed to parse Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7196"/>
         <source>failed to parse key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7234"/>
         <source>No outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7239"/>
         <source>Multiple transactions are created, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7244"/>
         <source>The transaction uses multiple or no inputs, which is not supposed to happen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7294"/>
         <source>Money successfully sent, transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7322"/>
         <source>missing threshold amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7327"/>
         <source>invalid amount threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7477"/>
         <source>Claimed change does not go to a paid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7482"/>
         <source>Claimed change is larger than payment to the change address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7491"/>
         <source>Change goes to more than one address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7513"/>
         <source>sending %s to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7523"/>
         <source> dummy output(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7526"/>
         <source>with no destinations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7535"/>
         <source>no change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5360"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5061"/>
         <source>Password for new watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="378"/>
         <source>false</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="690"/>
         <source>Commands: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="704"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="711"/>
         <source>Command usage: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="714"/>
         <source>Command description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="740"/>
         <source>wallet is watch-only and has no spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="766"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="982"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1027"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1110"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1167"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1300"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1394"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1591"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7562"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7626"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7663"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7968"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8052"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9572"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9810"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9859"/>
         <source>command not supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="771"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="848"/>
         <source>wallet is watch-only and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="780"/>
         <source>wallet is multisig but not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="858"/>
         <source>wallet is non-deterministic and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="813"/>
         <source>Failed to retrieve seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="843"/>
         <source>wallet is multisig and has no seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="868"/>
         <source>Incorrect password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1064"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1117"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1184"/>
         <source>Your original password was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="905"/>
         <source>Error with wallet rewrite: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9333"/>
         <source>Random payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="926"/>
         <source>Current fee is %s %s per %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="523"/>
         <source>Payment required, see the &apos;rpc_payment_info&apos; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="942"/>
         <source>Error: failed to estimate backlog array size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="947"/>
         <source>Error: bad estimated backlog array size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="959"/>
         <source> (current)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="962"/>
         <source>%u block (%u minutes) backlog at priority %u%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="964"/>
         <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="967"/>
         <source>No backlog at priority </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="987"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1032"/>
         <source>This wallet is already multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="992"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1037"/>
         <source>wallet is watch-only and cannot be made multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="998"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1043"/>
         <source>This wallet has been used before, please use a new wallet to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1006"/>
         <source>Send this multisig info to all other participants, then use make_multisig &lt;threshold&gt; &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1007"/>
         <source>This includes the PRIVATE view key, so needs to be disclosed only to that multisig wallet&apos;s participants </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2797"/>
         <source>Invalid threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1077"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1199"/>
         <source>Another step is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1089"/>
         <source>Error creating multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1096"/>
         <source>Error creating multisig: new wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1099"/>
         <source> multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1123"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1172"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1239"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1305"/>
         <source>This wallet is not multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1128"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1177"/>
         <source>This wallet is already finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1144"/>
         <source>Failed to finalize multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1150"/>
         <source>Failed to finalize multisig: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1211"/>
         <source>Multisig address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1244"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1310"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1404"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1520"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1601"/>
         <source>This multisig wallet is not yet finalized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9683"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9840"/>
         <source>failed to save file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1280"/>
         <source>Error exporting multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1284"/>
         <source>Multisig info exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1333"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9596"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9622"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9873"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1350"/>
         <source>Multisig info imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1354"/>
         <source>Failed to import multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1365"/>
         <source>Failed to update spent status after importing multisig info: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1371"/>
         <source>Untrusted daemon, spent status may be incorrect. Use a trusted daemon and run &quot;rescan_spent&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1399"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1515"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1596"/>
         <source>This is not a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1449"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1458"/>
         <source>Failed to sign multisig transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1465"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1470"/>
         <source>Failed to sign multisig transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1479"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1492"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7607"/>
         <source>Transaction successfully signed to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1493"/>
         <source>It may be relayed to the network with submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1552"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1622"/>
         <source>Failed to load multisig transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1558"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1627"/>
         <source>Multisig transaction signed by only %u signers, needs %u more signatures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1567"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10083"/>
         <source>Transaction successfully submitted, transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1568"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10084"/>
         <source>You can check its status by using the `show_transfers` command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1657"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5654"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5979"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6631"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6661"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7066"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7305"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7651"/>
         <source>unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1643"/>
         <source>Failed to export multisig transaction to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1647"/>
         <source>Saved exported multisig transaction file(s): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1652"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1993"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5649"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5974"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1675"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1832"/>
         <source>Invalid key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1681"/>
         <source>Invalid txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1693"/>
         <source>Key image either not spent, or spent with mixin 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1708"/>
         <source>Failed to get key image ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1723"/>
         <source>File doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1745"/>
         <source>Invalid ring specification: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1753"/>
         <source>Invalid key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1758"/>
         <source>Invalid ring type, expected relative or abosolute: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1764"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1776"/>
         <source>Error reading line: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1787"/>
         <source>Invalid ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1796"/>
         <source>Invalid relative ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1808"/>
         <source>Invalid absolute ring: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Failed to set ring for key image: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1817"/>
         <source>Continuing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1847"/>
         <source>Missing absolute or relative keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1864"/>
         <source>invalid index: must be a strictly positive unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1872"/>
         <source>invalid index: indices wrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1882"/>
         <source>invalid index: indices should be in strictly ascending order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1889"/>
         <source>failed to set ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1912"/>
         <source>Invalid key image or txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1921"/>
         <source>failed to unset ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1944"/>
         <source>RPC client ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1945"/>
         <source>RPC client secret key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1948"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2358"/>
         <source>Failed to query daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1956"/>
         <source>Using daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1957"/>
         <source>Payments required for node use, current credits: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1958"/>
         <source>Credits target: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1961"/>
         <source>Credits spent this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1963"/>
         <source>Credit discrepancy this session: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>Difficulty: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
         <source>credits per hash found, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1965"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>credits/hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1973"/>
         <source>Mining for payment at %.1f H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1978"/>
         <source>Estimated time till %u credits target mined: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1982"/>
         <source>Mining for payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1985"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1988"/>
         <source>No payment needed for node use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>Bad argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2061"/>
         <source>should be &quot;add&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2070"/>
         <source>Failed to open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2154"/>
         <source>Failed to save known rings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2163"/>
         <source>usage: %s &lt;key_image&gt;|&lt;pubkey&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2220"/>
         <source>Frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2222"/>
         <source>Not frozen: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2236"/>
         <source> bytes sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2237"/>
         <source> bytes received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2249"/>
         <source>No known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2261"/>
         <source>last_seen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2267"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2275"/>
         <source>Error retrieving public node list: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2282"/>
         <source>Welcome to Monero, the private cryptocurrency.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2284"/>
         <source>Monero, like Bitcoin, is a cryptocurrency. That is, it is digital money.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2288"/>
         <source>Monero protects your privacy on the blockchain, and while Monero strives to improve all the time,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2289"/>
         <source>no privacy technology can be 100% perfect, Monero included.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2290"/>
         <source>Monero cannot protect you from malware, and it may not be as effective as we hope against powerful adversaries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2291"/>
         <source>Flaws in Monero may be discovered in the future, and attacks may be developed to peek under some</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2292"/>
         <source>of the layers of privacy Monero provides. Be safe and practice defense in depth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2363"/>
         <source>Daemon does not require payment for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2371"/>
         <source>Starting mining for RPC access: diff %llu, %f credits/hash%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2372"/>
         <source>Run stop_mining_for_rpc to stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2418"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2437"/>
         <source>wallet is watch-only and cannot transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2444"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2450"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2476"/>
         <source>ring size must be an integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2462"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6573"/>
         <source>WARNING: this is a non default ring size, which may harm your privacy. Default is recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2481"/>
         <source>could not change default ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2493"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2516"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2532"/>
         <source>priority must be either 0, 1, 2, 3, or 4, or one of: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2537"/>
         <source>could not change default priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2627"/>
         <source>invalid unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2707"/>
         <source>invalid count: must be an unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2663"/>
         <source>invalid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2741"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2859"/>
         <source>Invalid height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2814"/>
         <source>Invalid target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2890"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2909"/>
         <source>Invalid amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2966"/>
         <source>invalid argument: must be either 1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3075"/>
         <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3078"/>
         <source>Stop mining in the daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3082"/>
         <source>Set another daemon to connect to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3085"/>
         <source>Save the current blockchain data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3088"/>
         <source>Synchronize the transactions and balance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3092"/>
         <source>Show the wallet&apos;s balance of the currently selected account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3096"/>
         <source>Show the incoming transfers, all or filtered by availability and address index.
 
 Output format:
@@ -1603,57 +1193,46 @@ Amount, Spent(&quot;T&quot;|&quot;F&quot;), &quot;frozen&quot;|&quot;locked&quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3102"/>
         <source>Show the payments for the given payment IDs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3105"/>
         <source>Show the blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3116"/>
         <source>Send all unlocked balance to an address and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. &lt;priority&gt; is the priority of the sweep. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3119"/>
         <source>Send all unmixable outputs to yourself with ring_size 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3126"/>
         <source>Send all unlocked outputs below the threshold to an address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3130"/>
         <source>Send a single output of the given key image to an address without change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3134"/>
         <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3138"/>
         <source>Sign a transaction from a file. If the parameter &quot;export_raw&quot; is specified, transaction raw hex data suitable for the daemon RPC /sendrawtransaction is exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3141"/>
         <source>Submit a signed transaction from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3145"/>
         <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3149"/>
         <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances.
 If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty).
 If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;.
@@ -1664,224 +1243,180 @@ If the &quot;tag_description&quot; argument is specified, the tag &lt;tag_name&g
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3159"/>
         <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the wallet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3163"/>
         <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3167"/>
         <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3170"/>
         <source>Save the wallet data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3173"/>
         <source>Save a watch-only keys file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3176"/>
         <source>Display the private view key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3179"/>
         <source>Display the private spend key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3182"/>
         <source>Display the Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3258"/>
         <source>Display the encrypted Electrum-style mnemonic seed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3261"/>
         <source>Rescan the blockchain for spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3265"/>
         <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3269"/>
         <source>Set the transaction key (r) for a given &lt;txid&gt; in case the tx was made by some other device or 3rd party wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3273"/>
         <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3277"/>
         <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3281"/>
         <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3285"/>
         <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3289"/>
         <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3293"/>
         <source>Generate a signature proving that you own at least this much, optionally with a challenge string &lt;message&gt;.
 If &apos;all&apos; is specified, you prove the entire sum of all of your existing accounts&apos; balances.
 Otherwise, you prove the reserve of the smallest possible amount above &lt;amount&gt; available in your current account.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3299"/>
         <source>Check a signature proving that the owner of &lt;address&gt; holds at least this much, optionally with a challenge string &lt;message&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3319"/>
         <source>Show the unspent outputs of a specified address within an optional amount range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3327"/>
         <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3331"/>
         <source>Get a string note for a txid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3335"/>
         <source>Set an arbitrary description for the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3339"/>
         <source>Get the description of the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3342"/>
         <source>Show the wallet&apos;s status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3345"/>
         <source>Show the wallet&apos;s information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3349"/>
         <source>Sign the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3353"/>
         <source>Verify a signature on the contents of a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3361"/>
         <source>Import a signed key images list and verify their spent status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3369"/>
         <source>Attempts to reconnect HW wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3373"/>
         <source>Export a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3377"/>
         <source>Import a set of outputs owned by this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3381"/>
         <source>Show information about a transfer to/from this address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3384"/>
         <source>Change the wallet&apos;s password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3391"/>
         <source>Print the information about the current fee and transaction backlog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3393"/>
         <source>Export data needed to create a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3396"/>
         <source>Turn this wallet into a multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3400"/>
         <source>Turn this wallet into a multisig wallet, extra step for N-1/N wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3408"/>
         <source>Export multisig info for other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3412"/>
         <source>Import multisig info from other participants</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3416"/>
         <source>Sign a multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3420"/>
         <source>Submit a signed multisig transaction from a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3424"/>
         <source>Export a signed multisig transaction to a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3511"/>
         <source>Print the ring(s) used to spend a given key image or transaction (if the ring size is &gt; 1)
 
 Output format:
@@ -1889,489 +1424,340 @@ Key Image, &quot;absolute&quot;, list of rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3517"/>
         <source>Set the ring used for a given key image, so it can be reused in a fork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3521"/>
         <source>Unsets the ring used for a given key image or transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3525"/>
         <source>Save known rings to the shared rings database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3541"/>
         <source>Freeze a single output by key image so it will not be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3545"/>
         <source>Thaw a single output by key image so it may be used again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3549"/>
         <source>Checks whether a given output is currently frozen by key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3557"/>
         <source>Prints simple network stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3561"/>
         <source>Lists known public nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3565"/>
         <source>Prints basic info about Monero for first time users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3569"/>
         <source>Returns version information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3573"/>
         <source>Get info about RPC payments to current node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3577"/>
         <source>Start mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3581"/>
         <source>Stop mining to pay for RPC access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3585"/>
         <source>Show the help section or the documentation about a &lt;command&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3663"/>
         <source>needs an argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3677"/>
         <source>set seed: needs an argument. available options: language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3686"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3687"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3688"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3690"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3697"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3698"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3700"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3702"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3703"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3704"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3707"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3710"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3715"/>
         <source>0 or 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3689"/>
         <source>integer &gt;= </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3691"/>
         <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3692"/>
         <source>0, 1, 2, 3, or 4, or one of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3693"/>
         <source>0|1|2 (or never|action|decrypt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3694"/>
         <source>monero, millinero, micronero, nanonero, piconero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3695"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3717"/>
         <source>unsigned integer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3696"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3708"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3709"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3701"/>
         <source>block height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3705"/>
         <source>&lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3712"/>
         <source>1/yes or 0/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3716"/>
         <source>floating point &gt;= 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3719"/>
         <source>set: unrecognized argument(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3777"/>
         <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3789"/>
         <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3794"/>
         <source>Wallet and key files found, loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3800"/>
         <source>Key file found but not wallet file. Regenerating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3806"/>
         <source>Key file not found. Failed to open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3814"/>
         <source>No wallet found with that name. Confirm creation of new wallet named: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3825"/>
         <source>Generating new wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3906"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3921"/>
         <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot;, --generate-from-json=&quot;jsonfilename&quot; and --generate-from-device=&quot;wallet_name&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3940"/>
         <source>can&apos;t specify both --restore-deterministic-wallet or --restore-multisig-wallet and --non-deterministic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3946"/>
         <source>--restore-multisig-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3948"/>
         <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3962"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;multisig seed here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3977"/>
         <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3991"/>
         <source>Multisig seed failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4000"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4050"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4086"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4107"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4127"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4191"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4216"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4232"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4271"/>
         <source>No data supplied, cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4036"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4113"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4222"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6369"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6944"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7203"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7776"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7844"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7908"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8112"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9629"/>
         <source>failed to parse address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4118"/>
         <source>This address is a subaddress which cannot be used here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4056"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4148"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4065"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4165"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4069"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4169"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4251"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4095"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4173"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4307"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4334"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4366"/>
         <source>account creation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4091"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4133"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4276"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4296"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4161"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4301"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4196"/>
         <source>Error: expected M/N, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4201"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4206"/>
         <source>Error: M/N is currently unsupported. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4209"/>
         <source>Generating master wallet from %u of %u multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4238"/>
         <source>failed to parse secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4246"/>
         <source>failed to verify secret view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4289"/>
         <source>Error: M/N is currently unsupported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4341"/>
         <source>No restore height is specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4342"/>
         <source>Assumed you are creating a new account, restore will be done from current estimated blockchain height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4347"/>
         <source>account creation aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4357"/>
         <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4421"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4441"/>
         <source>bad m_restore_height parameter: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4385"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4432"/>
         <source>Restore height is: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4455"/>
         <source>Restore height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4469"/>
         <source>can&apos;t specify --subaddress-lookahead and --wallet-file at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4473"/>
         <source>failed to open account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4478"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5208"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5261"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5401"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7812"/>
         <source>wallet is null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4512"/>
         <source>Failed to initialize ring database: privacy enhancing features will be inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4584"/>
         <source>wallet failed to connect to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4585"/>
         <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or change the daemon address using the &apos;set_daemon&apos; command.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4613"/>
         <source>List of available languages for your wallet&apos;s seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4614"/>
         <source>If your display freezes, exit blind with ^C, then run again with --use-english-language-names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4632"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4637"/>
         <source>invalid language choice entered. Please try again.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4651"/>
         <source>invalid password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4699"/>
         <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4715"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4789"/>
         <source>Generated new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4718"/>
         <source>View key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4724"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4794"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4838"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4893"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4735"/>
         <source>Your wallet has been generated!
 To start synchronizing with the daemon, use the &quot;refresh&quot; command.
 Use the &quot;help&quot; command to see the list of available commands.
@@ -2383,218 +1769,170 @@ your wallet again (your wallet keys are NOT at risk in any case).
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4833"/>
         <source>Generated new wallet on hw device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4885"/>
         <source>failed to generate new mutlisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4888"/>
         <source>Generated new %u/%u multisig wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4904"/>
         <source>wallet file path not valid: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4914"/>
         <source>Key file not found. Failed to open wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4935"/>
         <source>Opened watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4937"/>
         <source>Opened %u/%u multisig wallet%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4939"/>
         <source>Opened wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4957"/>
         <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4972"/>
         <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4980"/>
         <source>failed to load wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4997"/>
         <source>Use the &quot;help&quot; command to see the list of available commands.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4998"/>
         <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5020"/>
         <source>failed to deinitialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5043"/>
         <source>Wallet data saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5057"/>
         <source>wallet is multisig and cannot save a watch-only version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5065"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5073"/>
         <source>Watch only wallet saved as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5077"/>
         <source>Failed to save watch only wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5199"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5937"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9707"/>
         <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5248"/>
         <source>Mining started in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5250"/>
         <source>mining has NOT been started: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5270"/>
         <source>Mining stopped in daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5272"/>
         <source>mining has NOT been stopped: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5327"/>
         <source>Unexpected array length - Exited simple_wallet::set_daemon()</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5349"/>
         <source>Expected trusted or untrusted, got </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5373"/>
         <source>untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5389"/>
         <source>This does not seem to be a valid daemon URL.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5409"/>
         <source>Blockchain saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5411"/>
         <source>blockchain can&apos;t be saved: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5428"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5474"/>
         <source>Height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5429"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5475"/>
         <source>txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5431"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5477"/>
         <source>idx </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5476"/>
         <source>spent </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5503"/>
         <source>Enter password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5586"/>
         <source>Starting refresh...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5605"/>
         <source>New transfer received since rescan was started. Key images are incomplete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5612"/>
         <source>Refresh done, blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="532"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5620"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5951"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3189"/>
         <source>Available options:
  seed language
    Set the wallet&apos;s seed language.
@@ -2665,550 +2003,415 @@ credits-target &lt;unsigned int&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4487"/>
         <source>RPC client secret key should be 32 byte in hex format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5180"/>
         <source>With background mining enabled, the daemon will mine when idle and not on battery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5297"/>
         <source>Error checking daemon RPC access prices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5303"/>
         <source>Error checking daemon RPC access prices: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5369"/>
         <source>Failed to connect to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5381"/>
         <source>Daemon RPC credits/hash is less than was claimed. Either this daemon is cheating, or it changed its setup recently.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5382"/>
         <source>Claimed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5383"/>
         <source>Actual: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5624"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5955"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5628"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5959"/>
         <source>payment required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5634"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5969"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5639"/>
         <source>refresh error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5644"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>refresh failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5659"/>
         <source>Blocks received: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5688"/>
         <source> (Some owned outputs have partial key images - import_multisig_info needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5690"/>
         <source> (Some owned outputs have missing key images - import_key_images needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>Currently selected account: [</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5691"/>
         <source>] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>(No tag assigned)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5693"/>
         <source>Tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5699"/>
         <source>Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5700"/>
         <source>unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5705"/>
         <source>Balance per address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5706"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5714"/>
         <source>%8u %6s %21s %21s %7u %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>pubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5806"/>
         <source>key image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>unlocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>ringct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>global index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
         <source>tx id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>addr index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5817"/>
         <source>Used at heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5822"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5823"/>
         <source>[frozen]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>RingCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5824"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5837"/>
         <source>No incoming transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5841"/>
         <source>No incoming available transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5845"/>
         <source>No incoming unavailable transfers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5869"/>
         <source>unlock time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5881"/>
         <source>No payments with id </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5903"/>
         <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5929"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6024"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6426"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6891"/>
         <source>failed to get blockchain height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5964"/>
         <source>failed to get spent status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6032"/>
         <source>
 Transaction %llu/%llu: txid=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6048"/>
         <source>failed to find construction data for tx input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6070"/>
         <source>failed to get output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6078"/>
         <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6082"/>
         <source>
 Originating block heights: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
         <source>
 |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6094"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>|
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6111"/>
         <source>
 Warning: Some input keys being spent are from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>the same transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6112"/>
         <source>blocks that are temporally very close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6113"/>
         <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6248"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6843"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7120"/>
         <source>Ring size must not be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6260"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6855"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7132"/>
         <source>ring size %u is too small, minimum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6265"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7137"/>
         <source>ring size %u is too large, maximum is %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6272"/>
         <source>wrong number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6289"/>
         <source>payment id failed to encode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6308"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6884"/>
         <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6336"/>
         <source>failed to parse short payment ID from URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6361"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6363"/>
         <source>Invalid last argument: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6381"/>
         <source>a single transaction cannot use more than one payment id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6397"/>
         <source>failed to parse payment id, though it was detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6465"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Is this okay anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6470"/>
         <source>There is currently a %u block backlog at that fee level. Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6716"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7011"/>
         <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7017"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7254"/>
         <source>Sweeping %s for a total fee of %s.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6769"/>
         <source>Discarding %s of unmixable outputs that cannot be spent, which can be undone by &quot;rescan_spent&quot;.  Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6904"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7146"/>
         <source>Failed to parse number of outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6909"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7151"/>
         <source>Amount of outputs should be greater than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6933"/>
         <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6303"/>
         <source>bad locked_blocks parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6953"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7211"/>
         <source>a single transaction cannot use more than one payment id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6403"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6962"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7179"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7219"/>
         <source>failed to set up payment id, though it was decoded correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1079"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1201"/>
         <source>Send this multisig info to all other participants, then use exchange_multisig_keys &lt;info1&gt; [&lt;info2&gt;...] with others&apos; multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1210"/>
         <source>Multisig wallet has been successfully created. Current wallet type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1216"/>
         <source>Failed to perform multisig keys exchange: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="1543"/>
         <source>Failed to load multisig transaction from MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2082"/>
         <source>Failed to mark output spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2109"/>
         <source>Failed to mark output unspent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2133"/>
         <source>Spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2135"/>
         <source>Not spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2139"/>
         <source>Failed to check whether output is spent: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2327"/>
         <source>Please confirm the transaction on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2985"/>
         <source>Device name not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2994"/>
         <source>Device reconnect failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2999"/>
         <source>Device reconnect failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3304"/>
         <source>Show the incoming/outgoing transfers within an optional height range.
 
 Output format:
@@ -3222,42 +2425,34 @@ Pending or Failed:               &quot;failed&quot;|&quot;pending&quot;, &quot;o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3314"/>
         <source>export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;filepath&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3315"/>
         <source>Export to CSV the incoming/outgoing transfers within an optional height range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3323"/>
         <source>Rescan the blockchain from scratch. If &quot;hard&quot; is specified, you will lose any information which can not be recovered from the blockchain itself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3357"/>
         <source>Export a signed set of key images to a &lt;filename&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3365"/>
         <source>Synchronizes key images with the hw wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3388"/>
         <source>Generate a new random full size payment id (obsolete). These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3404"/>
         <source>Performs extra multisig keys exchange rounds. Needed for arbitrary M/N multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3428"/>
         <source>Interface with the MMS (Multisig Messaging System)
 &lt;subcommand&gt; is one of:
   init, info, signer, list, next, sync, transfer, delete, send, receive, export, note, show, set, help
@@ -3266,73 +2461,59 @@ Get help about a subcommand with: help mms &lt;subcommand&gt;, or mms help &lt;s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3436"/>
         <source>Initialize and configure the MMS for M/N = number of required signers/number of authorized signers multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3440"/>
         <source>Display current MMS configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3444"/>
         <source>Set or modify authorized signer info (single-word label, transport address, Monero address), or list all signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3448"/>
         <source>List all messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3452"/>
         <source>Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
 By using &apos;sync&apos; processing of waiting messages with multisig sync info can be forced regardless of wallet state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3457"/>
         <source>Force generation of multisig sync info regardless of wallet state, to recover from special situations like &quot;stale data&quot; errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3461"/>
         <source>Initiate transfer with MMS support; arguments identical to normal &apos;transfer&apos; command arguments, for info see there</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3465"/>
         <source>Delete a single message by giving its id, or delete all messages by using &apos;all&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3469"/>
         <source>Send a single message by giving its id, or send all waiting messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3473"/>
         <source>Check right away for new messages to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3477"/>
         <source>Write the content of a message to a file &quot;mms_message_content&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3481"/>
         <source>Send a one-line message to an authorized signer, identified by its label, or show any waiting unread notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3485"/>
         <source>Show detailed info about a single message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3489"/>
         <source>Available options:
  auto-send &lt;1|0&gt;
    Whether to automatically send newly generated messages right away.
@@ -3340,1762 +2521,1345 @@ By using &apos;sync&apos; processing of waiting messages with multisig sync info
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3495"/>
         <source>Send completed signer config to all other authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3499"/>
         <source>Start auto-config at the auto-config manager&apos;s wallet by issuing auto-config tokens and optionally set others&apos; labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3503"/>
         <source>Delete any auto-config tokens and abort a auto-config process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3507"/>
         <source>Start auto-config by using the token received from the auto-config manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3529"/>
         <source>Mark output(s) as spent so they never get selected as fake outputs in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3533"/>
         <source>Marks an output as unspent so it may get selected as a fake output in a ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3537"/>
         <source>Checks whether an output is marked as spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3713"/>
         <source>&lt;device_name[:device_spec]&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3738"/>
         <source>wrong number range, use: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3843"/>
         <source>NOTE: the following %s can be used to recover access to your wallet. Write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3845"/>
         <source>25 words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4266"/>
         <source>Secret spend key (%u of %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4343"/>
         <source>Use --restore-height or --restore-date if you want to restore an already setup account from a specific height.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4345"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4433"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6575"/>
         <source>Is this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4456"/>
         <source>Still apply restore height?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4623"/>
         <source>Enter the number corresponding to the language of your choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5518"/>
         <source>Device requires attention</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5524"/>
         <source>Enter device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5526"/>
         <source>Failed to read device PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5533"/>
         <source>Please enter the device passphrase on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5538"/>
         <source>Enter device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5540"/>
         <source>Failed to read device passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5556"/>
         <source>The first refresh has finished for the HW-based wallet with received money. hw_key_images_sync is needed. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5182"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5558"/>
         <source>Do you want to do it now? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2308"/>
         <source>Unknown command &apos;%s&apos;, try &apos;help&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2934"/>
         <source>Inactivity lock timeout disabled on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2948"/>
         <source>Invalid number of seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3010"/>
         <source>Export format not specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3024"/>
         <source>Export format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3185"/>
         <source>Display the restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3553"/>
         <source>Lock the wallet console, requiring the wallet password to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3711"/>
         <source>unsigned integer (seconds, 0 to disable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3714"/>
         <source>&quot;binary&quot; or &quot;ascii&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4495"/>
         <source>Warning: using an untrusted daemon at %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4496"/>
         <source>Using a third party daemon can be detrimental to your security and privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4499"/>
         <source>Using your own without SSL exposes your RPC traffic to monitoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4500"/>
         <source>You are strongly encouraged to connect to the Monero network using your own daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4501"/>
         <source>If you or someone you trust are operating this daemon, you can use --trusted-daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4508"/>
         <source>Moreover, a daemon is also less secure when running in bootstrap mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4521"/>
         <source>If you are new to Monero, type &quot;welcome&quot; for a brief overview.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4662"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4759"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4807"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4850"/>
         <source>Error creating wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5093"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5125"/>
         <source>Failed to query mining status: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5108"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5136"/>
         <source>Failed to setup background mining: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5112"/>
         <source>Background mining enabled. Thank you for supporting the Monero network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5140"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5148"/>
         <source>Background mining not enabled. Run &quot;set setup-background-mining 1&quot; to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5154"/>
         <source>Using an untrusted daemon, skipping background mining check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5179"/>
         <source>The daemon is not set up to background mine.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5181"/>
         <source>Enabling this supports the network you are using, and makes you eligible for receiving new monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5186"/>
         <source>Background mining not enabled. Set setup-background-mining to 1 to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5455"/>
         <source>NOTE: This transaction is locked, see details with: show_transfer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5560"/>
         <source>hw_key_images_sync skipped. Run command manually before a transfer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5768"/>
         <source>Invalid keyword: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6053"/>
         <source>
 Input %llu/%llu (%s): amount=%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6144"/>
         <source>Transaction spends more than one very old output. Privacy would be better if they were sent separately.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6145"/>
         <source>Spend them now anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6168"/>
         <source>I locked your Monero wallet to protect you while you were away</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6188"/>
         <source>Locked due to inactivity. The wallet password is required to unlock the console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6351"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8073"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8587"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8595"/>
         <source>amount is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6352"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7363"/>
         <source>expected number from 0 to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6486"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6495"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6582"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6731"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6983"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7026"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7262"/>
         <source>transaction cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6442"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6977"/>
         <source>No outputs found, or daemon is not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2285"/>
         <source>Unlike Bitcoin, your Monero transactions and balance stay private and are not visible to the world by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2286"/>
         <source>However, you have the option of making those available to select parties if you choose to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2294"/>
         <source>Welcome to Monero and financial privacy. For more information see https://GetMonero.org</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5447"/>
         <source>NOTE: this transaction uses an encrypted payment ID: consider using subaddresses instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5451"/>
         <source>WARNING: this transaction uses an unencrypted payment ID: these are obsolete and ignored. Use subaddresses instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6475"/>
         <source>Failed to check for backlog: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6524"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6999"/>
         <source>
 Transaction </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6531"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7006"/>
         <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6546"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6551"/>
         <source>.
 This transaction (including %s change) will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6595"/>
         <source>Unsigned transaction(s) successfully written to MMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6603"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6640"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6742"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6754"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7037"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7074"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7272"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7284"/>
         <source>Failed to write transaction(s) to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6608"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6645"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6746"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6758"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7041"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7078"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7276"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7288"/>
         <source>Unsigned transaction(s) successfully written to file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6617"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7053"/>
         <source>Failed to cold sign transaction with HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6701"/>
         <source>No unmixable outputs found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="6714"/>
         <source>Sweeping </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7374"/>
         <source>Failed to parse donation address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7390"/>
         <source>Donating %s %s to %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7538"/>
         <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8480"/>
         <source>usage: export_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]] [output=&lt;path&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>running balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8559"/>
         <source>CSV exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8744"/>
         <source>Rescan anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8755"/>
         <source>Warning: your restore height is higher than wallet restore height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8756"/>
         <source>Rescan anyway ? (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8775"/>
         <source>MMS received new message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8944"/>
         <source>locked due to inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9284"/>
         <source>&lt;index&gt; is out of bounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9560"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9561"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10377"/>
         <source>Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9562"/>
         <source>Network type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9563"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9564"/>
         <source>Mainnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10212"/>
         <source> (Y/Yes/N/No): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10239"/>
         <source>Choose processing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10248"/>
         <source>Sign tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10256"/>
         <source>Send the tx for submission to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10260"/>
         <source>Send the tx for signing to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10267"/>
         <source>Submit tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10270"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10276"/>
         <source>Choice: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10288"/>
         <source>Wrong choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>I/O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10295"/>
         <source>Authorized Signer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Message State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10296"/>
         <source>Since</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10313"/>
         <source> ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>#</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10319"/>
         <source>Transport Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Auto-Config Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10320"/>
         <source>Monero Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10324"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10332"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10334"/>
         <source>&lt;not set&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10375"/>
         <source>Message </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10376"/>
         <source>In/out: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>State: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10378"/>
         <source>%s since %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10382"/>
         <source>Sent: Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10386"/>
         <source>Sent: %s, %s ago</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10389"/>
         <source>Authorized signer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source>Content size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10390"/>
         <source> bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>Content: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10391"/>
         <source>(binary data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10421"/>
         <source>Send these messages now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10431"/>
         <source>Queued for sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10451"/>
         <source>Invalid message id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10460"/>
         <source>usage: mms init &lt;required_signers&gt;/&lt;authorized_signers&gt; &lt;own_label&gt; &lt;own_transport_address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10466"/>
         <source>The MMS is already initialized. Re-initialize by deleting all signer info and messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10481"/>
         <source>Error in the number of required signers and/or authorized signers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10498"/>
         <source>The MMS is not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10521"/>
         <source>Invalid signer number </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10526"/>
         <source>mms signer [&lt;number&gt; &lt;label&gt; [&lt;transport_address&gt; [&lt;monero_address&gt;]]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10545"/>
         <source>Invalid Monero address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10552"/>
         <source>Wallet state does not allow changing Monero addresses anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10564"/>
         <source>Usage: mms list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10577"/>
         <source>Usage: mms next [sync]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10602"/>
         <source>No next step: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10612"/>
         <source>prepare_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10618"/>
         <source>make_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10633"/>
         <source>exchange_multisig_keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10648"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10768"/>
         <source>export_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10657"/>
         <source>import_multisig_info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10670"/>
         <source>sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10680"/>
         <source>submit_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10690"/>
         <source>Send tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10701"/>
         <source>Process signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10713"/>
         <source>Replace current signer config with the one displayed above?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10727"/>
         <source>Process auto config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10741"/>
         <source>Nothing ready to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10761"/>
         <source>Usage: mms sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10785"/>
         <source>Usage: mms delete (&lt;message_id&gt; | all)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10792"/>
         <source>Delete all messages?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10818"/>
         <source>Usage: mms send [&lt;message_id&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10835"/>
         <source>Usage: mms receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10852"/>
         <source>Usage: mms export &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10864"/>
         <source>Message content saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10868"/>
         <source>Failed to to save message content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10892"/>
         <source>Usage: mms note [&lt;label&gt; &lt;text&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10899"/>
         <source>No signer found with label </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10921"/>
         <source>Usage: mms show &lt;message_id&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10940"/>
         <source>Usage: mms set &lt;option_name&gt; [&lt;option_value&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10957"/>
         <source>Wrong option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10962"/>
         <source>Auto-send is off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10967"/>
         <source>Unknown option</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10975"/>
         <source>Usage: mms help [&lt;subcommand&gt;]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10991"/>
         <source>Usage: mms send_signer_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10997"/>
         <source>Signer config not yet complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11012"/>
         <source>Usage: mms start_auto_config [&lt;label&gt; &lt;label&gt; ...]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11017"/>
         <source>There are signers without a label set. Complete labels before auto-config or specify them as parameters here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11023"/>
         <source>Auto-config is already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11047"/>
         <source>Usage: mms stop_auto_config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11050"/>
         <source>Delete any auto-config tokens and stop auto-config?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11063"/>
         <source>Usage: mms auto_config &lt;auto_config_token&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11070"/>
         <source>Invalid auto-config token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11076"/>
         <source>Auto-config already running. Cancel and restart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11094"/>
         <source>MMS not available in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11118"/>
         <source>The MMS is not active. Activate using the &quot;mms init&quot; command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11195"/>
         <source>Invalid MMS subcommand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11200"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="11204"/>
         <source>Error in MMS command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9582"/>
         <source>wallet is watch-only and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9587"/>
         <source>This wallet is multisig and cannot sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9636"/>
         <source>Bad signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9640"/>
         <source>Good signature from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9656"/>
         <source>wallet is watch-only and cannot export key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9694"/>
         <source>Signed key images exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9739"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9785"/>
         <source>command only supported by HW wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9744"/>
         <source>hw wallet does not support cold KI sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9756"/>
         <source>Please confirm the key image sync on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9762"/>
         <source>Key images synchronized to height </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9765"/>
         <source>Running untrusted daemon, cannot determine which transaction output is spent. Use a trusted daemon with --trusted-daemon and run rescan_spent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> spent, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9768"/>
         <source> unspent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9772"/>
         <source>Failed to import key images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9777"/>
         <source>Failed to import key images: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9794"/>
         <source>Failed to reconnect device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9799"/>
         <source>Failed to reconnect device: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9851"/>
         <source>Outputs exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10006"/>
         <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10041"/>
         <source>Transaction ID not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
         <source>Transaction successfully saved to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10076"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>, txid </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10078"/>
         <source>Failed to save transaction to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="373"/>
         <source>true</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="426"/>
         <source>failed to parse refresh type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="796"/>
         <source>Enter optional seed offset passphrase, empty to see raw seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4005"/>
         <source>Enter seed offset passphrase, empty if none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="4991"/>
         <source>You may want to remove the file &quot;%s&quot; and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7388"/>
         <source>Donating %s %s to The Monero Project (donate.getmonero.org or %s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7567"/>
         <source>This is a multisig wallet, it can only sign with sign_multisig</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7572"/>
         <source>This is a watch only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7590"/>
         <source>Failed to sign transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7596"/>
         <source>Failed to sign transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7617"/>
         <source>Transaction raw hex data exported to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7638"/>
         <source>Failed to load transaction from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7674"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7712"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7769"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7818"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7900"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7985"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8020"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9441"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9469"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9903"/>
         <source>failed to parse txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7690"/>
         <source>Tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7695"/>
         <source>no tx keys found for this txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7722"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7733"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7740"/>
         <source>failed to parse tx_key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7749"/>
         <source>Tx key successfully stored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7753"/>
         <source>Failed to store tx key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7787"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7999"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8088"/>
         <source>signature file saved to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7789"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8001"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8090"/>
         <source>failed to save signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7793"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7881"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7959"/>
         <source>error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7826"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7835"/>
         <source>failed to parse tx key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7857"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7930"/>
         <source>in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7860"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7933"/>
         <source>WARNING: this transaction is not yet included in the blockchain!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7870"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7943"/>
         <source>WARNING: failed to determine number of confirmations!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7876"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7949"/>
         <source>received nothing in txid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7916"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8030"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8124"/>
         <source>failed to load signature file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7927"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8037"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7954"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8039"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8139"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7978"/>
         <source>wallet is watch-only and cannot generate the proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8062"/>
         <source>The reserve proof can be generated only by a full wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8117"/>
         <source>Address must not be a subaddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8427"/>
         <source>usage: show_transfers [in|out|all|pending|failed|coinbase] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8224"/>
         <source>bad min_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8236"/>
         <source>bad max_height parameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8505"/>
         <source>block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8256"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8350"/>
         <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8602"/>
         <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8628"/>
         <source>There is no unspent output in the specified address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8634"/>
         <source>, number of keys: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8639"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8644"/>
         <source>
 Min block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8645"/>
         <source>
 Max block height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8646"/>
         <source>
 Min amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8647"/>
         <source>
 Max amount found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8648"/>
         <source>
 Total count: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8688"/>
         <source>
 Bin size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8689"/>
         <source>
 Outputs per *: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8691"/>
         <source>count
   ^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8693"/>
         <source>  |</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>  +</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8695"/>
         <source>+--&gt; block height
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>   ^</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8696"/>
         <source>^
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8697"/>
         <source>  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8742"/>
         <source>Warning: this will lose any information which can not be recovered from the blockchain.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8743"/>
         <source>This includes destination addresses, tx secret keys, tx notes, etc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8135"/>
         <source>Good signature -- total: %s, spent: %s, unspent: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2037"/>
         <source>First line is not an amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2051"/>
         <source>Invalid output: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2076"/>
         <source>Invalid output key, and file doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2099"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2126"/>
         <source>Invalid output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2458"/>
         <source>WARNING: from v8, ring size will be fixed and this setting will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="2592"/>
         <source>invalid argument: must be either 0/never, 1/action, or 2/encrypt/decrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3108"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3112"/>
         <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the transaction fee. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding URI_2 or &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="3122"/>
         <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used. If the parameter &quot;outputs=&lt;N&gt;&quot; is specified and  N &gt; 0, wallet splits the transaction into N even outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="5497"/>
         <source>Password needed (%s) - use the refresh command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8901"/>
         <source>Daemon requests payment at diff %llu, with %f credits/hash%s. Run start_mining_for_rpc to start mining to pay for RPC access, or use another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8928"/>
         <source>Error mining to daemon: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8934"/>
         <source>Failed to start mining for RPC payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8946"/>
         <source>wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8948"/>
         <source> (no daemon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8950"/>
         <source> (out of sync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9001"/>
         <source>(Untitled account)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9014"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9032"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9057"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9080"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9228"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9251"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9279"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9019"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9233"/>
         <source>specify an index between 0 and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>
 Grand total:
   Balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9137"/>
         <source>, unlocked balance: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9145"/>
         <source>Untagged accounts:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9151"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9154"/>
         <source>Accounts with tag: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9155"/>
         <source>Tag&apos;s description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9157"/>
         <source>Account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9163"/>
         <source> %c%8u %6s %21s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9173"/>
         <source>----------------------------------------------------------------------------------</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9174"/>
         <source>%15s %21s %21s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>Primary address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9198"/>
         <source>(used)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9219"/>
         <source>(Untitled address)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9260"/>
         <source>&lt;index_min&gt; is already out of bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9265"/>
         <source>&lt;index_max&gt; exceeds the bound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9329"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9342"/>
         <source>Integrated addresses can only be created for account 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9334"/>
         <source>Matching integrated address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9355"/>
         <source>Integrated address: %s, payment ID: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Subaddress: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9361"/>
         <source>Standard address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9366"/>
         <source>failed to parse payment ID or address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9403"/>
         <source>failed to parse index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9411"/>
         <source>Address book is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9417"/>
         <source>Index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9423"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9553"/>
         <source>Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9424"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9552"/>
         <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9509"/>
         <source>no description found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9511"/>
         <source>description found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9551"/>
         <source>Filename: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9556"/>
         <source>Watch only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="9558"/>
         <source>%u/%u multisig%s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7532"/>
         <source>%s change to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7866"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="7939"/>
         <source>This transaction has %u confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5103,65 +3867,50 @@ Grand total:
 <context>
     <name>gencert</name>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="61"/>
         <source>Filename to save the certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="62"/>
         <source>Filename to save the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="63"/>
         <source>Passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="64"/>
         <source>File containing the passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="65"/>
         <source>Prompt for a passphrase with which to encrypt the private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="137"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="143"/>
         <source>Argument is needed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="153"/>
         <source>Failed to read passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="188"/>
         <source>Failed to create certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="198"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="206"/>
         <source>Failed to write certificate: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="218"/>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="226"/>
         <source>Failed to write private key: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="237"/>
         <source>Failed to save certificate file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_ssl_cert/gen_ssl_cert.cpp" line="243"/>
         <source>Failed to save private key file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5169,93 +3918,74 @@ Grand total:
 <context>
     <name>genms</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="70"/>
         <source>Base filename (-1, -2, etc suffixes will be appended as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="71"/>
         <source>Give threshold and participants at once as M/N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="72"/>
         <source>How many participants will share parts of the multisig wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="73"/>
         <source>How many signers are required to sign a valid transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="74"/>
         <source>Create testnet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="75"/>
         <source>Create stagenet multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="76"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="83"/>
         <source>Generating %u %u/%u multisig wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="107"/>
         <source>Failed to verify multisig info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="142"/>
         <source>Error verifying multisig extra info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="153"/>
         <source>Generated multisig wallets for address </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="157"/>
         <source>Error creating multisig wallets: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="182"/>
         <source>This program generates a set of multisig wallets - use this simpler scheme only if all the participants trust each other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="201"/>
         <source>Error: Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="208"/>
         <source>Error: expected N/M, but got: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="216"/>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="225"/>
         <source>Error: either --scheme or both of --threshold and --participants may be given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="232"/>
         <source>Error: expected N &gt; 1 and N &lt;= M, but got N==%u and M==%d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="241"/>
         <source>Error: --filename-base is required</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5263,149 +3993,120 @@ Grand total:
 <context>
     <name>mms::message_store</name>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="69"/>
         <source>Use PyBitmessage instance at URL &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="70"/>
         <source>Specify &lt;arg&gt; as username:password for PyBitmessage API</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="824"/>
         <source>Auto-config cannot proceed because auto config data from other signers is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="849"/>
         <source>The signer config is not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="901"/>
         <source>Wallet can&apos;t go multisig because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="943"/>
         <source>Wallet can&apos;t start another key exchange round because key sets from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1007"/>
         <source>Syncing not done because multisig sync data from other signers are missing or not complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1121"/>
         <source>There are waiting messages, but nothing is ready to process under normal circumstances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1124"/>
         <source>
 Use &quot;mms next sync&quot; if you want to force processing of the waiting sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1128"/>
         <source>
 Use &quot;mms note&quot; to display the waiting notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1133"/>
         <source>There are no messages waiting to be processed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1351"/>
         <source>key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1353"/>
         <source>additional key set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1355"/>
         <source>multisig sync data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1357"/>
         <source>partially signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1359"/>
         <source>fully signed tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1361"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1363"/>
         <source>signer config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1365"/>
         <source>auto-config data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1367"/>
         <source>unknown message type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1376"/>
         <source>in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1378"/>
         <source>out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1380"/>
         <source>unknown message direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1389"/>
         <source>ready to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1391"/>
         <source>sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1393"/>
         <source>waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1395"/>
         <source>processed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1397"/>
         <source>cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/message_store.cpp" line="1399"/>
         <source>unknown message state</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,320 +4114,256 @@ Use &quot;mms note&quot; to display the waiting notes</source>
 <context>
     <name>sw</name>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="152"/>
         <source>Generate new wallet and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="153"/>
         <source>Generate new wallet from device and save it to &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="154"/>
         <source>Generate incoming-only wallet from view key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="155"/>
         <source>Generate deterministic wallet from spend key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="156"/>
         <source>Generate wallet from private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="157"/>
         <source>Generate a master wallet from multisig wallet keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="159"/>
         <source>Language for mnemonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="160"/>
         <source>Specify Electrum seed for wallet recovery/creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="161"/>
         <source>Recover wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="162"/>
         <source>alias for --restore-deterministic-wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="163"/>
         <source>Recover multisig wallet using Electrum-style mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="164"/>
         <source>Generate non-deterministic view and spend keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="167"/>
         <source>Restore from estimated blockchain height on specified date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="313"/>
         <source>failed to read wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="320"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="398"/>
         <source>invalid argument: must be either 0/1, true/false, y/n, yes/no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="454"/>
         <source>DNSSEC validation passed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="458"/>
         <source>WARNING: DNSSEC validation was unsuccessful, this address may not be correct!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="461"/>
         <source>For URL: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="463"/>
         <source> Monero Address = </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="475"/>
         <source>you have cancelled the transfer request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="496"/>
         <source>failed to parse index: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="509"/>
         <source>invalid format for subaddress lookahead; must be &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="528"/>
         <source>no connection to daemon. Please make sure daemon is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="537"/>
         <source>RPC error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="541"/>
         <source>failed to get random outputs to mix: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="548"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="556"/>
         <source>Not enough money in unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="566"/>
         <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="572"/>
         <source>not enough outputs for specified ring size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>output amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="575"/>
         <source>found outputs to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="577"/>
         <source>Please use sweep_unmixable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="581"/>
         <source>transaction was not constructed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="589"/>
         <source>Reason: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="598"/>
         <source>one of destinations is zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="603"/>
         <source>failed to find a suitable way to split transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="609"/>
         <source>unknown transfer error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="614"/>
         <source>Multisig error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="620"/>
         <source>internal error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="625"/>
         <source>unexpected error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="629"/>
         <source>There was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="641"/>
         <source>File %s likely stores wallet private keys! Use a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8153"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8155"/>
         <source> minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8157"/>
         <source> hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8159"/>
         <source> days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8161"/>
         <source> months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="8162"/>
         <source>a long time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10137"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.
 WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key reuse mitigations built in. Doing so will harm your privacy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10162"/>
         <source>Unknown command: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="165"/>
         <source>Allow communicating with a daemon that uses a different RPC version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="166"/>
         <source>Restore from specific blockchain height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="168"/>
         <source>The newly created transaction will not be relayed to the monero network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="169"/>
         <source>Create an address file for new wallets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="171"/>
         <source>Display English language names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="330"/>
         <source>daemon is busy. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="339"/>
         <source>possibly lost connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="356"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="465"/>
         <source>Is this OK?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="586"/>
         <source>transaction %s was rejected by daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="644"/>
         <source>File %s already exists. Are you sure to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10156"/>
         <source>Failed to initialize wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5734,313 +4371,246 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet2</name>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="253"/>
         <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="254"/>
         <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="259"/>
         <source>Wallet password file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="260"/>
         <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="269"/>
         <source>For testnet. Daemon must also be launched with --testnet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="386"/>
         <source>can&apos;t specify daemon host or port more than once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="522"/>
         <source>can&apos;t specify more than one of --password and --password-file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="535"/>
         <source>the password file specified could not be read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="561"/>
         <source>Failed to load file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="258"/>
         <source>Wallet password (escape/quote as needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="255"/>
         <source>[&lt;ip&gt;:]&lt;port&gt; socks proxy to use for daemon connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="256"/>
         <source>Enable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="257"/>
         <source>Disable commands which rely on a trusted daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="261"/>
         <source>Specify username[:password] for daemon RPC client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="262"/>
         <source>Enable SSL on daemon RPC connections: enabled|disabled|autodetect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="266"/>
         <source>List of valid fingerprints of allowed RPC servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="267"/>
         <source>Allow any SSL certificate from the daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="268"/>
         <source>Allow user (via --daemon-ssl-ca-certificates) chain certificates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="270"/>
         <source>For stagenet. Daemon must also be launched with --stagenet flag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="272"/>
         <source>Set shared ring database path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="283"/>
         <source>Number of rounds for the key derivation function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="284"/>
         <source>HW device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="285"/>
         <source>HW device wallet derivation path (e.g., SLIP-10)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="287"/>
         <source>Do not use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="288"/>
         <source>Do not connect to a daemon, nor use DNS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="289"/>
         <source>File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, wihch typically means more than 256 bits of data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="378"/>
         <source>Invalid argument for </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source>Enabling --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="430"/>
         <source> requires --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="431"/>
         <source> or use of a .onion/.i2p domain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="465"/>
         <source>--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="475"/>
         <source>Daemon is local, assuming trusted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="542"/>
         <source>no password specified; use --prompt-for-password to prompt for a password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Enter a new password for the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="544"/>
         <source>Wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="567"/>
         <source>Failed to parse JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="574"/>
         <source>Version %u too new, we can only grok up to %u</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="590"/>
         <source>failed to parse view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="595"/>
-        <location filename="../src/wallet/wallet2.cpp" line="663"/>
-        <location filename="../src/wallet/wallet2.cpp" line="708"/>
         <source>failed to verify view key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="606"/>
         <source>failed to parse spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="611"/>
-        <location filename="../src/wallet/wallet2.cpp" line="673"/>
-        <location filename="../src/wallet/wallet2.cpp" line="734"/>
         <source>failed to verify spend key secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="623"/>
         <source>Electrum-style word list failed verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="643"/>
         <source>At least one of either an Electrum-style word list, private view key, or private spend key must be specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="647"/>
         <source>Both Electrum-style word list and private key(s) specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="657"/>
         <source>invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="666"/>
         <source>view key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="676"/>
         <source>spend key does not match standard address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="684"/>
         <source>Cannot generate deprecated wallets from JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="720"/>
         <source>failed to parse address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="726"/>
         <source>Address must be specified in order to create watch-only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="743"/>
         <source>failed to generate new wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1762"/>
         <source>Password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="1763"/>
         <source>Invalid password: password is needed to compute key image for incoming monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="4378"/>
-        <location filename="../src/wallet/wallet2.cpp" line="4968"/>
-        <location filename="../src/wallet/wallet2.cpp" line="5572"/>
         <source>Primary account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="11253"/>
         <source>No funds received in this tx.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="12034"/>
         <source>failed to read file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="170"/>
         <source>Set subaddress lookahead sizes to &lt;major&gt;:&lt;minor&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="263"/>
         <source>Path to a PEM format private key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="264"/>
         <source>Path to a PEM format certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet2.cpp" line="265"/>
         <source>Path to file containing concatenated PEM format certificate(s) to replace system CA(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6048,125 +4618,99 @@ WARNING: Do not reuse your Monero keys on another fork, UNLESS this fork has key
 <context>
     <name>tools::wallet_rpc_server</name>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="188"/>
         <source>Failed to create directory </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="190"/>
         <source>Failed to create directory %s: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source>Cannot specify --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="201"/>
         <source> and --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>Failed to create file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="220"/>
         <source>. Check permissions or remove file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="230"/>
         <source>Error writing to file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="233"/>
         <source>RPC username/password is stored in file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="612"/>
         <source>Tag %s is unregistered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="3291"/>
         <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4492"/>
         <source>This is the RPC monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4304"/>
         <source>Can&apos;t specify more than one of --testnet and --stagenet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4320"/>
         <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4332"/>
         <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4336"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4381"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4413"/>
         <source>Saving wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4383"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4415"/>
         <source>Successfully saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4386"/>
         <source>Successfully loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4390"/>
         <source>Wallet initialization failed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4396"/>
         <source>Failed to initialize wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4400"/>
         <source>Starting wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4407"/>
         <source>Failed to run wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4410"/>
         <source>Stopped wallet RPC server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4419"/>
         <source>Failed to save wallet: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6174,80 +4718,63 @@ daemon to work correctly.</source>
 <context>
     <name>wallet_args</name>
     <message>
-        <location filename="../src/gen_multisig/gen_multisig.cpp" line="168"/>
-        <location filename="../src/wallet/wallet_rpc_server.cpp" line="4472"/>
-        <location filename="../src/simplewallet/simplewallet.cpp" line="10102"/>
         <source>Wallet options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="73"/>
         <source>Generate wallet from JSON format file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="77"/>
         <source>Use wallet &lt;arg&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="81"/>
         <source>Set RPC client secret key for RPC payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="109"/>
         <source>Max number of threads to use for a parallel job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="110"/>
         <source>Specify log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="111"/>
         <source>Config file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="123"/>
         <source>General options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="148"/>
         <source>This is the command line monero wallet. It needs to connect to a monero
 daemon to work correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="173"/>
         <source>Can&apos;t find config file </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="217"/>
         <source>Logging to: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="219"/>
         <source>Logging to %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="223"/>
         <source>WARNING: You may not have a high enough lockable memory limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="225"/>
         <source>see ulimit -l</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/wallet/wallet_args.cpp" line="150"/>
         <source>Usage:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/utils/translations/update-translations.sh
+++ b/utils/translations/update-translations.sh
@@ -12,5 +12,5 @@ then
 fi
 
 echo "using $lupdate"
-"$lupdate" `find src -name \*.cpp` -ts translations/*.ts -no-obsolete
+"$lupdate" `find src -name \*.cpp` -ts translations/*.ts -no-obsolete -locations none
 


### PR DESCRIPTION
Based on #10673.

This removes the locations from translation files. It also updates the `*.ts` generation script to not include them in future runs.

Updating the translation files produces very spammy git diffs because line numbers change for almost every translation. Removing them makes future PRs easier to review. The locations are not needed to generate the `.qm` files.