### PR TITLE
epee: avoid unsafe file truncation

### DIFF
--- a/contrib/epee/include/file_io_utils.h
+++ b/contrib/epee/include/file_io_utils.h
@@ -27,16 +27,34 @@
 #ifndef _FILE_IO_UTILS_H_
 #define _FILE_IO_UTILS_H_
 
+#include <functional>
+#include <iosfwd>
 #include <string>
 #include <ctime>
 #include <cstdint>
+#ifndef _WIN32
+#include <sys/types.h>
+#endif
 
 namespace epee
 {
 namespace file_io_utils
 {
+    #ifdef _WIN32
+    using file_mode = unsigned int;
+    #else
+    using file_mode = mode_t;
+    #endif
+
     bool is_file_exist(const std::string& path);
-    bool save_string_to_file(const std::string& path_to_file, const std::string& str);
+namespace detail
+{
+    // The callback receives a file descriptor managed by save_fd_to_file and must not close it.
+    // On Windows this is a CRT file descriptor wrapping a HANDLE.
+    bool save_fd_to_file(const std::string& path_to_file, const std::function<bool(int)>& writer, file_mode create_mode = 0666);
+}
+    bool save_stream_to_file(const std::string& path_to_file, const std::function<bool(std::ostream&)>& writer, file_mode create_mode = 0666);
+    bool save_string_to_file(const std::string& path_to_file, const std::string& str, file_mode create_mode = 0666);
     bool load_file_to_string(const std::string& path_to_file, std::string& target_str, size_t max_size = 1000000000);
 }
 }

--- a/contrib/epee/src/file_io_utils.cpp
+++ b/contrib/epee/src/file_io_utils.cpp
@@ -26,12 +26,26 @@
 
 #include "file_io_utils.h"
 
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <climits>
+#include <cstring>
 #include <fstream>
+#include <ostream>
+#include <streambuf>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
 #include <windows.h>
 #include "string_tools.h"
+#else
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 #endif
 
 // On Windows there is a problem with non-ASCII characters in path and file names
@@ -60,6 +74,76 @@ namespace epee
 {
 namespace file_io_utils
 {
+	namespace
+	{
+		bool write_all(const int fd, const char* data, size_t size)
+		{
+			while (size != 0)
+			{
+				const size_t chunk = std::min<size_t>(size, INT_MAX);
+#ifdef _WIN32
+				const int written = _write(fd, data, static_cast<unsigned int>(chunk));
+#else
+				const ssize_t written = write(fd, data, chunk);
+#endif
+				if (written < 0)
+				{
+					if (errno == EINTR)
+						continue;
+					return false;
+				}
+				if (written == 0)
+				{
+					errno = EIO;
+					return false;
+				}
+				data += written;
+				size -= static_cast<size_t>(written);
+			}
+			return true;
+		}
+
+		class file_streambuf final : public std::streambuf
+		{
+		public:
+			explicit file_streambuf(const int fd)
+				: fd_(fd)
+			{
+				setp(buffer_.data(), buffer_.data() + buffer_.size());
+			}
+
+		protected:
+			int_type overflow(const int_type ch) override
+			{
+				if (!flush())
+					return traits_type::eof();
+				if (!traits_type::eq_int_type(ch, traits_type::eof()))
+				{
+					*pptr() = traits_type::to_char_type(ch);
+					pbump(1);
+				}
+				return traits_type::not_eof(ch);
+			}
+
+			int sync() override
+			{
+				return flush() ? 0 : -1;
+			}
+
+		private:
+			bool flush()
+			{
+				const std::ptrdiff_t size = pptr() - pbase();
+				if (size <= 0)
+					return true;
+				pbump(-static_cast<int>(size));
+				return write_all(fd_, buffer_.data(), static_cast<size_t>(size));
+			}
+
+			const int fd_;
+			std::array<char, 16384> buffer_;
+		};
+	}
  
 	bool is_file_exist(const std::string& path)
 	{
@@ -68,37 +152,130 @@ namespace file_io_utils
 	}
 
 
-	bool save_string_to_file(const std::string& path_to_file, const std::string& str)
+namespace detail
+{
+	bool save_fd_to_file(const std::string& path_to_file, const std::function<bool(int)>& writer, file_mode create_mode)
 	{
 #ifdef _WIN32
-                std::wstring wide_path;
-                try { wide_path = string_tools::utf8_to_utf16(path_to_file); } catch (...) { return false; }
-                HANDLE file_handle = CreateFileW(wide_path.c_str(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-                if (file_handle == INVALID_HANDLE_VALUE)
-                    return false;
-                DWORD bytes_written;
-                DWORD bytes_to_write = (DWORD)str.size();
-                BOOL result = WriteFile(file_handle, str.data(), bytes_to_write, &bytes_written, NULL);
-                CloseHandle(file_handle);
-                if (bytes_written != bytes_to_write)
-                    result = FALSE;
-                return result;
-#else
-		try
+		(void)create_mode;
+		std::wstring wide_path;
+		try { wide_path = string_tools::utf8_to_utf16(path_to_file); } catch (...) { return false; }
+		HANDLE file_handle = CreateFileW(wide_path.c_str(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+		if (file_handle == INVALID_HANDLE_VALUE)
+			return false;
+		const int file_fd = _open_osfhandle(reinterpret_cast<intptr_t>(file_handle), _O_WRONLY | _O_BINARY);
+		if (file_fd < 0)
 		{
-			std::ofstream fstream;
-			fstream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-			fstream.open(path_to_file, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
-			fstream << str;
-			fstream.close();
-			return true;
+			const int error = errno;
+			CloseHandle(file_handle);
+			errno = error;
+			return false;
 		}
-
-		catch(...)
+		// The CRT descriptor now owns file_handle; _close(file_fd) closes both.
+#else
+		errno = 0;
+		struct stat st;
+		int result;
+		do
+		{
+			result = lstat(path_to_file.c_str(), &st);
+		} while (result != 0 && errno == EINTR);
+		if (result == 0)
+		{
+			if (S_ISLNK(st.st_mode) || !S_ISREG(st.st_mode))
+				return false;
+		}
+		else if (errno != ENOENT)
 		{
 			return false;
 		}
+
+#ifdef O_NOFOLLOW
+		const int flags = O_WRONLY | O_CREAT | O_NOFOLLOW;
+#else
+		const int flags = O_WRONLY | O_CREAT;
 #endif
+		int file_fd;
+		do
+		{
+			file_fd = open(path_to_file.c_str(), flags, create_mode);
+		} while (file_fd < 0 && errno == EINTR);
+		if (file_fd < 0)
+			return false;
+
+		do
+		{
+			result = fstat(file_fd, &st);
+		} while (result != 0 && errno == EINTR);
+		if (result != 0 || !S_ISREG(st.st_mode))
+		{
+			const int error = result != 0 ? errno : EINVAL;
+			close(file_fd);
+			errno = error;
+			return false;
+		}
+
+		do
+		{
+			result = ftruncate(file_fd, 0);
+		} while (result != 0 && errno == EINTR);
+		if (result != 0)
+		{
+			const int error = errno;
+			close(file_fd);
+			errno = error;
+			return false;
+		}
+#endif
+
+		errno = 0;
+		bool writer_result = false;
+		try
+		{
+			writer_result = writer(file_fd);
+		}
+		catch (...)
+		{
+			if (errno == 0)
+				errno = EIO;
+		}
+		const int writer_error = errno;
+#ifdef _WIN32
+		const int close_result = _close(file_fd);
+#else
+		const int close_result = close(file_fd);
+#endif
+		const int close_error = errno;
+		if (!writer_result)
+			errno = writer_error ? writer_error : (close_result != 0 ? close_error : EIO);
+		else if (close_result != 0)
+			errno = close_error;
+		return writer_result && close_result == 0;
+	}
+}
+
+
+	bool save_stream_to_file(const std::string& path_to_file, const std::function<bool(std::ostream&)>& writer, file_mode create_mode)
+	{
+		return detail::save_fd_to_file(path_to_file, [&writer](const int fd)
+		{
+			file_streambuf buffer{fd};
+			std::ostream stream{&buffer};
+			const bool result = writer(stream);
+			if (!result)
+				return false;
+			stream.flush();
+			return stream.good();
+		}, create_mode);
+	}
+
+
+	bool save_string_to_file(const std::string& path_to_file, const std::string& str, file_mode create_mode)
+	{
+		return detail::save_fd_to_file(path_to_file, [&str](const int fd)
+		{
+			return write_all(fd, str.data(), str.size());
+		}, create_mode);
 	}
 
 

--- a/contrib/epee/src/file_io_utils.cpp
+++ b/contrib/epee/src/file_io_utils.cpp
@@ -30,6 +30,7 @@
 #include <array>
 #include <cerrno>
 #include <climits>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <ostream>
@@ -128,6 +129,21 @@ namespace file_io_utils
 			int sync() override
 			{
 				return flush() ? 0 : -1;
+			}
+
+			pos_type seekoff(const off_type off, const std::ios_base::seekdir direction, const std::ios_base::openmode mode) override
+			{
+				if (!(mode & std::ios_base::out) || direction != std::ios_base::cur || off != 0)
+					return pos_type(off_type(-1));
+
+#ifdef _WIN32
+				const __int64 position = _lseeki64(fd_, 0, SEEK_CUR);
+#else
+				const off_t position = lseek(fd_, 0, SEEK_CUR);
+#endif
+				if (position < 0)
+					return pos_type(off_type(-1));
+				return pos_type(static_cast<off_type>(position) + static_cast<off_type>(pptr() - pbase()));
 			}
 
 		private:

--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -611,15 +611,43 @@ boost::system::error_code store_ssl_keys(boost::asio::ssl::context& ssl, const b
   if (!dflt_SSL || !(ssl_key = SSL_get_privatekey(dflt_SSL.get())) || !(ssl_cert = SSL_get_certificate(dflt_SSL.get())))
     return {EINVAL, boost::system::system_category()};
 
-  using file_closer = int(std::FILE*);
   boost::system::error_code error{};
-  std::unique_ptr<std::FILE, file_closer*> file{nullptr, std::fclose};
+  auto save_pem_to_file = [](const boost::filesystem::path& path, const std::function<bool(BIO*)>& writer, epee::file_io_utils::file_mode create_mode = 0666) -> boost::system::error_code
+  {
+    unsigned long ssl_error = 0;
+    errno = 0;
+    const bool saved = epee::file_io_utils::detail::save_fd_to_file(path.string(), [&writer, &ssl_error](const int fd)
+    {
+      std::unique_ptr<BIO, decltype(&BIO_free)> file{BIO_new_fd(fd, BIO_NOCLOSE), BIO_free};
+      if (!file)
+      {
+        ssl_error = ERR_get_error();
+        return false;
+      }
+      if (!writer(file.get()) || BIO_flush(file.get()) != 1)
+      {
+        ssl_error = ERR_get_error();
+        return false;
+      }
+      return true;
+    }, create_mode);
+    if (!saved)
+    {
+      if (ssl_error)
+        return boost::asio::error::ssl_errors(ssl_error);
+      return {errno ? errno : EIO, boost::system::system_category()};
+    }
+    return {};
+  };
 
   // write key file unencrypted
   {
     const boost::filesystem::path key_file{base.string() + ".key"};
-    file.reset(std::fopen(key_file.string().c_str(), "wb"));
-    if (!file)
+    error = save_pem_to_file(key_file, [ssl_key](BIO* file)
+    {
+      return PEM_write_bio_PrivateKey(file, ssl_key, nullptr, nullptr, 0, nullptr, nullptr) != 0;
+    }, 0600);
+    if (error)
     {
       if (epee::file_io_utils::is_file_exist(key_file.string())) {
         MERROR("Permission denied to overwrite SSL private key file: '" << key_file.string() << "'");
@@ -627,52 +655,43 @@ boost::system::error_code store_ssl_keys(boost::asio::ssl::context& ssl, const b
         MERROR("Could not open SSL private key file for writing: '" << key_file.string() << "'");
       }
 
-      return {errno, boost::system::system_category()};
+      return error;
     }
     boost::filesystem::permissions(key_file, boost::filesystem::owner_read, error);
     if (error)
       return error;
-    if (!PEM_write_PrivateKey(file.get(), ssl_key, nullptr, nullptr, 0, nullptr, nullptr))
-      return boost::asio::error::ssl_errors(ERR_get_error());
-    if (std::fclose(file.release()) != 0)
-      return {errno, boost::system::system_category()};
   }
 
   // write certificate file in standard SSL X.509 unencrypted
   const boost::filesystem::path cert_file{base.string() + ".crt"};
-  file.reset(std::fopen(cert_file.string().c_str(), "wb"));
-  if (!file)
-    return {errno, boost::system::system_category()};
+  error = save_pem_to_file(cert_file, [ssl_cert](BIO* file)
+  {
+    return PEM_write_bio_X509(file, ssl_cert) != 0;
+  });
+  if (error)
+    return error;
   const auto cert_perms = (boost::filesystem::owner_read | boost::filesystem::group_read | boost::filesystem::others_read);
   boost::filesystem::permissions(cert_file, cert_perms, error);
   if (error)
     return error;
-  if (!PEM_write_X509(file.get(), ssl_cert))
-    return boost::asio::error::ssl_errors(ERR_get_error());
-  if (std::fclose(file.release()) != 0)
-    return {errno, boost::system::system_category()};
 
   // write SHA-256 fingerprint file
   const boost::filesystem::path fp_file{base.string() + ".fingerprint"};
-  file.reset(std::fopen(fp_file.string().c_str(), "w"));
-  if (!file)
-    return {errno, boost::system::system_category()};
-  const auto fp_perms = (boost::filesystem::owner_read | boost::filesystem::group_read | boost::filesystem::others_read);
-  boost::filesystem::permissions(fp_file, fp_perms, error);
-  if (error)
-    return error;
   try
   {
     const std::string fingerprint = get_hr_ssl_fingerprint(ssl_cert);
-    if (fingerprint.length() != fwrite(fingerprint.c_str(), sizeof(char), fingerprint.length(), file.get()))
-      return {errno, boost::system::system_category()};
+    errno = 0;
+    if (!epee::file_io_utils::save_string_to_file(fp_file.string(), fingerprint))
+      return {errno ? errno : EIO, boost::system::system_category()};
   }
   catch (const boost::system::system_error& fperr)
   {
     return fperr.code();
   }
-  if (std::fclose(file.release()) != 0)
-    return {errno, boost::system::system_category()};
+  const auto fp_perms = (boost::filesystem::owner_read | boost::filesystem::group_read | boost::filesystem::others_read);
+  boost::filesystem::permissions(fp_file, fp_perms, error);
+  if (error)
+    return error;
 
   return error;
 }

--- a/src/p2p/net_peerlist.cpp
+++ b/src/p2p/net_peerlist.cpp
@@ -42,6 +42,7 @@
 
 #include "net_peerlist_boost_serialization.h"
 #include "common/util.h"
+#include "file_io_utils.h"
 
 
 namespace nodetool
@@ -240,12 +241,10 @@ namespace nodetool
 
   bool peerlist_storage::store(const std::string& path, const peerlist_types& other) const
   {
-    std::ofstream dest_file{};
-    dest_file.open( path , std::ios_base::binary | std::ios_base::out| std::ios::trunc);
-    if(dest_file.fail())
-      return false;
-
-    return store(dest_file, other);
+    return epee::file_io_utils::save_stream_to_file(path, [this, &other](std::ostream& dest)
+    {
+      return store(dest, other);
+    });
   }
 
   peerlist_types peerlist_storage::take_zone(epee::net_utils::zone zone)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -48,6 +48,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/preprocessor/stringize.hpp>
 #include <openssl/evp.h>
+#include <openssl/pem.h>
 #include "include_base_utils.h"
 using namespace epee;
 
@@ -6943,24 +6944,12 @@ void wallet2::store_to(const std::string &path, const epee::wipeable_string &pas
   }
 
   // Save cache to new file. If storing to the same file, the temp path has the ".new" extension
-#ifdef WIN32
-    // On Windows avoid using std::ofstream which does not work with UTF-8 filenames
-    // The price to pay is temporary higher memory consumption for string stream + binary archive
-    std::ostringstream oss;
-    binary_archive<true> oar(oss);
-    bool success = ::serialization::serialize(oar, cache_file_data.get());
-    if (success) {
-        success = save_to_file(new_file, oss.str());
-    }
-    THROW_WALLET_EXCEPTION_IF(!success, error::file_save_error, new_file);
-#else
-    std::ofstream ostr;
-    ostr.open(new_file, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
-    binary_archive<true> oar(ostr);
-    bool success = ::serialization::serialize(oar, cache_file_data.get());
-    ostr.close();
-    THROW_WALLET_EXCEPTION_IF(!success || !ostr.good(), error::file_save_error, new_file);
-#endif
+  const bool success = epee::file_io_utils::save_stream_to_file(new_file, [&cache_file_data](std::ostream& stream)
+  {
+    binary_archive<true> oar(stream);
+    return ::serialization::serialize(oar, cache_file_data.get());
+  });
+  THROW_WALLET_EXCEPTION_IF(!success, error::file_save_error, new_file);
 
   if (same_file)
   {
@@ -15182,25 +15171,13 @@ bool wallet2::save_to_file(const std::string& path_to_file, const std::string& r
     return epee::file_io_utils::save_string_to_file(path_to_file, raw);
   }
 
-  FILE *fp = fopen(path_to_file.c_str(), "w+");
-  if (!fp)
+  return epee::file_io_utils::detail::save_fd_to_file(path_to_file, [&raw](const int fd)
   {
-    MERROR("Failed to open wallet file for writing: " << path_to_file << ": " << strerror(errno));
-    return false;
-  }
-
-  // Save the result b/c we need to close the fp before returning success/failure.
-  int write_result = PEM_write(fp, ASCII_OUTPUT_MAGIC.c_str(), "", (const unsigned char *) raw.c_str(), raw.length());
-  fclose(fp);
-
-  if (write_result == 0)
-  {
-    return false;
-  }
-  else
-  {
-    return true;
-  }
+    std::unique_ptr<BIO, decltype(&BIO_free)> bio{BIO_new_fd(fd, BIO_NOCLOSE), BIO_free};
+    return bio &&
+      PEM_write_bio(bio.get(), ASCII_OUTPUT_MAGIC.c_str(), "", (const unsigned char *) raw.c_str(), raw.length()) != 0 &&
+      BIO_flush(bio.get()) == 1;
+  });
 }
 //----------------------------------------------------------------------------------------------------
 

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -27,6 +27,11 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <array>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#ifndef _WIN32
+#include <sys/stat.h>
+#endif
 #include <boost/predef/other/endian.h>
 #include <boost/endian/conversion.hpp>
 #include <boost/range/algorithm/equal.hpp>
@@ -50,6 +55,7 @@
 #include "byte_slice.h"
 #include "byte_stream.h"
 #include "crypto/crypto.h"
+#include "file_io_utils.h"
 #include "hex.h"
 #include "net/net_utils_base.h"
 #include "net/local_ip.h"
@@ -2048,3 +2054,129 @@ TEST(scope_guard, unique_scope_guard_move_assign)
   ASSERT_EQ(1, count1);
   ASSERT_EQ(1, count2);
 }
+
+TEST(FileIOUtils, SaveStringToFileWritesRegularFile)
+{
+  boost::system::error_code ec;
+  const boost::filesystem::path dir = boost::filesystem::temp_directory_path(ec) / boost::filesystem::unique_path("file-io-%%%%%%%%%%%%%%%%", ec);
+  ASSERT_FALSE(ec) << ec.message();
+  ASSERT_TRUE(boost::filesystem::create_directory(dir, ec));
+  ASSERT_FALSE(ec) << ec.message();
+  const epee::scope_guard cleanup([&dir](){ boost::filesystem::remove_all(dir); });
+
+  const boost::filesystem::path file = dir / "regular";
+  ASSERT_TRUE(epee::file_io_utils::save_string_to_file(file.string(), "old"));
+  ASSERT_TRUE(epee::file_io_utils::save_string_to_file(file.string(), "new"));
+
+  std::string contents;
+  ASSERT_TRUE(epee::file_io_utils::load_file_to_string(file.string(), contents));
+  ASSERT_EQ("new", contents);
+}
+
+TEST(FileIOUtils, SaveStreamToFileWritesInChunks)
+{
+  boost::system::error_code ec;
+  const boost::filesystem::path dir = boost::filesystem::temp_directory_path(ec) / boost::filesystem::unique_path("file-io-%%%%%%%%%%%%%%%%", ec);
+  ASSERT_FALSE(ec) << ec.message();
+  ASSERT_TRUE(boost::filesystem::create_directory(dir, ec));
+  ASSERT_FALSE(ec) << ec.message();
+  const epee::scope_guard cleanup([&dir](){ boost::filesystem::remove_all(dir); });
+
+  const boost::filesystem::path file = dir / "stream";
+  const std::array<char, 4096> chunk{};
+  constexpr size_t chunk_count = 4096;
+  ASSERT_TRUE(epee::file_io_utils::save_stream_to_file(file.string(), [&chunk](std::ostream& stream)
+  {
+    for (size_t i = 0; i < chunk_count; ++i)
+      stream.write(chunk.data(), chunk.size());
+    return stream.good();
+  }));
+
+  ASSERT_EQ(chunk.size() * chunk_count, boost::filesystem::file_size(file, ec));
+  ASSERT_FALSE(ec) << ec.message();
+}
+
+TEST(FileIOUtils, SaveStreamToFileTruncatesRegularFile)
+{
+  boost::system::error_code ec;
+  const boost::filesystem::path dir = boost::filesystem::temp_directory_path(ec) / boost::filesystem::unique_path("file-io-%%%%%%%%%%%%%%%%", ec);
+  ASSERT_FALSE(ec) << ec.message();
+  ASSERT_TRUE(boost::filesystem::create_directory(dir, ec));
+  ASSERT_FALSE(ec) << ec.message();
+  const epee::scope_guard cleanup([&dir](){ boost::filesystem::remove_all(dir); });
+
+  const boost::filesystem::path file = dir / "stream";
+  ASSERT_TRUE(epee::file_io_utils::save_string_to_file(file.string(), "longer contents"));
+  ASSERT_TRUE(epee::file_io_utils::save_stream_to_file(file.string(), [](std::ostream& stream)
+  {
+    stream << "short";
+    return stream.good();
+  }));
+
+  std::string contents;
+  ASSERT_TRUE(epee::file_io_utils::load_file_to_string(file.string(), contents));
+  ASSERT_EQ("short", contents);
+}
+
+TEST(FileIOUtils, SaveStringToFileRefusesDirectory)
+{
+  boost::system::error_code ec;
+  const boost::filesystem::path dir = boost::filesystem::temp_directory_path(ec) / boost::filesystem::unique_path("file-io-%%%%%%%%%%%%%%%%", ec);
+  ASSERT_FALSE(ec) << ec.message();
+  ASSERT_TRUE(boost::filesystem::create_directory(dir, ec));
+  ASSERT_FALSE(ec) << ec.message();
+  const epee::scope_guard cleanup([&dir](){ boost::filesystem::remove_all(dir); });
+
+  const boost::filesystem::path target = dir / "target";
+  ASSERT_TRUE(boost::filesystem::create_directory(target, ec));
+  ASSERT_FALSE(ec) << ec.message();
+
+  ASSERT_FALSE(epee::file_io_utils::save_string_to_file(target.string(), "replacement"));
+  ASSERT_TRUE(boost::filesystem::is_directory(target, ec));
+  ASSERT_FALSE(ec) << ec.message();
+}
+
+#ifndef _WIN32
+TEST(FileIOUtils, SaveStringToFileRefusesSymlink)
+{
+  boost::system::error_code ec;
+  const boost::filesystem::path dir = boost::filesystem::temp_directory_path(ec) / boost::filesystem::unique_path("file-io-%%%%%%%%%%%%%%%%", ec);
+  ASSERT_FALSE(ec) << ec.message();
+  ASSERT_TRUE(boost::filesystem::create_directory(dir, ec));
+  ASSERT_FALSE(ec) << ec.message();
+  const epee::scope_guard cleanup([&dir](){ boost::filesystem::remove_all(dir); });
+
+  const boost::filesystem::path victim = dir / "victim";
+  const boost::filesystem::path link = dir / "link";
+  ASSERT_TRUE(epee::file_io_utils::save_string_to_file(victim.string(), "victim"));
+  boost::filesystem::create_symlink(victim, link, ec);
+  ASSERT_FALSE(ec) << ec.message();
+
+  ASSERT_FALSE(epee::file_io_utils::save_string_to_file(link.string(), "replacement"));
+
+  std::string contents;
+  ASSERT_TRUE(epee::file_io_utils::load_file_to_string(victim.string(), contents));
+  ASSERT_EQ("victim", contents);
+}
+
+TEST(FileIOUtils, SaveStringToFileRefusesFifo)
+{
+  boost::system::error_code ec;
+  const boost::filesystem::path dir = boost::filesystem::temp_directory_path(ec) / boost::filesystem::unique_path("file-io-%%%%%%%%%%%%%%%%", ec);
+  ASSERT_FALSE(ec) << ec.message();
+  ASSERT_TRUE(boost::filesystem::create_directory(dir, ec));
+  ASSERT_FALSE(ec) << ec.message();
+  const epee::scope_guard cleanup([&dir](){ boost::filesystem::remove_all(dir); });
+
+  const boost::filesystem::path fifo = dir / "fifo";
+  ASSERT_EQ(0, mkfifo(fifo.string().c_str(), 0600));
+
+  ASSERT_FALSE(epee::file_io_utils::save_string_to_file(fifo.string(), "replacement"));
+  ASSERT_TRUE(boost::filesystem::exists(fifo, ec));
+  ASSERT_FALSE(ec) << ec.message();
+
+  struct stat st;
+  ASSERT_EQ(0, lstat(fifo.string().c_str(), &st));
+  ASSERT_TRUE(S_ISFIFO(st.st_mode));
+}
+#endif

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -2118,6 +2118,30 @@ TEST(FileIOUtils, SaveStreamToFileTruncatesRegularFile)
   ASSERT_EQ("short", contents);
 }
 
+TEST(FileIOUtils, SaveStreamToFileReportsOutputPosition)
+{
+  boost::system::error_code ec;
+  const boost::filesystem::path dir = boost::filesystem::temp_directory_path(ec) / boost::filesystem::unique_path("file-io-%%%%%%%%%%%%%%%%", ec);
+  ASSERT_FALSE(ec) << ec.message();
+  ASSERT_TRUE(boost::filesystem::create_directory(dir, ec));
+  ASSERT_FALSE(ec) << ec.message();
+  const epee::scope_guard cleanup([&dir](){ boost::filesystem::remove_all(dir); });
+
+  const boost::filesystem::path file = dir / "positioned-stream";
+  ASSERT_TRUE(epee::file_io_utils::save_stream_to_file(file.string(), [](std::ostream& stream)
+  {
+    stream << "abc";
+    if (stream.tellp() != std::streampos{3})
+      return false;
+    stream.flush();
+    return stream.good() && stream.tellp() == std::streampos{3};
+  }));
+
+  std::string contents;
+  ASSERT_TRUE(epee::file_io_utils::load_file_to_string(file.string(), contents));
+  ASSERT_EQ("abc", contents);
+}
+
 TEST(FileIOUtils, SaveStringToFileRefusesDirectory)
 {
   boost::system::error_code ec;


### PR DESCRIPTION
- On POSIX it rejects symlinks and non-regular files before truncating.
- On Windows it keeps the existing `CreateFileW` behavior while allowing ostream-based callers, such as wallet cache serialization, to stream directly to the file instead of buffering the whole cache in memory first.
- There are still some race risks, but avoiding all of them would make this quite a bit more complicated, and I think this is a good balance between improving the behavior and keeping the diff manageable.

Needs testing on Windows before it can be merged.