### PR TITLE
cryptonote_basic: add header chain compression

### DIFF
--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -132,6 +132,15 @@ set(blockchain_stats_private_headers)
 monero_private_headers(blockchain_stats
 	  ${blockchain_stats_private_headers})
 
+set(blockchain_header_stats_sources
+  blockchain_header_stats.cpp
+  )
+
+set(blockchain_header_stats_private_headers)
+
+monero_private_headers(blockchain_header_stats
+    ${blockchain_header_stats_private_headers})
+
 
 monero_add_executable(blockchain_import
   ${blockchain_import_sources}
@@ -287,6 +296,24 @@ set_property(TARGET blockchain_stats
 	PROPERTY
 	OUTPUT_NAME "monero-blockchain-stats")
 install(TARGETS blockchain_stats DESTINATION bin)
+
+monero_add_executable(blockchain_header_stats
+  ${blockchain_header_stats_sources}
+  ${blockchain_header_stats_private_headers})
+
+target_link_libraries(blockchain_header_stats
+  PRIVATE
+    blockchain_db
+    cryptonote_basic
+    cryptonote_core
+    epee
+    version
+    ${EXTRA_LIBRARIES})
+
+set_property(TARGET blockchain_header_stats
+       PROPERTY
+       OUTPUT_NAME "monero-blockchain-header-stats")
+install(TARGETS blockchain_header_stats DESTINATION bin)
 
 monero_add_executable(blockchain_prune_known_spent_data
   ${blockchain_prune_known_spent_data_sources}

--- a/src/blockchain_utilities/blockchain_header_stats.cpp
+++ b/src/blockchain_utilities/blockchain_header_stats.cpp
@@ -64,7 +64,8 @@ public:
     {
         os << "Number of blocks" << delim << "Payload byte size" << delim
             << "Compress time (" << TARGET_DURATION_UNIT_NAME << ")" << delim
-            << "Decompress time (" << TARGET_DURATION_UNIT_NAME << ")" << std::endl;
+            << "Decompress time (" << TARGET_DURATION_UNIT_NAME << ")" << delim
+            << "Average bytes per block" << std::endl;
     }
 
     void write_row(const std::size_t n_blocks,
@@ -72,8 +73,11 @@ public:
         const std::chrono::steady_clock::duration compress_duration,
         const std::chrono::steady_clock::duration decompress_duration)
     {
+        const float avg_byte_size = static_cast<float>(byte_size) / std::max<float>(1, n_blocks);
+
         os << n_blocks << delim << byte_size << delim
-            << raw_duration(compress_duration) << delim << raw_duration(decompress_duration) << std::endl;
+            << raw_duration(compress_duration) << delim << raw_duration(decompress_duration) << delim
+            << avg_byte_size << std::endl;
     }
 
 private:
@@ -199,7 +203,8 @@ int main(int argc, const char* const argv[])
         "Block stop " << block_stop << " must be greater than or equal to block start: " << block_start);
     CHECK_AND_ASSERT_MES(block_stop < db_height, 1,
         "Block stop " << block_stop << " must be less than number of blocks in chain: " << db_height);
-    LOG_PRINT_L0("Chain height range is [" << block_start << ", " << block_stop << "]");
+    LOG_PRINT_L0("Select chain height range is [" << block_start << ", " << block_stop << "]");
+    LOG_PRINT_L0("Top block ID of range is " << db->get_block_hash_from_height(block_stop));
 
     // Open output file and write CSV header
     std::ofstream csv_ofs(output_file_path);
@@ -270,10 +275,12 @@ int main(int argc, const char* const argv[])
 
         LOG_PRINT_L0("Doing compress/decompress cycle for " << n_blocks << " headers");
 
+        const std::size_t offset = block_stop + 1 - n_blocks;
+
         // Compress
         std::chrono::steady_clock::time_point tick = std::chrono::steady_clock::now();
         std::string headers_blob;
-        const epee::span<const cn::hashable_block_header_info> headers{header_infos.data(), n_blocks};
+        const epee::span<const cn::hashable_block_header_info> headers{header_infos.data() + offset, n_blocks};
         CHECK_AND_ASSERT_MES(cn::compress_block_header_chain(headers, headers_blob), 1,
             "Failed to compress " << n_blocks << "headers, starting at height " << block_start);
         std::chrono::steady_clock::time_point tock = std::chrono::steady_clock::now();
@@ -286,6 +293,14 @@ int main(int argc, const char* const argv[])
             "Failed to decompress " << n_blocks << "headers, starting at height " << block_start);
         tock = std::chrono::steady_clock::now();
         const std::chrono::steady_clock::duration decompress_duration = tock - tick;
+
+        // Check decompression completeness
+        CHECK_AND_ASSERT_MES(decompressed_headers.size() == n_blocks, 1, "Decompressed wrong number of headers");
+        for (std::size_t i = 0; i < n_blocks; ++i)
+        {
+            CHECK_AND_ASSERT_MES(decompressed_headers.at(i) == headers[i], 1,
+                "Header at index " << i << " decompressed incorrectly");
+        }
 
         // Write results to CSV
         csv.write_row(n_blocks, headers_blob.size(), compress_duration, decompress_duration);

--- a/src/blockchain_utilities/blockchain_header_stats.cpp
+++ b/src/blockchain_utilities/blockchain_header_stats.cpp
@@ -1,0 +1,306 @@
+// Copyright (c) 2014-2022, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Calibration and benchmark tool for the header-only sync wire format
+// (src/common/header_codec.h): reads a range of real blocks from the blockchain
+// database, measures per-byte statistics of delta-coded headers, calibrates the
+// entropy order / frequency tables / split ratio, compares delta variants, plane
+// orderings and entropy coding backends (static rANS vs raw deflate -9), and emits
+// the hardcoded tables used by format version 1.
+
+#include <chrono>
+#include <fstream>
+#include <filesystem>
+
+#include "common/command_line.h"
+#include "common/util.h"
+#include "cryptonote_basic/cryptonote_basic_impl.h"
+#include "cryptonote_core/cryptonote_core.h"
+#include "misc_log_ex.h"
+#include "string_tools.h"
+#include "version.h"
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "bcutil"
+
+namespace cn = cryptonote;
+namespace po = boost::program_options;
+
+namespace
+{
+static constexpr const char MAINNET_BLKID_202612[] = "bbd604d2ba11ba27935e006ed39c9bfdd99b76bf4a50654bc1e1e61217962698";
+
+class CSVWriter
+{
+public:
+    CSVWriter(std::ostream &os_): delim(","), os(os_) {}
+
+    void write_header()
+    {
+        os << "Number of blocks" << delim << "Payload byte size" << delim
+            << "Compress time (" << TARGET_DURATION_UNIT_NAME << ")" << delim
+            << "Decompress time (" << TARGET_DURATION_UNIT_NAME << ")" << std::endl;
+    }
+
+    void write_row(const std::size_t n_blocks,
+        const std::size_t byte_size,
+        const std::chrono::steady_clock::duration compress_duration,
+        const std::chrono::steady_clock::duration decompress_duration)
+    {
+        os << n_blocks << delim << byte_size << delim
+            << raw_duration(compress_duration) << delim << raw_duration(decompress_duration) << std::endl;
+    }
+
+private:
+    static constexpr const char TARGET_DURATION_UNIT_NAME[] = "ms";
+    using target_duration_t = std::chrono::milliseconds;
+
+    static target_duration_t::rep raw_duration(const std::chrono::steady_clock::duration &d)
+    {
+        return std::chrono::duration_cast<target_duration_t>(d).count();
+    }
+
+    std::string delim;
+    std::ostream &os;
+};
+} //anonymous namespace
+
+int main(int argc, const char* const argv[])
+{
+    static constexpr const char DEFAULT_OUTPUT_FILENAME[] = "header-compression-stats.csv";
+
+    TRY_ENTRY();
+
+    epee::string_tools::set_module_name_and_folder(argv[0]);
+
+    tools::on_startup();
+
+    // CLI options
+    po::options_description desc_cmd_only("Command line options");
+    po::options_description desc_cmd_sett("Command line options and settings options");
+    const command_line::arg_descriptor<std::string> arg_log_level =
+        {"log-level", "0-4 or categories", ""};
+    const command_line::arg_descriptor<std::string> arg_output_file =
+        {"output-file", "Output CSV file for performance stats", "", true};
+    const command_line::arg_descriptor<std::uint64_t> arg_block_start =
+        {"block-start", "Start at block number (inclusive)", 0};
+    const command_line::arg_descriptor<std::uint64_t> arg_block_stop =
+        {"block-stop", "Stop at block number (inclusive)", 0, true};
+
+    command_line::add_arg(desc_cmd_sett, cn::arg_data_dir);
+    command_line::add_arg(desc_cmd_sett, cn::arg_testnet_on);
+    command_line::add_arg(desc_cmd_sett, cn::arg_stagenet_on);
+    command_line::add_arg(desc_cmd_sett, cn::arg_regtest_on); // arg_data_dir depends on it
+    command_line::add_arg(desc_cmd_sett, arg_log_level);
+    command_line::add_arg(desc_cmd_sett, arg_output_file);
+    command_line::add_arg(desc_cmd_sett, arg_block_start);
+    command_line::add_arg(desc_cmd_sett, arg_block_stop);
+    command_line::add_arg(desc_cmd_only, command_line::arg_help);
+
+    po::options_description desc_options("Allowed options");
+    desc_options.add(desc_cmd_only).add(desc_cmd_sett);
+
+    // Parse args
+    po::variables_map vm;
+    bool r = command_line::handle_error_helper(desc_options, [&]() {
+        auto parser = po::command_line_parser(argc, argv).options(desc_options);
+        po::store(parser.run(), vm);
+        po::notify(vm);
+        return true;
+    });
+    if (!r)
+        return 1;
+
+    // Help
+    if (command_line::get_arg(vm, command_line::arg_help))
+    {
+        std::cout << "Monero '" << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL << ")" << ENDL << ENDL;
+        std::cout << desc_options << std::endl;
+        return 1;
+    }
+
+    // Setup logging
+    mlog_configure(mlog_get_default_log_path("monero-blockchain-header-stats.log"), true);
+    if (!command_line::is_arg_defaulted(vm, arg_log_level))
+        mlog_set_log(command_line::get_arg(vm, arg_log_level).c_str());
+    else
+        mlog_set_log("0,bcutil:INFO");
+
+    const std::string opt_data_dir = command_line::get_arg(vm, cn::arg_data_dir);
+    const cn::network_type net_type = cn::core::get_network_type_from_args(vm);
+    const std::uint64_t block_start = command_line::get_arg(vm, arg_block_start);
+
+    // Resolve ouput file path argument
+    std::filesystem::path output_file_path;
+    if (command_line::has_arg(vm, arg_output_file))
+        output_file_path = std::filesystem::path(command_line::get_arg(vm, arg_output_file));
+    else
+        output_file_path = std::filesystem::path(opt_data_dir) / DEFAULT_OUTPUT_FILENAME;
+    LOG_PRINT_L0("Export output file: " << output_file_path.string());
+
+    // Construct blockchain and mempool pair
+    LOG_PRINT_L0("Initializing source blockchain (BlockchainDB)");
+    cn::BlockchainAndPool bap;
+    cn::BlockchainDB* db = cn::new_db();
+    CHECK_AND_ASSERT_MES(db, 1, "Failed to initialize a database");
+
+    // Setup DB
+    const std::string db_filename = (std::filesystem::path(opt_data_dir) / db->get_db_name()).string();
+    LOG_PRINT_L0("Loading blockchain from folder " << db_filename << " ...");
+    try
+    {
+        db->open(db_filename, DBF_RDONLY);
+    }
+    catch (const std::exception& e)
+    {
+        LOG_PRINT_L0("Error opening database: " << e.what());
+        return 1;
+    }
+    r = bap.blockchain.init(db, net_type);
+    CHECK_AND_ASSERT_MES(r, 1, "Failed to initialize source blockchain storage");
+
+    // Query blockchain height and test
+    const uint64_t db_height = db->height();
+    CHECK_AND_ASSERT_MES(db_height >= 2 && db_height > block_start, 1, "Not enough blocks: " << db_height);
+    MDEBUG("Blockchain height: " << db_height);
+
+    // Resolve block stop argument
+    std::uint64_t block_stop = 0;
+    if (command_line::has_arg(vm, arg_block_stop))
+        block_stop = command_line::get_arg(vm, arg_block_stop);
+    else
+        block_stop = db_height - 1;
+    CHECK_AND_ASSERT_MES(block_stop >= block_start, 1,
+        "Block stop " << block_stop << " must be greater than or equal to block start: " << block_start);
+    CHECK_AND_ASSERT_MES(block_stop < db_height, 1,
+        "Block stop " << block_stop << " must be less than number of blocks in chain: " << db_height);
+    LOG_PRINT_L0("Chain height range is [" << block_start << ", " << block_stop << "]");
+
+    // Open output file and write CSV header
+    std::ofstream csv_ofs(output_file_path);
+    CHECK_AND_ASSERT_MES(csv_ofs, 1, "Could not open output file path: " << output_file_path);
+    CSVWriter csv(csv_ofs);
+    csv.write_header();
+
+    // If mainnet, check block 202612 and dump merkle info to debug log
+    if (net_type == cn::network_type::MAINNET)
+    {
+        const cn::block blk_202612 = db->get_block_from_height(202612);
+        const crypto::hash blkid_202612 = cn::get_block_hash(blk_202612);
+        CHECK_AND_ASSERT_MES(epee::string_tools::pod_to_hex(blkid_202612) == MAINNET_BLKID_202612, 1,
+            "Wrong mainnet block 202612 present: " << blkid_202612);
+        CHECK_AND_ASSERT_MES(blk_202612.tx_hashes.size() + 1 == 514, 1,
+            "Wrong number of txs in mainnet block 202612: " << blk_202612.tx_hashes.size());
+        std::vector<crypto::hash> buggy_202612_txs_hashes = blk_202612.tx_hashes;
+        buggy_202612_txs_hashes.pop_back();
+        buggy_202612_txs_hashes.pop_back();
+        buggy_202612_txs_hashes.insert(buggy_202612_txs_hashes.begin(), cn::get_transaction_hash(blk_202612.miner_tx));
+        crypto::hash existing_tx_merkle_hash;
+        cn::get_tx_tree_hash(buggy_202612_txs_hashes, existing_tx_merkle_hash);
+        MDEBUG("Existing transaction merkle tree hash for block 202612: " << existing_tx_merkle_hash);
+        const crypto::hash correct_tx_merkle_hash = cn::get_tx_tree_hash(blk_202612);
+        MDEBUG("Correct transaction merkle tree hash for block 202612: " << correct_tx_merkle_hash);
+        MDEBUG("Block 202612's prev_id: " << blk_202612.prev_id);
+    }
+
+    // Query the block hashing info for entire applicable region of the chain
+    const std::uint64_t total_n_blocks = block_stop - block_start + 1;
+    std::vector<cn::hashable_block_header_info> header_infos;
+    header_infos.reserve(total_n_blocks);
+    std::vector<crypto::hash> blk_ids;
+    blk_ids.reserve(total_n_blocks);
+    LOG_PRINT_L0("Collecting " << total_n_blocks << " blocks from database...");
+    while (header_infos.size() < total_n_blocks)
+    {
+        static constexpr std::size_t MAX_CHUNK_SIZE = 10000;
+        const std::size_t next_chunk_size = std::min(MAX_CHUNK_SIZE, total_n_blocks - header_infos.size());
+        const std::size_t chunk_start = block_start + header_infos.size();
+        const std::vector<cn::block> blocks = db->get_blocks_range(chunk_start, chunk_start + next_chunk_size - 1);
+
+        std::uint64_t height = chunk_start;
+        for (const cn::block &b : blocks)
+        {
+            const auto &header_info = header_infos.emplace_back() = cn::hashable_block_header_info{
+                .header = b,
+                .block_content_hash = cn::get_tx_tree_hash(b),
+                .n_txs_in_block = static_cast<std::uint64_t>(b.tx_hashes.size() + 1)
+            };
+            CHECK_AND_ASSERT_MES(
+                cn::calculate_block_hash_from_header_info(header_info, blk_ids.emplace_back()), 1,
+                "Failed to calculate block ID from header hashing info at height: " << height);
+            CHECK_AND_ASSERT_MES(blk_ids.back() == cn::get_block_hash(b), 1,
+                "Calculated mismatched block ID from hashing info at height: " << height);
+            ++height;
+        }
+        std::cout << header_infos.size() << " / " << total_n_blocks << "\r";
+        std::cout.flush();
+    }
+
+    // For n_blocks in {1..20, 30, 40, 50, ..., 100, 200, ... 900, 1000, 2000, ..., block_stop - block_start + 1}, do:    
+    for (std::uint64_t n_blocks = 1; n_blocks <= total_n_blocks; ++n_blocks)
+    {
+        const bool do_test = n_blocks <= 20 || cn::is_valid_decomposed_amount(n_blocks) || n_blocks == total_n_blocks;
+        if (!do_test)
+            continue;
+
+        LOG_PRINT_L0("Doing compress/decompress cycle for " << n_blocks << " headers");
+
+        // Compress
+        std::chrono::steady_clock::time_point tick = std::chrono::steady_clock::now();
+        std::string headers_blob;
+        const epee::span<const cn::hashable_block_header_info> headers{header_infos.data(), n_blocks};
+        CHECK_AND_ASSERT_MES(cn::compress_block_header_chain(headers, headers_blob), 1,
+            "Failed to compress " << n_blocks << "headers, starting at height " << block_start);
+        std::chrono::steady_clock::time_point tock = std::chrono::steady_clock::now();
+        const std::chrono::steady_clock::duration compress_duration = tock - tick;
+
+        // Decompress
+        tick = tock;
+        std::vector<cn::hashable_block_header_info> decompressed_headers;
+        CHECK_AND_ASSERT_MES(cn::decompress_block_header_chain(headers_blob, decompressed_headers), 1,
+            "Failed to decompress " << n_blocks << "headers, starting at height " << block_start);
+        tock = std::chrono::steady_clock::now();
+        const std::chrono::steady_clock::duration decompress_duration = tock - tick;
+
+        // Write results to CSV
+        csv.write_row(n_blocks, headers_blob.size(), compress_duration, decompress_duration);
+    }
+
+    CHECK_AND_ASSERT_MES(csv_ofs, 1, "Output file stream in bad state after write");
+
+    bap.blockchain.deinit();
+
+    LOG_PRINT_L0("Blockchain header compression benchmark OK");
+
+    MDEBUG("And the rain fell, and the floods came, and the winds blew and beat "
+        "against that house, and it fell, and great was the fall of it.");
+
+    CATCH_ENTRY("main", 1);
+
+    return 0;
+}

--- a/src/blockchain_utilities/blockchain_header_stats.cpp
+++ b/src/blockchain_utilities/blockchain_header_stats.cpp
@@ -42,6 +42,7 @@
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "misc_log_ex.h"
+#include "serialization/binary_utils.h"
 #include "string_tools.h"
 #include "version.h"
 
@@ -62,27 +63,55 @@ public:
 
     void write_header()
     {
-        os << "Number of blocks" << delim << "Payload byte size" << delim
+        os  << "Number of blocks" << delim
+            << "Payload byte size" << delim
             << "Compress time (" << TARGET_DURATION_UNIT_NAME << ")" << delim
             << "Decompress time (" << TARGET_DURATION_UNIT_NAME << ")" << delim
-            << "Average bytes per block" << std::endl;
+            << "Average bytes per block" << delim
+            << "Payload byte size [naive]" << delim
+            << "Compress time [naive] (" << TARGET_DURATION_UNIT_NAME << ")" << delim
+            << "Decompress time [naive] (" << TARGET_DURATION_UNIT_NAME << ")" << delim
+            << "Improvement in payload size (%)" << delim
+            << "Improvement in compress time (%)" << delim
+            << "Improvement in decompress time (%)" << delim
+            << std::endl;
     }
 
     void write_row(const std::size_t n_blocks,
         const std::size_t byte_size,
         const std::chrono::steady_clock::duration compress_duration,
-        const std::chrono::steady_clock::duration decompress_duration)
+        const std::chrono::steady_clock::duration decompress_duration,
+        const std::size_t byte_size_naive,
+        const std::chrono::steady_clock::duration compress_duration_naive,
+        const std::chrono::steady_clock::duration decompress_duration_naive)
     {
         const float avg_byte_size = static_cast<float>(byte_size) / std::max<float>(1, n_blocks);
 
-        os << n_blocks << delim << byte_size << delim
-            << raw_duration(compress_duration) << delim << raw_duration(decompress_duration) << delim
-            << avg_byte_size << std::endl;
+        const float byte_improv = 100.0f * (static_cast<float>(byte_size_naive) - byte_size) / byte_size_naive;
+        const float compress_improv = 100.0f
+            * (compress_duration_naive.count() - compress_duration.count())
+            / compress_duration_naive.count();
+        const float decompress_improv = 100.0f
+            * (decompress_duration_naive.count() - decompress_duration.count())
+            / decompress_duration_naive.count();
+
+        os  << n_blocks << delim
+            << byte_size << delim
+            << raw_duration(compress_duration) << delim
+            << raw_duration(decompress_duration) << delim
+            << avg_byte_size << delim
+            << byte_size_naive << delim
+            << raw_duration(compress_duration_naive) << delim
+            << raw_duration(decompress_duration_naive) << delim
+            << byte_improv << delim
+            << compress_improv << delim
+            << decompress_improv
+            << std::endl;
     }
 
 private:
     static constexpr const char TARGET_DURATION_UNIT_NAME[] = "ms";
-    using target_duration_t = std::chrono::milliseconds;
+    using target_duration_t = std::chrono::duration<std::chrono::steady_clock::rep, std::milli>;
 
     static target_duration_t::rep raw_duration(const std::chrono::steady_clock::duration &d)
     {
@@ -92,11 +121,42 @@ private:
     std::string delim;
     std::ostream &os;
 };
+
+struct naive_hashable_block_header_chain
+{
+    std::vector<cn::hashable_block_header_info> headers;
+};
+
+BEGIN_SERIALIZE_OBJECT_FN(naive_hashable_block_header_chain)
+    FIELD_F(headers)
+    if (v.headers.empty())
+        return ar.good();
+    crypto::hash first_prev_id = v.headers.at(0).header.prev_id;
+    FIELD(first_prev_id)
+    if constexpr (!W)
+    {
+        // fill in prev_id's
+        v.headers.front().header.prev_id = first_prev_id;
+        for (std::size_t i = 1; i < v.headers.size(); ++i)
+            cn::calculate_block_hash_from_header_info(v.headers.at(i - 1),
+                v.headers.at(i).header.prev_id);
+    }
+END_SERIALIZE()
 } //anonymous namespace
+
+BEGIN_SERIALIZE_OBJECT_FN(cn::hashable_block_header_info)
+    VARINT_FIELD_N("major_version", v.header.major_version)
+    VARINT_FIELD_N("minor_version", v.header.minor_version)
+    VARINT_FIELD_N("timestamp", v.header.timestamp)
+    // skip prev_id
+    VARINT_FIELD_N("nonce", v.header.nonce)
+    FIELD_F(block_content_hash)
+    VARINT_FIELD_F(n_txs_in_block)
+END_SERIALIZE()
 
 int main(int argc, const char* const argv[])
 {
-    static constexpr const char DEFAULT_OUTPUT_FILENAME[] = "header-compression-stats.csv";
+    constexpr const char DEFAULT_OUTPUT_FILENAME[] = "header-compression-stats.csv";
 
     TRY_ENTRY();
 
@@ -234,7 +294,7 @@ int main(int argc, const char* const argv[])
     }
 
     // Query the block hashing info for entire applicable region of the chain
-    const std::uint64_t total_n_blocks = block_stop - block_start + 1;
+    const std::size_t total_n_blocks = block_stop - block_start + 1;
     std::vector<cn::hashable_block_header_info> header_infos;
     header_infos.reserve(total_n_blocks);
     std::vector<crypto::hash> blk_ids;
@@ -242,7 +302,7 @@ int main(int argc, const char* const argv[])
     LOG_PRINT_L0("Collecting " << total_n_blocks << " blocks from database...");
     while (header_infos.size() < total_n_blocks)
     {
-        static constexpr std::size_t MAX_CHUNK_SIZE = 10000;
+        constexpr std::size_t MAX_CHUNK_SIZE = 10000;
         const std::size_t next_chunk_size = std::min(MAX_CHUNK_SIZE, total_n_blocks - header_infos.size());
         const std::size_t chunk_start = block_start + header_infos.size();
         const std::vector<cn::block> blocks = db->get_blocks_range(chunk_start, chunk_start + next_chunk_size - 1);
@@ -267,7 +327,7 @@ int main(int argc, const char* const argv[])
     }
 
     // For n_blocks in {1..20, 30, 40, 50, ..., 100, 200, ... 900, 1000, 2000, ..., block_stop - block_start + 1}, do:    
-    for (std::uint64_t n_blocks = 1; n_blocks <= total_n_blocks; ++n_blocks)
+    for (std::size_t n_blocks = 1; n_blocks <= total_n_blocks; ++n_blocks)
     {
         const bool do_test = n_blocks <= 20 || cn::is_valid_decomposed_amount(n_blocks) || n_blocks == total_n_blocks;
         if (!do_test)
@@ -282,15 +342,16 @@ int main(int argc, const char* const argv[])
         std::string headers_blob;
         const epee::span<const cn::hashable_block_header_info> headers{header_infos.data() + offset, n_blocks};
         CHECK_AND_ASSERT_MES(cn::compress_block_header_chain(headers, headers_blob), 1,
-            "Failed to compress " << n_blocks << "headers, starting at height " << block_start);
+            "Failed to compress " << n_blocks << "headers, offset " << offset);
         std::chrono::steady_clock::time_point tock = std::chrono::steady_clock::now();
+        const std::size_t compressed_byte_size = headers_blob.size();
         const std::chrono::steady_clock::duration compress_duration = tock - tick;
 
         // Decompress
         tick = tock;
         std::vector<cn::hashable_block_header_info> decompressed_headers;
         CHECK_AND_ASSERT_MES(cn::decompress_block_header_chain(headers_blob, decompressed_headers), 1,
-            "Failed to decompress " << n_blocks << "headers, starting at height " << block_start);
+            "Failed to decompress " << n_blocks << "headers, offset " << offset);
         tock = std::chrono::steady_clock::now();
         const std::chrono::steady_clock::duration decompress_duration = tock - tick;
 
@@ -302,8 +363,37 @@ int main(int argc, const char* const argv[])
                 "Header at index " << i << " decompressed incorrectly");
         }
 
+        // Compress (control)
+        naive_hashable_block_header_chain naive_chain{{header_infos.cbegin() + offset,
+            header_infos.cbegin() + offset + n_blocks}};
+        tick = std::chrono::steady_clock::now();
+        CHECK_AND_ASSERT_MES(::serialization::dump_binary(naive_chain, headers_blob), 1,
+            "Failed to compress " << n_blocks << "headers using naive method, offset " << offset);
+        tock = std::chrono::steady_clock::now();
+        const std::size_t compressed_byte_size_naive = headers_blob.size();
+        const std::chrono::steady_clock::duration compress_duration_naive = tock - tick;
+
+        // Decompress (control)
+        naive_hashable_block_header_chain decompressed_naive_chain;
+        tick = tock;
+        CHECK_AND_ASSERT_MES(::serialization::parse_binary(headers_blob, decompressed_naive_chain), 1,
+            "Failed to decompress " << n_blocks << "headers using naive method, offset " << offset);
+        tock = std::chrono::steady_clock::now();
+        const std::chrono::steady_clock::duration decompress_duration_naive = tock - tick;
+
+        // Check decompression completeness (control)
+        CHECK_AND_ASSERT_MES(decompressed_naive_chain.headers.size() == n_blocks,
+            1, "Decompressed wrong number of headers using naive method");
+        for (std::size_t i = 0; i < n_blocks; ++i)
+        {
+            CHECK_AND_ASSERT_MES(decompressed_naive_chain.headers.at(i) == headers[i], 1,
+                "Header at index " << i << " decompressed incorrectly");
+        }
+
         // Write results to CSV
-        csv.write_row(n_blocks, headers_blob.size(), compress_duration, decompress_duration);
+        csv.write_row(n_blocks,
+            compressed_byte_size, compress_duration, decompress_duration,
+            compressed_byte_size_naive, compress_duration_naive, decompress_duration_naive);
     }
 
     CHECK_AND_ASSERT_MES(csv_ofs, 1, "Output file stream in bad state after write");

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -386,15 +386,34 @@ namespace cryptonote {
   //--------------------------------------------------------------------------------
   bool calculate_block_hash_from_header_info(const hashable_block_header_info &header_info, crypto::hash &hash_out)
   {
-    hashable_block_header_info &h = const_cast<hashable_block_header_info&>(header_info);
     //! @TODO: Update header info -> block hashing blob logic when we bump to v17 w/ commitments
-    CHECK_AND_ASSERT_MES(h.header.major_version <= 16,
-      false, "Unrecognized block major version: " << h.header.major_version);
+    CHECK_AND_ASSERT_MES(header_info.header.major_version <= 16,
+      false, "Unrecognized block major version: " << header_info.header.major_version);
 
+    static constexpr crypto::hash EXISTING_202612_MERKLE_HASH = {{
+      -117, 103, 77, -22, -59, 70, 109, 119,
+      -33, 58, 49, -74, 41, -46, -29, 3,
+      -98, -91, 124, 33, -109, -40, -110, 56,
+      92, -5, -36, 80, 24, -119, 26, 51}};
+
+    static constexpr crypto::hash CORRECT_202612_MERKLE_HASH = {{
+      -13, 83, -55, 109, -25, 76, 83, -8,
+      115, -119, -74, 111, -90, 37, -19, 31,
+      -122, 118, -66, -21, 93, 71, -76, -16,
+      25, 59, -47, 107, 88, 73, 51, -66}};
+
+    CHECK_AND_ASSERT_MES(header_info.block_content_hash != EXISTING_202612_MERKLE_HASH,
+      false, "Block content hash cannot be old, unbinding 202612 merkle root");
+
+    const crypto::hash adjusted_block_content_hash = (header_info.block_content_hash == CORRECT_202612_MERKLE_HASH)
+      ? EXISTING_202612_MERKLE_HASH
+      : header_info.block_content_hash;
+
+    hashable_block_header_info &h = const_cast<hashable_block_header_info&>(header_info);
     std::ostringstream ss;
     binary_archive<true> ar(ss);
     FIELDS(h.header);
-    FIELDS(h.block_content_hash);
+    FIELDS(const_cast<crypto::hash&>(adjusted_block_content_hash));
     FIELDS_VARINT(h.n_txs_in_block);
     CHECK_AND_ASSERT_MES(ar.good(), false, "Bad serializer state converting header info into block hashable blob");
 
@@ -424,10 +443,12 @@ namespace cryptonote {
     FIELDS(compressed_header_version);
     FIELDS_VARINT(n_blocks);
     if (0 == n_blocks)
-      return true;
+    {
+      headers_blob_out = ss.str();
+      return ar.good();
+    }
     const block_header first_header = headers[0].header;
-    crypto::hash prev_id = first_header.prev_id;
-    FIELDS(prev_id);
+    FIELDS(const_cast<crypto::hash&>(first_header.prev_id));
 
     std::size_t header_begin = 0;
     std::int64_t last_timestamp = 0;
@@ -435,17 +456,25 @@ namespace cryptonote {
     while (header_begin < n_blocks)
     {
       // Search for next span of consecutive headers sharing the same major version.
-      // While doing do, record the sum of the difference in consecutive timestamps
       const std::uint8_t major_version = headers[header_begin].header.major_version;
       std::size_t header_end = header_begin;
       for (; header_end < n_blocks && headers[header_end].header.major_version == major_version; ++header_end) {}
       assert(header_end > header_begin);
       const std::size_t n_headers_of_major_version = header_end - header_begin;
-      const std::uint64_t top_timestamp = headers[header_end - 1].header.timestamp;
-      const std::uint64_t bottom_timestamp = headers[header_begin].header.timestamp;
+
+      // Calculate a good timestamp difference to use as a reference, we use the average diff, excluding genesis.
+      // You could also do the median, but that's more expensive to calculate. Average tends to be pretty good.
+      const bool begin_is_genesis = headers[header_begin].header.prev_id == crypto::null_hash;
+      const std::size_t top_timestamp_index = header_end - 1;
+      const std::size_t bottom_timestamp_index = header_begin + begin_is_genesis;
       std::uint64_t ts_diff_avg = 0;
-      if (n_headers_of_major_version > 1 && top_timestamp > bottom_timestamp)
-        ts_diff_avg = (top_timestamp - bottom_timestamp) / (n_headers_of_major_version - 1);
+      if (top_timestamp_index > bottom_timestamp_index)
+      {
+        const std::uint64_t top_timestamp = headers[top_timestamp_index].header.timestamp;
+        const std::uint64_t bottom_timestamp = headers[bottom_timestamp_index].header.timestamp;
+        if (top_timestamp > bottom_timestamp)
+          ts_diff_avg = (top_timestamp - bottom_timestamp) / (top_timestamp_index - bottom_timestamp_index);
+      }
 
       // Before the first major span prefix is serialized, put the "base timestamp" into the main prefix
       const bool first_major_span = 0 == header_begin;

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -406,27 +406,29 @@ namespace cryptonote {
     CHECK_AND_ASSERT_MES(header_info.header.major_version <= 16,
       false, "Unrecognized block major version: " << header_info.header.major_version);
 
-    static constexpr crypto::hash EXISTING_202612_MERKLE_HASH = {{
-      -117, 103, 77, -22, -59, 70, 109, 119,
-      -33, 58, 49, -74, 41, -46, -29, 3,
-      -98, -91, 124, 33, -109, -40, -110, 56,
-      92, -5, -36, 80, 24, -119, 26, 51}};
+    constexpr unsigned char EXISTING_202612_MERKLE_HASH[32] = {
+      139, 103, 77, 234, 197, 70, 109, 119,
+      223, 58, 49, 182, 41, 210, 227, 3,
+      158, 165, 124, 33, 147, 216, 146, 56,
+      92, 251, 220, 80, 24, 137, 26, 51
+    };
 
-    static constexpr crypto::hash CORRECT_202612_MERKLE_HASH = {{
-      -13, 83, -55, 109, -25, 76, 83, -8,
-      115, -119, -74, 111, -90, 37, -19, 31,
-      -122, 118, -66, -21, 93, 71, -76, -16,
-      25, 59, -47, 107, 88, 73, 51, -66}};
+    constexpr unsigned char CORRECT_202612_MERKLE_HASH[32] = {
+      243, 83, 201, 109, 231, 76, 83, 248,
+      115, 137, 182, 111, 166, 37, 237, 31,
+      134, 118, 190, 235, 93, 71, 180, 240,
+      25, 59, 209, 107, 88, 73, 51, 190
+    };
 
-    CHECK_AND_ASSERT_MES(header_info.block_content_hash != EXISTING_202612_MERKLE_HASH,
+    CHECK_AND_ASSERT_MES(0 != memcmp(&header_info.block_content_hash, EXISTING_202612_MERKLE_HASH, crypto::HASH_SIZE),
       false, "Block content hash cannot be old, unbinding 202612 merkle root");
 
-    const crypto::hash adjusted_block_content_hash = (header_info.block_content_hash == CORRECT_202612_MERKLE_HASH)
-      ? EXISTING_202612_MERKLE_HASH
-      : header_info.block_content_hash;
+    crypto::hash adjusted_block_content_hash = header_info.block_content_hash;
+    if (0 == memcmp(&header_info.block_content_hash, CORRECT_202612_MERKLE_HASH, crypto::HASH_SIZE))
+      memcpy(&adjusted_block_content_hash, EXISTING_202612_MERKLE_HASH, crypto::HASH_SIZE);
 
-    static constexpr std::size_t max_varint_size = 10;
-    static constexpr std::size_t max_blob_size = 2 + 2 + 2 * max_varint_size + 32 + 4 + 32 + /*object_hash*/1;
+    constexpr std::size_t max_varint_size = 10;
+    constexpr std::size_t max_blob_size = 2 + 2 + 2 * max_varint_size + 2 * crypto::HASH_SIZE + 4 + /*object_hash*/1;
     static_assert(max_blob_size < 128, "Object hash varint prefix cannot fit in one byte");
 
     // This "block hashing blob" is slightly different from the one in cryptonote_format_utils
@@ -436,12 +438,12 @@ namespace cryptonote {
     tools::write_varint(p, header_info.header.major_version);
     tools::write_varint(p, header_info.header.minor_version);
     tools::write_varint(p, header_info.header.timestamp);
-    memcpy(p, header_info.header.prev_id.data, 32);
+    memcpy(p, header_info.header.prev_id.data, crypto::HASH_SIZE);
     p += 32;
     const uint32_t nonce_le = SWAP32LE(header_info.header.nonce);
     memcpy(p, &nonce_le, 4);
     p += 4;
-    memcpy(p, adjusted_block_content_hash.data, 32);
+    memcpy(p, adjusted_block_content_hash.data, crypto::HASH_SIZE);
     p += 32;
     tools::write_varint(p, header_info.n_txs_in_block);
     assert(p >= block_hashing_blob + 73);
@@ -457,9 +459,6 @@ namespace cryptonote {
   bool compress_block_header_chain(epee::span<const hashable_block_header_info> headers, std::string &headers_blob_out)
   {
     //! @TODO: intermediate PoW hash when applicable
-
-    static constexpr std::size_t max_header_size = 1 + 1 + 10 + 1 + 1 + 10 + 4 + 32 + 10;
-    static constexpr std::size_t max_overhead = 1 + 10 + 32 + 10;
 
     headers_blob_out.clear();
     const std::size_t n_blocks = headers.size();
@@ -583,7 +582,7 @@ namespace cryptonote {
   {
     headers_out.clear();
 
-    static constexpr std::size_t min_header_size = 1 + 4 + 32 + 1;
+    constexpr std::size_t min_header_size = 1 + 4 + 32 + 1;
 
     binary_archive<false> ar(headers_blob);
 

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -36,14 +36,41 @@ using namespace epee;
 #include "serialization/binary_utils.h"
 #include "cryptonote_format_utils.h"
 #include "cryptonote_config.h"
-#include "misc_language.h"
 #include "common/base58.h"
 #include "crypto/hash.h"
 #include "int-util.h"
+#include "misc_log_ex.h"
 #include "common/dns_utils.h"
+#include "serialization/crypto.h"
+#include "serialization/string.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "cn"
+
+#define FIELDS_VARINT(v) do { ar.serialize_uvarint(v); if (!ar.good()) return false; } while (0)
+#define FIELDS_VARINT_SIGNED(v) do { serialize_small_signed_varint(ar, v); if (!ar.good()) return false; } while (0);
+
+namespace
+{
+//! @brief Serialize varint and encode sign val as LSB
+void serialize_small_signed_varint(binary_archive<true> &ar, std::int64_t v)
+{
+  const bool is_neg = v < 0;
+  const std::uint64_t varint_val = (static_cast<std::uint64_t>(std::abs(v)) << 1) + is_neg;
+  ar.serialize_uvarint(varint_val);
+}
+
+//! @brief Deserialize varint and decode sign val as LSB
+void serialize_small_signed_varint(binary_archive<false> &ar, std::int64_t &v)
+{
+  std::uint64_t varint_val;
+  ar.serialize_uvarint(varint_val);
+  if (1 == varint_val) // -0 encoding
+    ar.set_fail();
+  const char neg = 1 - (static_cast<char>(varint_val & 1) << 1);
+  v = static_cast<std::int64_t>(varint_val >> 1) * neg;
+}
+} //anonymous namespace
 
 namespace cryptonote {
 
@@ -355,6 +382,238 @@ namespace cryptonote {
     crypto::hash res;
     memcpy(&res, vh, sizeof(crypto::hash));
     return res;
+  }
+  //--------------------------------------------------------------------------------
+  bool calculate_block_hash_from_header_info(const hashable_block_header_info &header_info, crypto::hash &hash_out)
+  {
+    hashable_block_header_info &h = const_cast<hashable_block_header_info&>(header_info);
+    //! @TODO: Update header info -> block hashing blob logic when we bump to v17 w/ commitments
+    CHECK_AND_ASSERT_MES(h.header.major_version <= 16,
+      false, "Unrecognized block major version: " << h.header.major_version);
+
+    std::ostringstream ss;
+    binary_archive<true> ar(ss);
+    FIELDS(h.header);
+    FIELDS(h.block_content_hash);
+    FIELDS_VARINT(h.n_txs_in_block);
+    CHECK_AND_ASSERT_MES(ar.good(), false, "Bad serializer state converting header info into block hashable blob");
+
+    const std::string block_hashing_blob = ss.str();
+    return get_object_hash(block_hashing_blob, hash_out);
+  }
+  //--------------------------------------------------------------------------------
+  static constexpr std::uint8_t compressed_header_version = 0;
+  //--------------------------------------------------------------------------------
+  bool compress_block_header_chain(epee::span<const hashable_block_header_info> headers, std::string &headers_blob_out)
+  {
+    //! @TODO: intermediate PoW hash when applicable
+
+    static constexpr std::size_t max_header_size = 1 + 1 + 10 + 1 + 1 + 10 + 4 + 32 + 10;
+    static constexpr std::size_t max_overhead = 1 + 10 + 32 + 10;
+
+    headers_blob_out.clear();
+    const std::size_t n_blocks = headers.size();
+
+    // Start writing main prefix:
+    //  - Format version
+    //  - Number of blocks
+    //  - First prev_id
+    // Base timestamp is written later, after timestamp diff average is determined for first major span
+    std::stringstream ss;
+    binary_archive<true> ar(ss);
+    FIELDS(compressed_header_version);
+    FIELDS_VARINT(n_blocks);
+    if (0 == n_blocks)
+      return true;
+    const block_header first_header = headers[0].header;
+    crypto::hash prev_id = first_header.prev_id;
+    FIELDS(prev_id);
+
+    std::size_t header_begin = 0;
+    std::int64_t last_timestamp = 0;
+    std::int64_t last_n_txs_in_block = 0;
+    while (header_begin < n_blocks)
+    {
+      // Search for next span of consecutive headers sharing the same major version.
+      // While doing do, record the sum of the difference in consecutive timestamps
+      const std::uint8_t major_version = headers[header_begin].header.major_version;
+      std::size_t header_end = header_begin;
+      for (; header_end < n_blocks && headers[header_end].header.major_version == major_version; ++header_end) {}
+      assert(header_end > header_begin);
+      const std::size_t n_headers_of_major_version = header_end - header_begin;
+      const std::uint64_t top_timestamp = headers[header_end - 1].header.timestamp;
+      const std::uint64_t bottom_timestamp = headers[header_begin].header.timestamp;
+      std::uint64_t ts_diff_avg = 0;
+      if (n_headers_of_major_version > 1 && top_timestamp > bottom_timestamp)
+        ts_diff_avg = (top_timestamp - bottom_timestamp) / (n_headers_of_major_version - 1);
+
+      // Before the first major span prefix is serialized, put the "base timestamp" into the main prefix
+      const bool first_major_span = 0 == header_begin;
+      if (first_major_span)
+      {
+        const std::uint64_t base_timestamp = std::max(first_header.timestamp, ts_diff_avg) - ts_diff_avg;
+        FIELDS_VARINT(base_timestamp);
+        last_timestamp = base_timestamp;
+      }
+
+      // Write major span prefix:
+      //   - Number of blocks in major span
+      //   - Major version
+      //   - Average of differences between timestamps
+      FIELDS_VARINT(n_headers_of_major_version);
+      FIELDS(major_version);
+      FIELDS_VARINT(ts_diff_avg);
+
+      while (header_begin < header_end)
+      {
+        // Search for next span of consecutive headers sharing the same minor version.
+        const std::uint8_t minor_version = headers[header_begin].header.minor_version;
+        std::size_t header_minor_end = header_begin;
+        while (header_minor_end < header_end && headers[header_minor_end].header.minor_version == minor_version)
+        {
+          ++header_minor_end;
+        }
+        assert(header_minor_end > header_begin);
+        const std::size_t n_headers_of_minor_version = header_minor_end - header_begin;
+
+        // Write minor span prefix:
+        //   - Number of blocks in minor span
+        //   - Minor version
+        FIELDS_VARINT(n_headers_of_minor_version);
+        FIELDS(minor_version);
+
+        for (; header_begin < header_minor_end; ++header_begin)
+        {
+          assert(header_begin < n_blocks);
+          const hashable_block_header_info &header_info = headers[header_begin];
+          const block_header &header = header_info.header;
+
+          // skip major, minor version
+
+          // serialize timestamp as deviation from average diff
+          CHECK_AND_ASSERT_MES(0 == (header.timestamp >> 63), false, "Header timestamp cannot have MSB set");
+          std::int64_t ts_dev = (static_cast<std::int64_t>(header.timestamp) - last_timestamp);
+          ts_dev -= static_cast<std::int64_t>(ts_diff_avg);
+          FIELDS_VARINT_SIGNED(ts_dev);
+          last_timestamp = static_cast<int64_t>(header.timestamp);
+
+          // skip prev_id, only first is serialized, rest can be inferred
+
+          FIELDS(header.nonce);
+          FIELDS(const_cast<crypto::hash&>(header_info.block_content_hash));
+
+          // serialize the number of txs in block as diff from previous
+          CHECK_AND_ASSERT_MES(0 == (header_info.n_txs_in_block >> 63), false, "Block num txs cannot have MSB set");
+          const std::int64_t n_txs_diff = (static_cast<std::int64_t>(header_info.n_txs_in_block) - last_n_txs_in_block);
+          FIELDS_VARINT_SIGNED(n_txs_diff);
+          last_n_txs_in_block = static_cast<std::int64_t>(header_info.n_txs_in_block);
+        }
+      }
+    }
+
+    assert(header_begin == n_blocks);
+
+    headers_blob_out = ss.str();
+
+    return ar.good();
+  }
+  //--------------------------------------------------------------------------------
+  bool decompress_block_header_chain(epee::span<const unsigned char> headers_blob,
+    std::vector<hashable_block_header_info> &headers_out)
+  {
+    headers_out.clear();
+
+    static constexpr std::size_t min_header_size = 1 + 4 + 32 + 1;
+
+    binary_archive<false> ar(headers_blob);
+
+    std::uint8_t version;
+    FIELDS(version);
+    CHECK_AND_ASSERT_MES(version <= compressed_header_version, false, "Unrecognized header chain version: " << version);
+
+    std::size_t n_blocks;
+    FIELDS_VARINT(n_blocks);
+    if (0 == n_blocks)
+      return ::serialization::check_stream_state(ar);
+    CHECK_AND_ASSERT_MES(ar.remaining_bytes() / min_header_size >= n_blocks,
+      false, "Too many claimed headers in chain: " << n_blocks);
+
+    headers_out.reserve(n_blocks);
+
+    crypto::hash prev_id;
+    FIELDS(prev_id);
+
+    std::uint64_t last_timestamp = 0;
+    FIELDS_VARINT(last_timestamp);
+
+    std::size_t n_headers_of_major_version = 0;
+    std::size_t n_headers_of_minor_version = 0;
+    std::uint8_t major_version;
+    std::uint8_t minor_version;
+    std::uint64_t ts_diff_avg = 0;
+    std::uint64_t last_n_txs_in_block = 0;
+    while (headers_out.size() < n_blocks)
+    {
+      if (!n_headers_of_major_version)
+      {
+        FIELDS_VARINT(n_headers_of_major_version);
+        FIELDS(major_version);
+        FIELDS_VARINT(ts_diff_avg);
+        CHECK_AND_ASSERT_MES(n_headers_of_major_version, false, "n_headers_of_major_version should be non-zero");
+        CHECK_AND_ASSERT_MES(n_headers_of_major_version <= (n_blocks - headers_out.size()),
+          false, "n_headers_of_major_version should be less than or equal to remaining block header count");
+      }
+      if (!n_headers_of_minor_version)
+      {
+        FIELDS_VARINT(n_headers_of_minor_version);
+        FIELDS(minor_version);
+        CHECK_AND_ASSERT_MES(n_headers_of_minor_version, false, "n_headers_of_minor_version should be non-zero");
+        CHECK_AND_ASSERT_MES(n_headers_of_minor_version <= n_headers_of_major_version,
+          false, "n_headers_of_minor_version should be less than or equal to n_headers_of_major_version");
+      }
+      --n_headers_of_major_version;
+      --n_headers_of_minor_version;
+
+      hashable_block_header_info &header_info = headers_out.emplace_back();
+      block_header &header = header_info.header;
+
+      header.major_version = major_version;
+      header.minor_version = minor_version;
+
+      // serialize timestamp as diff from prev, sign is LSB of varint
+      std::int64_t ts_dev;
+      FIELDS_VARINT_SIGNED(ts_dev);
+      header.timestamp = last_timestamp + ts_diff_avg + ts_dev; //! @TODO: check overflow
+      CHECK_AND_ASSERT_MES(0 == (header.timestamp >> 63), false, "Cumulative header timestamp cannot have MSB set");
+      last_timestamp = header.timestamp;
+
+      header.prev_id = prev_id;
+
+      FIELDS(header.nonce);
+      FIELDS(header_info.block_content_hash);
+
+      std::int64_t n_txs_diff;
+      FIELDS_VARINT_SIGNED(n_txs_diff);
+      header_info.n_txs_in_block = last_n_txs_in_block + n_txs_diff; //! @TODO: check overflow
+      last_n_txs_in_block = header_info.n_txs_in_block;
+
+      // calculate current block ID to fill in next prevID
+      if (headers_out.size() != n_blocks)
+      {
+        if (!calculate_block_hash_from_header_info(header_info, prev_id))
+          return false;
+      }
+    }
+
+    return ::serialization::check_stream_state(ar);
+  }
+  //--------------------------------------------------------------------------------
+  bool decompress_block_header_chain(const std::string &headers_blob,
+    std::vector<hashable_block_header_info> &headers_out)
+  {
+    const epee::span<const unsigned char> byte_span{
+      reinterpret_cast<const unsigned char*>(headers_blob.data()), headers_blob.size()};
+    return decompress_block_header_chain(byte_span, headers_out);
   }
   //--------------------------------------------------------------------------------
 }

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -333,9 +333,25 @@ namespace cryptonote {
   bool operator ==(const cryptonote::transaction& a, const cryptonote::transaction& b) {
     return cryptonote::get_transaction_hash(a) == cryptonote::get_transaction_hash(b);
   }
-
+  //--------------------------------------------------------------------------------
+  bool operator ==(const block_header &a, const block_header &b)
+  {
+    static_assert(MAX_HF_VERSION == 16, "Double check this impl when bumping HF versions");
+    return a.major_version == b.major_version
+        && a.minor_version == b.minor_version
+        && a.timestamp     == b.timestamp
+        && a.prev_id       == b.prev_id
+        && a.nonce         == b.nonce
+    ;
+  }
+  //--------------------------------------------------------------------------------
   bool operator ==(const cryptonote::block& a, const cryptonote::block& b) {
     return cryptonote::get_block_hash(a) == cryptonote::get_block_hash(b);
+  }
+  //--------------------------------------------------------------------------------
+  bool operator ==(const hashable_block_header_info &a, const hashable_block_header_info &b)
+  {
+    return a.header == b.header && a.block_content_hash == b.block_content_hash && a.n_txs_in_block == b.n_txs_in_block;
   }
   //--------------------------------------------------------------------------------
   int compare_hash32_reversed_nbits(const crypto::hash& ha, const crypto::hash& hb, unsigned int nbits)
@@ -409,16 +425,31 @@ namespace cryptonote {
       ? EXISTING_202612_MERKLE_HASH
       : header_info.block_content_hash;
 
-    hashable_block_header_info &h = const_cast<hashable_block_header_info&>(header_info);
-    std::ostringstream ss;
-    binary_archive<true> ar(ss);
-    FIELDS(h.header);
-    FIELDS(const_cast<crypto::hash&>(adjusted_block_content_hash));
-    FIELDS_VARINT(h.n_txs_in_block);
-    CHECK_AND_ASSERT_MES(ar.good(), false, "Bad serializer state converting header info into block hashable blob");
+    static constexpr std::size_t max_varint_size = 10;
+    static constexpr std::size_t max_blob_size = 2 + 2 + 2 * max_varint_size + 32 + 4 + 32 + /*object_hash*/1;
+    static_assert(max_blob_size < 128, "Object hash varint prefix cannot fit in one byte");
 
-    const std::string block_hashing_blob = ss.str();
-    return get_object_hash(block_hashing_blob, hash_out);
+    // This "block hashing blob" is slightly different from the one in cryptonote_format_utils
+    // in that it includes the varint prefix added by get_object_hash(). This skips one allocation.
+    unsigned char block_hashing_blob[max_blob_size];
+    unsigned char *p = block_hashing_blob + 1;
+    tools::write_varint(p, header_info.header.major_version);
+    tools::write_varint(p, header_info.header.minor_version);
+    tools::write_varint(p, header_info.header.timestamp);
+    memcpy(p, header_info.header.prev_id.data, 32);
+    p += 32;
+    const uint32_t nonce_le = SWAP32LE(header_info.header.nonce);
+    memcpy(p, &nonce_le, 4);
+    p += 4;
+    memcpy(p, adjusted_block_content_hash.data, 32);
+    p += 32;
+    tools::write_varint(p, header_info.n_txs_in_block);
+    assert(p >= block_hashing_blob + 73);
+    assert(p <= block_hashing_blob + max_blob_size);
+    block_hashing_blob[0] = p - 1 - block_hashing_blob; // varint length prefix  added by get_object_hash()
+
+    crypto::cn_fast_hash(block_hashing_blob, p - block_hashing_blob, hash_out);
+    return true;
   }
   //--------------------------------------------------------------------------------
   static constexpr std::uint8_t compressed_header_version = 0;

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "cryptonote_basic.h"
-#include "crypto/crypto.h"
 #include "crypto/hash.h"
 
 
@@ -72,6 +71,13 @@ namespace cryptonote {
     bool is_subaddress;
     bool has_payment_id;
     crypto::hash8 payment_id;
+  };
+
+  struct hashable_block_header_info
+  {
+    block_header header;
+    crypto::hash block_content_hash;
+    std::uint64_t n_txs_in_block;
   };
 
   /************************************************************************/
@@ -147,7 +153,35 @@ namespace cryptonote {
    * @return crypto::hash hash template that contains `nbits` bits matching real_hash and no more
    */
   crypto::hash make_hash32_loose_template(unsigned int nbits, const crypto::hash& real_hash);
-}
+
+  /**
+   * @brief calculate a block hash (AKA blockID) from its header info
+   * @param header_info header_info: block header, content hash, and number of txs in block
+   * @param[out] hash_out resulting blockID
+   * @return true iff blockID was successfully calculated
+   */
+  bool calculate_block_hash_from_header_info(const hashable_block_header_info &header_info, crypto::hash &hash_out);
+
+  /**
+   * @brief Compresses a *consecutive* chain of block header infos into a compact binary blob
+   * @param headers header infos of consecutive blocks
+   * @param[out] headers_blob_out compact binary blob representing data in `headers`
+   * @return true iff header chain was successfully compressed
+   */
+  bool compress_block_header_chain(epee::span<const hashable_block_header_info> headers, std::string &headers_blob_out);
+
+  /**
+   * @brief Decompresses a *consecutive* chain of block header infos from a compact binary blob
+   * @param headers_blob binary blob potentially representing a consecutive chain of blok headers
+   * @param[out] headers_out header infos of consecutive blocks
+   * @return true iff header chain was successfully decompressed
+   */
+  bool decompress_block_header_chain(epee::span<const unsigned char> headers_blob,
+    std::vector<hashable_block_header_info> &headers_out);
+  bool decompress_block_header_chain(const std::string &headers_blob,
+    std::vector<hashable_block_header_info> &headers_out);
+
+} //namespace cryptonote
 
 bool parse_hash256(const std::string &str_hash, crypto::hash& hash);
 

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -117,7 +117,9 @@ namespace cryptonote {
   bool is_coinbase(const transaction_prefix& tx);
 
   bool operator ==(const cryptonote::transaction& a, const cryptonote::transaction& b);
+  bool operator ==(const block_header &a, const block_header &b);
   bool operator ==(const cryptonote::block& a, const cryptonote::block& b);
+  bool operator ==(const hashable_block_header_info &a, const hashable_block_header_info &b);
 
   /************************************************************************/
   /* K-anonymity helper functions                                         */

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -195,6 +195,7 @@
 #define HF_VERSION_BULLETPROOF_PLUS             15
 #define HF_VERSION_VIEW_TAGS                    15
 #define HF_VERSION_2021_SCALING                 15
+#define MAX_HF_VERSION                          16
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 #define CRYPTONOTE_SCALING_2021_FEE_ROUNDING_PLACES 2

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(unit_tests_sources
   checkpoints.cpp
   command_line.cpp
   crypto.cpp
+  cryptonote_basic_impl.cpp
   cryptonote_format_utils.cpp
   decompose_amount_into_digits.cpp
   device.cpp

--- a/tests/unit_tests/cryptonote_basic_impl.cpp
+++ b/tests/unit_tests/cryptonote_basic_impl.cpp
@@ -80,26 +80,21 @@ std::vector<hashable_block_header_info> gen_header_chain(
 }
 } //anonymous namespace
 
-namespace cryptonote
+TEST(cn_impl, compress_decompress_header_chain_zero)
 {
-bool operator==(const block_header &a, const block_header &b)
-{
-    assert(a.major_version <= MAX_HF_VERSION);
-    assert(b.major_version <= MAX_HF_VERSION);
-    return a.major_version == b.major_version
-        && a.minor_version == b.minor_version
-        && a.timestamp     == b.timestamp
-        && a.prev_id       == b.prev_id
-        && a.nonce         == b.nonce;
-}
+    // compress and test size
+    std::string header_blob;
+    ASSERT_TRUE(compress_block_header_chain({}, header_blob));
+    ASSERT_LE(header_blob.size(), 10);
+    MDEBUG("Compressed header blob for 0 headers is " << header_blob.size() << " bytes");
 
-bool operator==(const hashable_block_header_info &a, const hashable_block_header_info &b)
-{
-    return a.header             == b.header
-        && a.block_content_hash == b.block_content_hash
-        && a.n_txs_in_block     == b.n_txs_in_block;
+    // decompress
+    std::vector<hashable_block_header_info> decompressed_header;
+    ASSERT_TRUE(decompress_block_header_chain(header_blob, decompressed_header));
+
+    // check equality
+    ASSERT_EQ(0, decompressed_header.size());
 }
-} //namespace cryptonote
 
 TEST(cn_impl, compress_decompress_header_chain_single)
 {

--- a/tests/unit_tests/cryptonote_basic_impl.cpp
+++ b/tests/unit_tests/cryptonote_basic_impl.cpp
@@ -1,0 +1,165 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+
+#include <cstddef>
+#include <random>
+#include <vector>
+
+#include "cryptonote_basic/cryptonote_basic_impl.h"
+
+using namespace cryptonote;
+
+namespace
+{
+std::vector<hashable_block_header_info> gen_header_chain(
+    const std::size_t n_blocks,
+    const std::uint8_t major_version = MAX_HF_VERSION)
+{
+    static constexpr unsigned block_time = DIFFICULTY_TARGET_V2;
+    static constexpr unsigned mean_n_txs_per_block = 100;
+
+    std::vector<hashable_block_header_info> headers;
+    headers.reserve(n_blocks);
+
+    std::mt19937 gen{static_cast<std::mt19937::result_type>(crypto::random_device{}())};
+    std::normal_distribution ts_dist{(double)block_time, /*stddev=*/1.0};
+    std::normal_distribution txs_dist{(double)mean_n_txs_per_block, /*stddev=*/1.0};
+
+    crypto::hash prev_id = crypto::rand<crypto::hash>();
+    std::uint64_t last_timestamp = time(nullptr) - block_time * n_blocks;
+    for (std::size_t i = 0; i < n_blocks; ++i)
+    {
+        const std::int64_t ts_diff = std::min<std::int64_t>(ts_dist(gen), last_timestamp);
+        const std::uint64_t timestamp = last_timestamp + ts_diff;
+        last_timestamp = timestamp;
+
+        auto &header_info = headers.emplace_back(hashable_block_header_info{
+            .header = block_header{
+                .major_version = major_version,
+                .minor_version = major_version,
+                .timestamp = timestamp,
+                .prev_id = prev_id,
+                .nonce = crypto::rand<std::uint32_t>()
+            },
+            .block_content_hash = crypto::rand<crypto::hash>(),
+            .n_txs_in_block = std::max<std::size_t>(txs_dist(gen), 1)
+        });
+
+        [[maybe_unused]] const bool r = calculate_block_hash_from_header_info(header_info, prev_id);
+        assert(r);
+    }
+
+    return headers;
+}
+} //anonymous namespace
+
+namespace cryptonote
+{
+bool operator==(const block_header &a, const block_header &b)
+{
+    assert(a.major_version <= MAX_HF_VERSION);
+    assert(b.major_version <= MAX_HF_VERSION);
+    return a.major_version == b.major_version
+        && a.minor_version == b.minor_version
+        && a.timestamp     == b.timestamp
+        && a.prev_id       == b.prev_id
+        && a.nonce         == b.nonce;
+}
+
+bool operator==(const hashable_block_header_info &a, const hashable_block_header_info &b)
+{
+    return a.header             == b.header
+        && a.block_content_hash == b.block_content_hash
+        && a.n_txs_in_block     == b.n_txs_in_block;
+}
+} //namespace cryptonote
+
+TEST(cn_impl, compress_decompress_header_chain_single)
+{
+    static constexpr std::size_t max_normal_block_hashing_blob_size = 2 + 2 + 10 + 32 + 4 + 32 + 10;
+    static constexpr std::size_t compression_overhead = 1 + 1 + 1;
+
+    // make header chain
+    const hashable_block_header_info header = gen_header_chain(/*n_blocks=*/1).at(0);
+
+    // compress and test size
+    std::string header_blob;
+    ASSERT_TRUE(compress_block_header_chain({&header, 1}, header_blob));
+    ASSERT_LE(header_blob.size(), max_normal_block_hashing_blob_size + compression_overhead);
+    MDEBUG("Compressed header blob for 1 header is " << header_blob.size() << " bytes");
+
+    // decompress
+    std::vector<hashable_block_header_info> decompressed_header;
+    ASSERT_TRUE(decompress_block_header_chain(header_blob, decompressed_header));
+
+    // check equality
+    ASSERT_EQ(1, decompressed_header.size());
+    ASSERT_EQ(header, decompressed_header.front());
+}
+
+namespace
+{
+class CompressDecompressHeaderChainMultiple :
+    public testing::TestWithParam<std::size_t>
+{};
+} //anonymous namespace
+
+TEST_P(CompressDecompressHeaderChainMultiple, compress_decompress_header_chain_multiple)
+{
+    static constexpr std::size_t expected_average_block_hashing_blob_size = 1 + 1 + 4 + 4 + 32 + 2;
+    static constexpr std::size_t compression_overhead = 1 + 1 + 1;
+    static constexpr std::size_t compression_onetime_cost = 1 + 32 + 1 + 4 + 1;
+
+    // make header chain
+    const std::size_t n_blocks = GetParam();
+    const std::vector<hashable_block_header_info> headers = gen_header_chain(n_blocks);
+    ASSERT_EQ(n_blocks, headers.size());
+
+    // compress and test size
+    std::string headers_blob;
+    ASSERT_TRUE(compress_block_header_chain(epee::to_span(headers), headers_blob));
+    const std::size_t max_expected_size = compression_overhead + compression_onetime_cost
+        + expected_average_block_hashing_blob_size * n_blocks;
+    ASSERT_LE(headers_blob.size(), max_expected_size);
+    const double avg_header_size = static_cast<double>(headers_blob.size()) / n_blocks;
+    MDEBUG("Compressed header blob for " << n_blocks << " headers is " << headers_blob.size()
+        << " bytes: average " << avg_header_size << " bytes/block");
+
+    // decompress
+    std::vector<hashable_block_header_info> decompressed_headers;
+    ASSERT_TRUE(decompress_block_header_chain(headers_blob, decompressed_headers));
+
+    // check equality
+    ASSERT_EQ(n_blocks, decompressed_headers.size());
+    ASSERT_EQ(headers, decompressed_headers);
+}
+
+INSTANTIATE_TEST_CASE_P(cn_impl, CompressDecompressHeaderChainMultiple,
+    testing::Values(1, 2, 4, 8, 10, 100, 1000, 10000, 100000, 1000000));


### PR DESCRIPTION
## Intro

Adds a compression algorithm which compresses the necessary info to form block hashing blobs (used for Block IDs and PoW). This algo, on real mainnet data, converges towards compressing the hashing blob at ~38.7 bytes per block. If intermediate PoW hashes (#10038) is implemented, this will change to (38.7 + 32) bytes per block. If v17 does not encode the number of txs per block in the hashing blob, we save one varint per block. This PR should help reduce bandwidth for the initial header sync before PoW is checked on a potential block header chain.

The definition of the block header hashing information is as so:

## Design

```
struct block_header
{
    uint8_t major_version;
    uint8_t minor_version;
    uint64_t timestamp;
    crypto::hash prev_id;
    uint32_t nonce;
};

struct hashable_block_header_info
{
    block_header header;
    crypto::hash block_content_hash;
    uint64_t n_txs_in_block;
};
```

Everything in `hashable_block_header_info` is needed to re-build the block hashing blob at each block. However, one can make some observations to reduce the data necessary to communicate a long chain of these headers:
- The `prev_id` field can be computed as a function of the previous block hashing blob
- The major and minor versions do not change very often in practice
- The timestamp is usually the previous timestamp plus some difficulty target, plus or minus
- The number of txs in a block is usually similar to the previous number

This leads to the following design decisions:
- The `prev_id` is dropped from all headers, except for the first one
- The major version is serialized once up front, and includes a number of consecutive headers who share this major version
- The minor version is serialized once up front, and includes a number of consecutive headers who share this minor version instead this span of major versions
- For each span of a major version, the average difference between timestamps in that span is calculated and serialized once per major version
- Per header, the timestamp is serialized as a signed deviation from the average of differences of timestamps
- The number of txs in a block is serialized as a signed difference from the previous number of txs in that block

The compressor performs 3 passes over the data. The de-compressor performs 1 pass over the data. Both compressor and de-compressor use trivial amounts of memory for overhead: all that is needed beside space for the block info and blob is several running integer fields, and 32 bytes for the `prev_id` on the decompression side. There is no dependency on external compression libraries.

## Performance

This is how it performs on real, recent mainnet headers:

|Number of blocks|Payload byte size|Compress time (ms)|Decompress time (ms)|Average bytes per block|
|-------------------------|--------------------------|-----------------------------|--------------------------------|------------------------------------|
|1|82|0|0|82|
|2|121|0|0|60.5|
|3|159|0|0|53|
|4|199|0|0|49.75|
|5|238|0|0|47.6|
|6|276|0|0|46|
|7|313|0|0|44.7143|
|8|350|0|0|43.75|
|9|392|0|0|43.5556|
|10|429|0|0|42.9|
|11|467|0|0|42.4545|
|12|505|0|0|42.0833|
|13|544|0|0|41.8462|
|14|580|0|0|41.4286|
|15|618|0|0|41.2|
|16|658|0|0|41.125|
|17|696|0|0|40.9412|
|18|734|0|0|40.7778|
|19|773|0|0|40.6842|
|20|814|0|0|40.7|
|30|1199|0|0|39.9667|
|40|1588|0|0|39.7|
|50|1974|0|0|39.48|
|60|2366|0|0|39.4333|
|70|2757|0|0|39.3857|
|80|3145|0|0|39.3125|
|90|3528|0|0|39.2|
|100|3923|0|0|39.23|
|200|7802|0|0|39.01|
|300|11708|0|0|39.0267|
|400|15606|0|0|39.015|
|500|19499|0|0|38.998|
|600|23403|0|0|39.005|
|700|27276|0|0|38.9657|
|800|31135|0|0|38.9188|
|900|35058|0|0|38.9533|
|1000|38930|0|0|38.93|
|2000|77707|0|1|38.8535|
|3000|116494|0|1|38.8313|
|4000|155382|0|2|38.8455|
|5000|194235|0|2|38.847|
|6000|233103|0|2|38.8505|
|7000|271880|0|2|38.84|
|8000|310665|0|1|38.8331|
|9000|349528|0|1|38.8364|
|10000|388354|0|2|38.8354|
|20000|776788|0|4|38.8394|
|30000|1165278|1|6|38.8426|
|40000|1553347|1|10|38.8337|
|50000|1941411|3|15|38.8282|
|60000|2329335|6|27|38.8223|
|70000|2717581|4|22|38.8226|
|80000|3105873|3|21|38.8234|
|90000|3493750|6|22|38.8194|
|100000|3881901|4|25|38.819|
|200000|7760722|13|61|38.8036|
|300000|11637564|14|85|38.7919|
|400000|15518478|22|105|38.7962|
|500000|19395831|28|147|38.7917|
|600000|23274660|36|189|38.7911|
|700000|27151552|52|194|38.7879|
|800000|31028403|48|203|38.7855|
|900000|34905055|58|217|38.7834|
|1000000|38781438|63|261|38.7814|
|2000000|77537075|175|588|38.7685|
|3000000|116364916|238|832|38.7883|
|3697324|143169069|282|973|38.7224|

When comparing compressed size, this algo performs ~3.3% worse than @SChernykh's header codec specified here: https://gist.github.com/SChernykh/194de94faeb701cc46b928a4fb02922d. However, the compress/decompress times are very promising, only taking 0.282s to compress the entire chain and 0.973s to decompress the entire chain! Benchmarks were done on a low-end laptop CPU.

## TODO
- [x] Test on real main chain data
- [ ] Reduce allocations in `std::ostringstream` on compression side
- [x] Block 202612 support
- [ ] Test 202612 security
- [x] Remove block hashing blob allocation on decompression side
- [x] Handle 0 length
- [x] Test 0 length
- [ ] PoW compute
- [ ] Naive comparison