### PR TITLE
ci: run guix builds on changes to external

### DIFF
--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -6,6 +6,7 @@ on:
       - 'contrib/depends/**'
       - 'contrib/guix/**'
       - '!contrib/**.md'
+      - 'external/**'
       - '.github/workflows/guix.yml'
       - '**/Cargo.lock'
   pull_request:
@@ -13,6 +14,7 @@ on:
       - 'contrib/depends/**'
       - 'contrib/guix/**'
       - '!contrib/**.md'
+      - 'external/**'
       - '.github/workflows/guix.yml'
       - '**/Cargo.lock'
 


### PR DESCRIPTION
Updating dependencies in `external` should trigger Guix release builds.