### PR TITLE
Blockchain: fix data race in get_dynamic_base_fee_estimate

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3654,6 +3654,7 @@ void Blockchain::get_dynamic_base_fee_estimate_2021_scaling(uint64_t base_reward
 
 void Blockchain::get_dynamic_base_fee_estimate_2021_scaling(uint64_t grace_blocks, std::vector<uint64_t> &fees) const
 {
+  CRITICAL_REGION_LOCAL(m_blockchain_lock);
   const uint8_t version = get_current_hard_fork_version();
   const uint64_t db_height = m_db->height();
 


### PR DESCRIPTION
`get_dynamic_base_fee_estimate_2021_scaling` (the `get_fee_estimate` RPC path) reads `m_long_term_block_weights_cache_rolling_median` and `m_current_block_cumul_weight_limit` without holding `m_blockchain_lock`, while the block-add path (`update_next_cumulative_weight_limit` -> `get_long_term_block_weight_median`) mutates both in place under that lock. Found with ThreadSanitizer; taking `m_blockchain_lock` in the reader, as every other reader of that state does, removes the race.