### PR TITLE
brew: remove some unused libraries

### DIFF
--- a/contrib/brew/Brewfile
+++ b/contrib/brew/Brewfile
@@ -4,10 +4,7 @@
 #     https://github.com/Homebrew/homebrew-bundle
 # execute brew bundle in the directory containing the Brewfile
 
-
-brew "autoconf"
 brew "autogen"
-brew "automake"
 brew "binutils"
 brew "coreutils"
 brew "cmake"
@@ -16,15 +13,12 @@ brew "boost"
 brew "openssl"
 brew "hidapi"
 brew "zmq"
-brew "libpgm"
 brew "unbound"
 brew "libsodium"
 brew "readline"
-brew "expat"
 brew "ccache"
 brew "doxygen"
 brew "graphviz"
 brew "libunwind-headers"
-brew "xz"
 brew "protobuf"
 brew "libusb"


### PR DESCRIPTION
- autoconf and automake are no longer used in depends: https://github.com/monero-project/monero/pull/9654
- libpgm is an optional zeromq dependency: https://github.com/monero-project/monero/pull/9542
- expat is an optional unbound dependency: https://github.com/monero-project/monero/pull/9681
- lzma (part of xz) is an optional libunwind dependency: https://github.com/monero-project/monero/blob/master/cmake/FindLibunwind.cmake#L30-L35
