### PR TITLE
Blockchain: fix wrong block_weight in handle_get_objects

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2270,9 +2270,7 @@ bool Blockchain::handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, NO
 
     //pack block
     e.block = std::move(bl.first);
-    e.block_weight = 0;
-    if (arg.prune && m_db->block_exists(arg.blocks[i]))
-      e.block_weight = m_db->get_block_weight(m_db->get_block_height(arg.blocks[i]));
+    e.block_weight = arg.prune ? m_db->get_block_weight(get_block_height(bl.second)) : 0;
   }
 
   return true;


### PR DESCRIPTION
When there are missing IDs, `blocks.size() != arg.blocks.size()`, so `arg.blocks` can't be indexed by `i` - the indices will be wrong, the wrong weight will be returned to some peer and this peer will ban our node.

Use `bl.second` instead of `arg.blocks[i]`. Also it saves one DB query per returned block.