### PR TITLE
tx_pool: fix use-after-free in prune()

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -419,7 +419,7 @@ namespace cryptonote
         break;
       try
       {
-        const crypto::hash &txid = it->get_right();
+        const crypto::hash txid = it->get_right();
         txpool_tx_meta_t meta;
         if (!m_blockchain.get_txpool_tx_meta(txid, meta))
         {


### PR DESCRIPTION
txid was a reference to an item which was later deleted in remove_tx_from_transient_lists(), and txid was used after that