### PR TITLE
net: canonicalize Tor/I2P hosts during deserialization [release-v0.18]

### DIFF
--- a/src/net/i2p_address.cpp
+++ b/src/net/i2p_address.cpp
@@ -114,11 +114,15 @@ namespace net
     bool i2p_address::_load(epee::serialization::portable_storage& src, epee::serialization::section* hparent)
     {
         i2p_serialized in{};
-        if (in._load(src, hparent) && in.host.size() < sizeof(host_) && (in.host == unknown_host || !host_check(in.host).has_error()))
+        if (in._load(src, hparent) && in.host.size() < sizeof(host_))
         {
-            std::memcpy(host_, in.host.data(), in.host.size());
-            std::memset(host_ + in.host.size(), 0, sizeof(host_) - in.host.size());
-            return true;
+            net::canonicalize_host(in.host);
+            if (in.host == unknown_host || !host_check(in.host).has_error())
+            {
+                std::memcpy(host_, in.host.data(), in.host.size());
+                std::memset(host_ + in.host.size(), 0, sizeof(host_) - in.host.size());
+                return true;
+            }
         }
         static_assert(sizeof(unknown_host) <= sizeof(host_), "bad buffer size");
         std::memcpy(host_, unknown_host, sizeof(unknown_host)); // include null terminator

--- a/src/net/tor_address.cpp
+++ b/src/net/tor_address.cpp
@@ -126,12 +126,16 @@ namespace net
     bool tor_address::_load(epee::serialization::portable_storage& src, epee::serialization::section* hparent)
     {
         tor_serialized in{};
-        if (in._load(src, hparent) && in.host.size() < sizeof(host_) && (in.host == unknown_host || !host_check(in.host).has_error()))
+        if (in._load(src, hparent) && in.host.size() < sizeof(host_))
         {
-            std::memcpy(host_, in.host.data(), in.host.size());
-            std::memset(host_ + in.host.size(), 0, sizeof(host_) - in.host.size());
-            port_ = in.port;
-            return true;
+            net::canonicalize_host(in.host);
+            if (in.host == unknown_host || !host_check(in.host).has_error())
+            {
+                std::memcpy(host_, in.host.data(), in.host.size());
+                std::memset(host_ + in.host.size(), 0, sizeof(host_) - in.host.size());
+                port_ = in.port;
+                return true;
+            }
         }
         static_assert(sizeof(unknown_host) <= sizeof(host_), "bad buffer size");
         std::memcpy(host_, unknown_host, sizeof(unknown_host)); // include null terminator

--- a/tests/unit_tests/net.cpp
+++ b/tests/unit_tests/net.cpp
@@ -327,6 +327,20 @@ TEST(tor_address, epee_serializev_v3)
     EXPECT_STREQ(v3_onion, command.tor.host_str());
     EXPECT_EQ(10u, command.tor.port());
 
+    // make sure tor_address::_load canonicalizes incoming hosts
+    {
+        epee::serialization::portable_storage stg{};
+        stg.load_from_binary(epee::to_span(buffer));
+
+        EXPECT_TRUE(stg.set_value("host", std::string{v3_onion_upper}, stg.open_section("tor", nullptr, false)));
+        EXPECT_TRUE(command.load(stg));
+    }
+
+    EXPECT_FALSE(command.tor.is_unknown());
+    EXPECT_NE(net::tor_address{}, command.tor);
+    EXPECT_STREQ(v3_onion, command.tor.host_str());
+    EXPECT_EQ(10u, command.tor.port());
+
     // make sure that exceeding max buffer doesn't destroy tor_address::_load
     {
         epee::serialization::portable_storage stg{};
@@ -724,6 +738,20 @@ TEST(i2p_address, epee_serializev_b32)
         EXPECT_TRUE(stg.load_from_binary(epee::to_span(buffer)));
         EXPECT_TRUE(command.load(stg));
     }
+    EXPECT_FALSE(command.i2p.is_unknown());
+    EXPECT_NE(net::i2p_address{}, command.i2p);
+    EXPECT_STREQ(b32_i2p, command.i2p.host_str());
+    EXPECT_EQ(1u, command.i2p.port());
+
+    // make sure i2p_address::_load canonicalizes incoming hosts
+    {
+        epee::serialization::portable_storage stg{};
+        stg.load_from_binary(epee::to_span(buffer));
+
+        EXPECT_TRUE(stg.set_value("host", std::string{b32_i2p_upper}, stg.open_section("i2p", nullptr, false)));
+        EXPECT_TRUE(command.load(stg));
+    }
+
     EXPECT_FALSE(command.i2p.is_unknown());
     EXPECT_NE(net::i2p_address{}, command.i2p);
     EXPECT_STREQ(b32_i2p, command.i2p.host_str());


### PR DESCRIPTION
#10703 