### PR TITLE
ci: macos: explicitely install unbound

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           brew uninstall cmake
           brew update
-          brew install --quiet cmake boost hidapi openssl zmq expat libunwind-headers protobuf ccache
+          brew install --quiet cmake boost hidapi openssl zmq unbound libunwind-headers protobuf ccache
       - name: build
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{env.MAKE_JOB_COUNT}}


### PR DESCRIPTION
https://github.com/monero-project/monero/actions/runs/26603468559/job/78392711942?pr=10677#step:6:62

We don't directly depend on `expat`, it's an (optional) transitive dependency for `unbound`.