### PR TITLE
guix: update gcc to 15.2.0

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -58,7 +58,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=${GUIX_REPO:-https://codeberg.org/guix/guix.git} \
-                      --commit=4a507aa8c0a579d150267d81ab4013189a7ec505 \
+                      --commit=0c2eff26bdf0cb9b3300c7b4883a2e471757940d \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -81,7 +81,7 @@ chain for " target " development."))
       (home-page (package-home-page xgcc))
       (license (package-license xgcc)))))
 
-(define base-gcc gcc-14)
+(define base-gcc gcc-15)
 (define base-linux-kernel-headers linux-libre-headers-6.1)
 
 (define* (make-monero-cross-toolchain  target
@@ -270,30 +270,30 @@ chain for " target " development."))
     (cond ((string-suffix? "-mingw32" target)
            (list
              zip ; used to create release archives
-             gcc-toolchain-14
+             gcc-toolchain-15
              (make-mingw-pthreads-cross-toolchain target)))
           ((string-contains target "-linux-gnu")
            (list
-             gcc-toolchain-14
-             (list gcc-toolchain-14 "static")
+             gcc-toolchain-15
+             (list gcc-toolchain-15 "static")
              (if (string-contains target "loongarch64")
                (make-monero-cross-toolchain target #:base-libc glibc)
                (make-monero-cross-toolchain target))))
           ((string-contains target "freebsd")
            (list
              xz ; used to unpack freebsd_base
-             gcc-toolchain-14
-             (list gcc-toolchain-14 "static")
+             gcc-toolchain-15
+             (list gcc-toolchain-15 "static")
              clang-toolchain-21
              binutils))
           ((string-contains target "android")
             (list
               unzip ; used to unpack android_ndk
-              gcc-toolchain-14
-              (list gcc-toolchain-14 "static")))
+              gcc-toolchain-15
+              (list gcc-toolchain-15 "static")))
           ((string-contains target "darwin")
            (list
-             gcc-toolchain-14
+             gcc-toolchain-15
              clang-toolchain-21
              lld-21
              (make-lld-wrapper lld-21 #:lld-as-ld? #t)))


### PR DESCRIPTION
Previous `time-machine` bump: #10331

The `time-machine` bump is required for [this fix](https://codeberg.org/guix/guix/commit/0e191e488873bea51c7efe4e181eed9a87d6fccb) and will also unlock LLVM 22.

To ensure reproducibility, reviewers are requested to perform a build and share their hashes.