### PR TITLE
cmake: only look for backtrace if stack trace enabled

### DIFF
--- a/external/easylogging++/CMakeLists.txt
+++ b/external/easylogging++/CMakeLists.txt
@@ -37,7 +37,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 monero_enable_coverage()
 
 find_package(Threads)
-find_package(Backtrace)
+
+if(STACK_TRACE)
+  find_package(Backtrace)
+endif()
 
 monero_find_all_headers(EASYLOGGING_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}")
 


### PR DESCRIPTION
With `-DSTACK_TRACE=OFF` cmake shows:

```
 -- Looking for backtrace
-- Looking for backtrace - found
-- backtrace facility detected in default set of libraries
-- Backtrace_LIBRARY: 
-- Could NOT find Backtrace (missing: Backtrace_INCLUDE_DIR) 
```