### PR TITLE
ci: switch to ucrt runtime for msys2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,9 +85,10 @@ jobs:
           restore-keys: ccache-${{ runner.os }}-build-
       - uses: msys2/setup-msys2@v2
         with:
+          msystem: ucrt64
           update: true
           cache: false
-          install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf mingw-w64-x86_64-libusb mingw-w64-x86_64-unbound mingw-w64-x86_64-rust git pkg-config
+          pacboy: toolchain:p cmake:p ccache:p boost:p openssl:p zeromq:p libsodium:p hidapi:p protobuf:p libusb:p unbound:p rust:p git:p
       - uses: ./.github/actions/set-make-job-count
       - name: build
         env:


### PR DESCRIPTION
The MINGW64 environment was deprecated and will be phased out: https://www.msys2.org/news/#2026-03-15-deprecating-the-mingw64-environment

See also: 
- https://www.msys2.org/docs/environments/
- https://www.msys2.org/docs/package-naming/#avoiding-writing-long-package-names
- https://github.com/mingw-w64/mingw-w64/blob/master/mingw-w64-doc/howto-build/ucrt-vs-msvcrt.txt