### PR TITLE
fix off-by-one buffer over-read in match_string2 unicode escape

### DIFF
--- a/contrib/epee/src/parserse_base_utils.cpp
+++ b/contrib/epee/src/parserse_base_utils.cpp
@@ -129,7 +129,7 @@ namespace misc_utils
             case '/':  //Slash character
               val.push_back('/');break;
             case 'u':  //Unicode code point
-              if (buf_end - it < 4)
+              if (buf_end - it < 5)
               {
                 ASSERT_MES_AND_THROW("Invalid Unicode escape sequence");
               }


### PR DESCRIPTION
Backport of #10696 to release-v0.18.

The `\u` branch in match_string2 (parserse_base_utils.cpp:132) guards on `buf_end - it < 4`, but the loop right after runs `*++it` four times and dereferences `it == buf_end` when a JSON string ends with `\u` plus exactly three hex digits, reading one byte past the parser's [begin, end) range. Require 5 remaining bytes so the four hex digits stay inside the buffer.