### PR TITLE
workflows: speed up slow-hash in PR core_tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,9 +186,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Most popular Ubuntu LTS version
-          - name: Ubuntu 24.04
-            container: ubuntu:24.04
+          # Oldest supported Ubuntu LTS version
+          - name: Ubuntu 22.04
+            container: ubuntu:22.04
     container:
       image: ${{ matrix.container }}
       env:
@@ -234,9 +234,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # Oldest supported Ubuntu LTS version
-          - name: Ubuntu 22.04
-            container: ubuntu:22.04
+          # Most popular Ubuntu LTS version
+          - name: Ubuntu 24.04
+            container: ubuntu:24.04
     container:
       image: ${{ matrix.container }}
       env:
@@ -256,7 +256,7 @@ jobs:
       - name: install pip
         run: apt install -y python3-pip
       - name: install Python dependencies
-        run: pip install requests psutil monotonic zmq deepdiff
+        run: python3 -m pip install --break-system-packages requests psutil monotonic zmq deepdiff
       - name: configure git
         run: git config --global --add safe.directory '*'
       - uses: actions/checkout@v5
@@ -272,15 +272,26 @@ jobs:
       - name: create dummy disk drives for testing
         run: tests/create_test_disks.sh >> $GITHUB_ENV
       - uses: ./.github/actions/set-make-job-count
-      - name: tests
+      - name: build
         env:
-          CTEST_OUTPUT_ON_FAILURE: ON
-          DNS_PUBLIC: tcp://9.9.9.9
           CMAKE_BUILD_PARALLEL_LEVEL: ${{env.MAKE_JOB_COUNT}}
         run: |
           ${{env.CCACHE_SETTINGS}}
           ${{env.BUILD_DEFAULT}}
-          cmake --build build --target test
+      - name: run tests except core_tests
+        env:
+          DNS_PUBLIC: tcp://9.9.9.9
+        run: ctest --test-dir build --output-on-failure -E core_tests
+      - name: use reduced slow-hash iterations for core_tests
+        if: github.event_name == 'pull_request'
+        env:
+          CFLAGS: -DMONERO_CRYPTO_SLOW_HASH_ITER=20
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{env.MAKE_JOB_COUNT}}
+        run: |
+          cmake -S . -B build --fresh -D ARCH="default" -D BUILD_TESTS=ON
+          cmake --build build --target core_tests
+      - name: run core_tests
+        run: ctest --test-dir build --output-on-failure -R core_tests
       - name: save ccache
         uses: actions/cache/save@v5
         if: github.event_name != 'pull_request' && steps.ccache-restore.outputs.cache-hit != 'true'

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -44,8 +44,12 @@
 
 #include <errno.h>
 
+#ifndef MONERO_CRYPTO_SLOW_HASH_ITER
+#define MONERO_CRYPTO_SLOW_HASH_ITER (1 << 20)
+#endif
+
 #define MEMORY         (1 << 21) // 2MB scratchpad
-#define ITER           (1 << 20)
+#define ITER           MONERO_CRYPTO_SLOW_HASH_ITER
 #define AES_BLOCK_SIZE  16
 #define AES_KEY_SIZE    32
 #define INIT_SIZE_BLK   8

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -320,10 +320,10 @@ TEST(ban, subnet)
     Server::init_options(opts);
     cryptonote::core::init_options(opts);
 
-    char** args = nullptr;
+    const char *argv[] = {"ban_subnet_test"};
     boost::program_options::variables_map vm;
     boost::program_options::store(
-      boost::program_options::parse_command_line(0, args, opts), vm
+      boost::program_options::parse_command_line(1, argv, opts), vm
     );
     server.init(vm);
   }
@@ -456,7 +456,7 @@ TEST(node_server, bind_same_p2p_port)
     cryptonote::core::init_options(desc_options);
     Server::init_options(desc_options);
 
-    const char *argv[2] = {nullptr, nullptr};
+    const char *argv[] = {"node_server_bind_same_p2p_port_test"};
     boost::program_options::variables_map vm;
     boost::program_options::store(boost::program_options::parse_command_line(1, argv, desc_options), vm);
 


### PR DESCRIPTION
https://github.com/monero-project/monero/pull/5821 was rejected because it added runtime code to critical code path, so I'm suggesting this alternative. For security reasons it's only run on pull requests, the full tests are still run on merge.

Splitting up `core_tests` from the other tests also has the advantage that the more frequently failing tests run first.

Reduces `core_tests` runtime from 2610.67 sec to 273.01 sec (~90% reduction).