### PR TITLE
p2p: track chain entry object requests with a boolean

### DIFF
--- a/src/cryptonote_basic/connection_context.cpp
+++ b/src/cryptonote_basic/connection_context.cpp
@@ -80,6 +80,7 @@ namespace cryptonote
     m_expected_heights.clear();
     m_expected_heights.shrink_to_fit();
     m_requested_objects.clear();
+    m_requested_objects_from_chain_entry = false;
   }
 
   boost::optional<crypto::hash> cryptonote_connection_context::get_expected_hash(const uint64_t height) const

--- a/src/cryptonote_basic/connection_context.h
+++ b/src/cryptonote_basic/connection_context.h
@@ -44,8 +44,9 @@ namespace cryptonote
   {
     cryptonote_connection_context(): m_state(state_before_handshake), m_remote_blockchain_height(0), m_last_response_height(0),
         m_expected_heights_start(0), m_last_request_time(boost::date_time::not_a_date_time), m_callback_request_count(0),
-        m_last_known_hash(crypto::null_hash), m_pruning_seed(0), m_rpc_port(0), m_rpc_credits_per_hash(0), m_anchor(false), m_score(0),
-        m_expect_response(0), m_expect_height(0), m_num_requested(0) {}
+        m_last_known_hash(crypto::null_hash), m_pruning_seed(0), m_rpc_port(0), m_rpc_credits_per_hash(0), m_anchor(false),
+        m_requested_objects_from_chain_entry(false), m_score(0),
+        m_expect_response(0), m_expect_height(0) {}
 
     enum state
     {
@@ -111,10 +112,10 @@ namespace cryptonote
     uint16_t m_rpc_port;
     uint32_t m_rpc_credits_per_hash;
     bool m_anchor;
+    bool m_requested_objects_from_chain_entry;
     int32_t m_score;
     int m_expect_response;
     uint64_t m_expect_height;
-    size_t m_num_requested;
     copyable_atomic m_new_stripe_notification{0};
     copyable_atomic m_idle_peer_notification{0};
   };

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -272,6 +272,7 @@ namespace cryptonote
             context.m_expect_response = 0;
             context.m_expect_height = 0;
             context.m_requested_objects.clear();
+            context.m_requested_objects_from_chain_entry = false;
             context.m_state = cryptonote_connection_context::state_standby; // we'll go back to adding, then (if we can't), download
           }
           else
@@ -563,7 +564,7 @@ namespace cryptonote
     ++context.m_callback_request_count;
     m_p2p->request_callback(context);
     MLOG_PEER_STATE("requesting callback");
-    context.m_num_requested = 0;
+    context.m_requested_objects_from_chain_entry = false;
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------
@@ -2036,7 +2037,7 @@ skip:
         const size_t block_queue_size_threshold = m_block_download_max_size ? m_block_download_max_size : BLOCK_QUEUE_SIZE_THRESHOLD;
         const bool queue_proceed_init = (nspans < m_span_limit.load()) && (size < block_queue_size_threshold);
         // get rid of blocks we already requested, or already have
-        if (skip_unneeded_hashes(context, true) && context.m_needed_objects.empty() && context.m_num_requested == 0)
+        if (skip_unneeded_hashes(context, true) && context.m_needed_objects.empty() && !context.m_requested_objects_from_chain_entry)
         {
           if (context.m_remote_blockchain_height > m_block_queue.get_next_needed_height(bc_height))
           {
@@ -2195,7 +2196,7 @@ skip:
           context.m_last_response_height = 0;
           goto skip;
         }
-        if (skip_unneeded_hashes(context, false) && context.m_needed_objects.empty() && context.m_num_requested == 0)
+        if (skip_unneeded_hashes(context, false) && context.m_needed_objects.empty() && !context.m_requested_objects_from_chain_entry)
         {
           if (context.m_remote_blockchain_height > m_block_queue.get_next_needed_height(m_core.get_current_blockchain_height()))
           {
@@ -2306,7 +2307,7 @@ skip:
           << "/" << tools::get_pruning_stripe(span.first + span.second - 1, context.m_remote_blockchain_height, CRYPTONOTE_PRUNING_LOG_STRIPES)
           << ", ours " << tools::get_pruning_stripe(m_core.get_blockchain_pruning_seed()) << ", peer stripe " << tools::get_pruning_stripe(context.m_pruning_seed));
 
-        context.m_num_requested += req.blocks.size();
+        context.m_requested_objects_from_chain_entry = true;
         post_notify<NOTIFY_REQUEST_GET_OBJECTS>(req, context);
         MLOG_PEER_STATE("requesting objects");
         return true;
@@ -2651,7 +2652,7 @@ skip:
     if (arg.total_height > m_core.get_target_blockchain_height())
       m_core.set_target_blockchain_height(arg.total_height);
 
-    context.m_num_requested = 0;
+    context.m_requested_objects_from_chain_entry = false;
     return 1;
   }
   //------------------------------------------------------------------------------------------------------------------------

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -563,7 +563,7 @@ namespace cryptonote
     ++context.m_callback_request_count;
     m_p2p->request_callback(context);
     MLOG_PEER_STATE("requesting callback");
-    context.m_num_requested = 0;
+    context.m_requested_objects_from_chain_entry = false;
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------
@@ -2036,7 +2036,7 @@ skip:
         const size_t block_queue_size_threshold = m_block_download_max_size ? m_block_download_max_size : BLOCK_QUEUE_SIZE_THRESHOLD;
         const bool queue_proceed_init = (nspans < m_span_limit.load()) && (size < block_queue_size_threshold);
         // get rid of blocks we already requested, or already have
-        if (skip_unneeded_hashes(context, true) && context.m_needed_objects.empty() && context.m_num_requested == 0)
+        if (skip_unneeded_hashes(context, true) && context.m_needed_objects.empty() && !context.m_requested_objects_from_chain_entry)
         {
           if (context.m_remote_blockchain_height > m_block_queue.get_next_needed_height(bc_height))
           {
@@ -2195,7 +2195,7 @@ skip:
           context.m_last_response_height = 0;
           goto skip;
         }
-        if (skip_unneeded_hashes(context, false) && context.m_needed_objects.empty() && context.m_num_requested == 0)
+        if (skip_unneeded_hashes(context, false) && context.m_needed_objects.empty() && !context.m_requested_objects_from_chain_entry)
         {
           if (context.m_remote_blockchain_height > m_block_queue.get_next_needed_height(m_core.get_current_blockchain_height()))
           {
@@ -2306,7 +2306,7 @@ skip:
           << "/" << tools::get_pruning_stripe(span.first + span.second - 1, context.m_remote_blockchain_height, CRYPTONOTE_PRUNING_LOG_STRIPES)
           << ", ours " << tools::get_pruning_stripe(m_core.get_blockchain_pruning_seed()) << ", peer stripe " << tools::get_pruning_stripe(context.m_pruning_seed));
 
-        context.m_num_requested += req.blocks.size();
+        context.m_requested_objects_from_chain_entry = true;
         post_notify<NOTIFY_REQUEST_GET_OBJECTS>(req, context);
         MLOG_PEER_STATE("requesting objects");
         return true;
@@ -2651,7 +2651,7 @@ skip:
     if (arg.total_height > m_core.get_target_blockchain_height())
       m_core.set_target_blockchain_height(arg.total_height);
 
-    context.m_num_requested = 0;
+    context.m_requested_objects_from_chain_entry = false;
     return 1;
   }
   //------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
`m_num_requested` was used only to track whether any objects had been requested from the current chain entry, but it was not reset consistently when the related request state was cleared. Replace it with an explicit boolean and reset it alongside `m_requested_objects`, making the intended lifetime clear.

If this is considered unnecessary churn I can instead keep `m_num_requested` and only fix the missing reset sites.