### PR TITLE
epee: use correct minor http version

### DIFF
--- a/contrib/epee/include/net/http_protocol_handler.inl
+++ b/contrib/epee/include/net/http_protocol_handler.inl
@@ -404,7 +404,7 @@ namespace net_utils
 		boost::smatch result;	
 		if(boost::regex_search(m_cache, result, rexp_match_command_line, boost::match_default) && result[0].matched)
 		{
-			if (!analize_http_method(result, m_query_info.m_http_method, m_query_info.m_http_ver_hi, m_query_info.m_http_ver_hi))
+			if (!analize_http_method(result, m_query_info.m_http_method, m_query_info.m_http_ver_hi, m_query_info.m_http_ver_lo))
 			{
 				m_state = http_state_error;
 				MERROR("Failed to analyze method");


### PR DESCRIPTION
https://codeberg.org/montero-project/monero/pulls/15

AFAICT this was already approved before it got nuked.