### PR TITLE
daemon: look for config file in data-dir if not specified

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -207,6 +207,11 @@ int main(int argc, char const * argv[])
 
     std::string config = command_line::get_arg(vm, daemon_args::arg_config_file);
     boost::filesystem::path config_path(config);
+    if (command_line::is_arg_defaulted(vm, daemon_args::arg_config_file))
+    {
+      config_path = boost::filesystem::absolute(
+          command_line::get_arg(vm, cryptonote::arg_data_dir)) / std::string(CRYPTONOTE_NAME ".conf");
+    }
     boost::system::error_code ec;
     if (bf::exists(config_path, ec))
     {


### PR DESCRIPTION
Resolves #10553. When a custom `--data-dir` is specified but `--config-file` is not, the daemon should look for `bitmonero.conf` in the specified `data-dir` rather than the default `data-dir`. This patch corrects the config file parsing priority so that it dynamically uses the `data-dir` provided in the command line argument if the config file argument is defaulted. A test script has been added to prevent regressions.