### PR TITLE
depends: boost: update to 1.91.0-1

### DIFF
--- a/contrib/depends/packages/boost.mk
+++ b/contrib/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
-$(package)_version=1.89.0
+$(package)_version=1.91.0-1
 $(package)_download_path=https://github.com/boostorg/boost/releases/download/boost-$($(package)_version)
 $(package)_file_name=boost-$($(package)_version)-b2-nodocs.tar.gz
-$(package)_sha256_hash=aa25e7b9c227c21abb8a681efd4fe6e54823815ffc12394c9339de998eb503fb
+$(package)_sha256_hash=b5a3d1490118e012f8b12688240d981bcdfcd009fd35bc70d120fbc907df4f7c
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release


### PR DESCRIPTION
Fixes a crash in Boost ASIO that affects FCMP++ GUI builds on Windows. Reported by @j-berman.

Introduced in: https://github.com/boostorg/asio/commit/7f60f27824014b2121103f70b29dcecc3f2a16df
Fixed in: https://github.com/boostorg/asio/commit/b2478a9ba9ed76d7c858419e3f677cc454591d45
