### PR TITLE
wallet: wallet args take `argv[]` as `const`

### DIFF
--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2026, The Monero Project
 //
 // All rights reserved.
 //
@@ -87,7 +87,8 @@ namespace wallet_args
   }
 
   std::pair<boost::optional<boost::program_options::variables_map>, bool> main(
-    int argc, char** argv,
+    int argc,
+    const char* const argv[],
     const char* const usage,
     const char* const notice,
     boost::program_options::options_description desc_params,

--- a/src/wallet/wallet_args.h
+++ b/src/wallet/wallet_args.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2026, The Monero Project
 //
 // All rights reserved.
 //
@@ -50,7 +50,8 @@ namespace wallet_args
     pair.second: Should the execution terminate successfully without actually launching the application
   */
   std::pair<boost::optional<boost::program_options::variables_map>, bool> main(
-    int argc, char** argv,
+    int argc,
+    const char* const argv[],
     const char* const usage,
     const char* const notice,
     boost::program_options::options_description desc_params,


### PR DESCRIPTION
Changes function `wallet_args::main()`'s `argv` parameter from a mutable array of mutable strings, to a const array of const strings, which is what Boost uses. Useful for downstream testing code. 