### PR TITLE
use byte-safe isalpha in epee json value parser

### DIFF
--- a/contrib/epee/include/storages/parserse_base_utils.h
+++ b/contrib/epee/include/storages/parserse_base_utils.h
@@ -93,6 +93,11 @@ namespace misc_utils
       return lut[(uint8_t)c] & 1;
     }
 
+    inline bool isalpha(char c)
+    {
+      return lut[(uint8_t)c] & 4;
+    }
+
     std::string transform_to_escape_sequence(const std::string& src);
     /*
       

--- a/contrib/epee/include/storages/portable_storage_from_json.h
+++ b/contrib/epee/include/storages/portable_storage_from_json.h
@@ -146,7 +146,7 @@ namespace epee
                 stg.set_value(name, double(nval), current_section);
               }
               state = match_state_wonder_after_value;
-            }else if(isalpha(*it) )
+            }else if(epee::misc_utils::parse::isalpha(*it) )
             {// could be null, true or false
               boost::string_ref word;
               misc_utils::parse::match_word2(it, buf_end, word);
@@ -245,7 +245,7 @@ namespace epee
             {
               array_md = array_mode_undifined;
               state = match_state_wonder_after_value;
-            }else if(isalpha(*it) )
+            }else if(epee::misc_utils::parse::isalpha(*it) )
             {// array of booleans
               boost::string_ref word;
               misc_utils::parse::match_word2(it, buf_end, word);
@@ -333,7 +333,7 @@ namespace epee
               }else CHECK_ISSPACE();
               break;
             case array_mode_booleans:
-              if(isalpha(*it) )
+              if(epee::misc_utils::parse::isalpha(*it) )
               {// array of booleans
                 boost::string_ref word;
                 misc_utils::parse::match_word2(it, buf_end, word);

--- a/tests/unit_tests/epee_serialization.cpp
+++ b/tests/unit_tests/epee_serialization.cpp
@@ -98,6 +98,35 @@ struct ObjWithOptChild
     KV_SERIALIZE_OPT(test_value, true);
   END_KV_SERIALIZE_MAP()
 };
+
+struct ObjWithBool
+{
+  bool b;
+
+  BEGIN_KV_SERIALIZE_MAP()
+    KV_SERIALIZE(b)
+  END_KV_SERIALIZE_MAP()
+};
+}
+
+TEST(epee_json, keyword_values)
+{
+  // true/false/null parse as keyword values
+  ObjWithBool o{};
+
+  o.b = false;
+  EXPECT_TRUE(epee::serialization::load_t_from_json(o, std::string("{\"b\": true}")));
+  EXPECT_TRUE(o.b);
+
+  o.b = true;
+  EXPECT_TRUE(epee::serialization::load_t_from_json(o, std::string("{\"b\": false}")));
+  EXPECT_FALSE(o.b);
+
+  EXPECT_TRUE(epee::serialization::load_t_from_json(o, std::string("{\"b\": null}")));
+
+  // A value beginning with a non-ASCII byte (most significant bit == 1) is not
+  // a keyword and must be rejected.
+  EXPECT_FALSE(epee::serialization::load_t_from_json(o, std::string("{\"b\": \xc3\x28}")));
 }
 
 TEST(epee_binary, serialize_deserialize)


### PR DESCRIPTION
1. the json value parser detects `null`/`true`/`false` with the libc `isalpha(*it)` on a raw `char`, so a non-ASCII value byte is passed as a negative `int`, outside the `unsigned char`/`EOF` range `isalpha` is defined for, and the result is locale dependent.
2. `epee::misc_utils::parse` already has byte-safe `isspace`/`isdigit` over `lut`, and `lut` already sets the alpha bit, so the global call was the odd one out.

Added a matching `parse::isalpha` and switched the three value-keyword sites to it.

`repro`: `load_from_json` on `{"b": <0xc3>(}` (a value starting with a non-ASCII byte), reachable from RPC/HTTP and P2P JSON.
`expected`: rejected, the byte is not a keyword start.
`actual`: `isalpha((char)0xc3)` evaluated out of range (UB) and locale dependent.
`fix`: classify with the `lut` alpha bit, matching the adjacent `parse::isdigit`.

Test added covering `true`/`false`/`null` and the non-ASCII byte.
