### PR TITLE
p2p: allow --ban-list to load from a URL

### DIFF
--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -156,7 +156,7 @@ namespace nodetool
     const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_seed_node   = {"seed-node", "Connect to a node to retrieve peer addresses, and disconnect"};
     const command_line::arg_descriptor<std::vector<std::string> > arg_tx_proxy = {"tx-proxy", "Send local txes through proxy: <network-type>,[socks5://[user:pass@]]<socks-ip:port>[,max_connections][,disable_noise] i.e. \"tor,127.0.0.1:9050,100,disable_noise\""};
     const command_line::arg_descriptor<std::vector<std::string> > arg_anonymous_inbound = {"anonymous-inbound", "<hidden-service-address>,<[bind-ip:]port>[,max_connections] i.e. \"x.onion,127.0.0.1:18083,100\""};
-    const command_line::arg_descriptor<std::string> arg_ban_list = {"ban-list", "Specify ban list file, one IP address per line"};
+    const command_line::arg_descriptor<std::string> arg_ban_list = {"ban-list", "Specify ban list file or http(s) URL, one IP address or subnet per line"};
     const command_line::arg_descriptor<bool> arg_p2p_hide_my_port   =    {"hide-my-port", "Do not announce yourself as peerlist candidate", false, true};
     const command_line::arg_descriptor<bool> arg_no_sync = {"no-sync", "Don't synchronize the blockchain with other peers", false};
     const command_line::arg_descriptor<bool> arg_enable_dns_blocklist = {"enable-dns-blocklist", "Apply realtime blocklist from DNS", false};

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -284,6 +284,7 @@ namespace nodetool
     virtual bool unblock_host(const epee::net_utils::network_address &address);
     virtual bool block_subnet(const epee::net_utils::ipv4_network_subnet &subnet, time_t seconds = P2P_IP_BLOCKTIME);
     virtual bool unblock_subnet(const epee::net_utils::ipv4_network_subnet &subnet);
+    size_t load_ban_list(const std::string &ban_list);
     virtual bool is_host_blocked(const epee::net_utils::network_address &address, time_t *seconds) { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return !is_remote_host_allowed(address, seconds); }
     virtual std::map<std::string, time_t> get_blocked_hosts() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_hosts; }
     virtual std::map<epee::net_utils::ipv4_network_subnet, time_t> get_blocked_subnets() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_subnets; }
@@ -350,6 +351,8 @@ namespace nodetool
     //-----------------------------------------------------------------------------------------------
 
     bool parse_peer_from_string(epee::net_utils::network_address& pe, const std::string& node_addr, uint16_t default_port = 0);
+    static bool is_ban_list_url(const std::string &spec);
+    static std::string fetch_ban_list(const std::string &url);
     bool handle_command_line(
         const boost::program_options::variables_map& vm
       );

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -352,9 +352,10 @@ namespace nodetool
 
     bool parse_peer_from_string(epee::net_utils::network_address& pe, const std::string& node_addr, uint16_t default_port = 0);
     static bool is_ban_list_url(const std::string &spec);
-    static std::string fetch_ban_list(const std::string &url);
+    static std::string fetch_ban_list(const std::string &url, const std::string &proxy);
     bool handle_command_line(
         const boost::program_options::variables_map& vm
+      , const std::string& proxy
       );
     bool idle_worker();
     bool handle_remote_peerlist(const std::vector<peerlist_entry>& peerlist, const epee::net_utils::connection_context_base& context);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -57,6 +57,7 @@
 #include "storages/levin_abstract_invoke2.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "net/parse.h"
+#include "net/http_client.h"
 #include "p2p/net_node.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -77,6 +78,15 @@ static inline boost::asio::ip::address_v4 make_address_v4_from_v6(const boost::a
 
 namespace nodetool
 {
+  namespace
+  {
+    // Safety bound for a ban list fetched from a URL. 10 MiB is far above any
+    // realistic IP or subnet list and bounds memory use. The body is buffered by
+    // the HTTP client before this check, so it is a sanity bound, not a stream limit.
+    constexpr std::size_t BAN_LIST_DOWNLOAD_MAX_SIZE = 10 * 1024 * 1024;
+    constexpr std::chrono::seconds BAN_LIST_DOWNLOAD_TIMEOUT{30};
+  }
+
   template<class t_payload_net_handler>
   node_server<t_payload_net_handler>::~node_server()
   {
@@ -418,6 +428,92 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
+  bool node_server<t_payload_net_handler>::is_ban_list_url(const std::string &spec)
+  {
+    // Treat the argument as remote when it carries an http or https scheme. Scheme
+    // names are case insensitive per RFC 3986 section 3.1.
+    return boost::istarts_with(spec, "http://") || boost::istarts_with(spec, "https://");
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
+  std::string node_server<t_payload_net_handler>::fetch_ban_list(const std::string &url)
+  {
+    epee::net_utils::http::url_content u_c;
+    if (!epee::net_utils::parse_url(url, u_c))
+      throw std::runtime_error("Failed to parse ban list URL: " + url);
+    if (u_c.host.empty())
+      throw std::runtime_error("Ban list URL has no host: " + url);
+
+    const bool https = u_c.schema == "https";
+    // For https, ssl_options_t(e_ssl_support_enabled) sets verification to system_ca,
+    // so the server certificate is validated against the system trust store. That
+    // validation is the integrity guarantee for the fetched list.
+    epee::net_utils::ssl_options_t ssl_options = https
+      ? epee::net_utils::ssl_options_t{epee::net_utils::ssl_support_t::e_ssl_support_enabled}
+      : epee::net_utils::ssl_options_t{epee::net_utils::ssl_support_t::e_ssl_support_disabled};
+
+    const uint16_t port = u_c.port ? u_c.port : (https ? 443 : 80);
+
+    epee::net_utils::http::http_simple_client client;
+    client.set_server(u_c.host, std::to_string(port), boost::none, std::move(ssl_options));
+
+    const epee::net_utils::http::http_response_info *info = nullptr;
+    const bool ok = client.invoke_get(u_c.uri, BAN_LIST_DOWNLOAD_TIMEOUT, "", std::addressof(info));
+    const auto disconnect = epee::misc_utils::create_scope_leave_handler([&client]{ client.disconnect(); });
+
+    if (!ok)
+      throw std::runtime_error("Failed to retrieve ban list from URL: " + url);
+    if (!info)
+      throw std::runtime_error("No HTTP response from ban list URL: " + url);
+    if (info->m_response_code != 200)
+      throw std::runtime_error("Unexpected HTTP status " + std::to_string(info->m_response_code) +
+        " from ban list URL: " + url);
+    if (info->m_body.empty())
+      throw std::runtime_error("Empty ban list received from URL: " + url);
+    if (info->m_body.size() > BAN_LIST_DOWNLOAD_MAX_SIZE)
+      throw std::runtime_error("Ban list from URL exceeds the maximum size of " +
+        std::to_string(BAN_LIST_DOWNLOAD_MAX_SIZE) + " bytes: " + url);
+
+    return info->m_body;
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
+  size_t node_server<t_payload_net_handler>::load_ban_list(const std::string &ban_list)
+  {
+    size_t applied = 0;
+    std::istringstream iss(ban_list);
+    for (std::string line; std::getline(iss, line); )
+    {
+      // ignore comments after '#' character
+      const size_t pound_idx = line.find('#');
+      if (pound_idx != std::string::npos)
+        line.resize(pound_idx);
+
+      // trim whitespace and ignore empty lines
+      boost::trim(line);
+      if (line.empty())
+        continue;
+
+      auto subnet = net::get_ipv4_subnet_address(line);
+      if (subnet)
+      {
+        block_subnet(*subnet, std::numeric_limits<time_t>::max());
+        ++applied;
+        continue;
+      }
+      const expect<epee::net_utils::network_address> parsed_addr = net::get_network_address(line, 0);
+      if (parsed_addr)
+      {
+        block_host(*parsed_addr, std::numeric_limits<time_t>::max());
+        ++applied;
+        continue;
+      }
+      MERROR("Invalid IP address or IPv4 subnet: " << line);
+    }
+    return applied;
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::handle_command_line(
       const boost::program_options::variables_map& vm
     )
@@ -504,46 +600,27 @@ namespace nodetool
     {
       const std::string ban_list = command_line::get_arg(vm, arg_ban_list);
 
-      const boost::filesystem::path ban_list_path(ban_list);
-      boost::system::error_code ec;
-      if (!boost::filesystem::exists(ban_list_path, ec))
+      std::string ban_list_contents;
+      if (is_ban_list_url(ban_list))
       {
-        throw std::runtime_error("Can't find ban list file " + ban_list + " - " + ec.message());
+        ban_list_contents = fetch_ban_list(ban_list);
       }
-
-      std::string banned_ips;
-      if (!epee::file_io_utils::load_file_to_string(ban_list_path.string(), banned_ips))
+      else
       {
-        throw std::runtime_error("Failed to read ban list file " + ban_list);
-      }
-
-      std::istringstream iss(banned_ips);
-      for (std::string line; std::getline(iss, line); )
-      {
-        // ignore comments after '#' character
-        const size_t pound_idx = line.find('#');
-        if (pound_idx != std::string::npos)
-          line.resize(pound_idx);
-
-        // trim whitespace and ignore empty lines
-        boost::trim(line);
-        if (line.empty())
-          continue;
-
-        auto subnet = net::get_ipv4_subnet_address(line);
-        if (subnet)
+        const boost::filesystem::path ban_list_path(ban_list);
+        boost::system::error_code ec;
+        if (!boost::filesystem::exists(ban_list_path, ec))
         {
-          block_subnet(*subnet, std::numeric_limits<time_t>::max());
-          continue;
+          throw std::runtime_error("Can't find ban list file " + ban_list + " - " + ec.message());
         }
-        const expect<epee::net_utils::network_address> parsed_addr = net::get_network_address(line, 0);
-        if (parsed_addr)
+
+        if (!epee::file_io_utils::load_file_to_string(ban_list_path.string(), ban_list_contents))
         {
-          block_host(*parsed_addr, std::numeric_limits<time_t>::max());
-          continue;
+          throw std::runtime_error("Failed to read ban list file " + ban_list);
         }
-        MERROR("Invalid IP address or IPv4 subnet: " << line);
       }
+
+      load_ban_list(ban_list_contents);
     }
 
     if(command_line::has_arg(vm, arg_p2p_hide_my_port))

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -58,6 +58,7 @@
 #include "cryptonote_core/cryptonote_core.h"
 #include "net/parse.h"
 #include "net/http_client.h"
+#include "net/http.h"
 #include "p2p/net_node.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -436,7 +437,7 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
-  std::string node_server<t_payload_net_handler>::fetch_ban_list(const std::string &url)
+  std::string node_server<t_payload_net_handler>::fetch_ban_list(const std::string &url, const std::string &proxy)
   {
     epee::net_utils::http::url_content u_c;
     if (!epee::net_utils::parse_url(url, u_c))
@@ -454,7 +455,16 @@ namespace nodetool
 
     const uint16_t port = u_c.port ? u_c.port : (https ? 443 : 80);
 
-    epee::net_utils::http::http_simple_client client;
+    // When a proxy is configured, route the fetch through it. The socks connector
+    // sends the hostname to the proxy (remote DNS), so neither the connection nor
+    // the name resolution reveals the operator's address to the list host.
+    net::http::client client;
+    if (!proxy.empty())
+    {
+      if (!net::socks::endpoint::get(proxy))
+        throw std::runtime_error("Failed to parse proxy address for ban list URL: " + proxy);
+      client.set_proxy(proxy);
+    }
     client.set_server(u_c.host, std::to_string(port), boost::none, std::move(ssl_options));
 
     const epee::net_utils::http::http_response_info *info = nullptr;
@@ -516,6 +526,7 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::handle_command_line(
       const boost::program_options::variables_map& vm
+    , const std::string& proxy
     )
   {
     bool testnet = command_line::get_arg(vm, cryptonote::arg_testnet_on);
@@ -603,7 +614,7 @@ namespace nodetool
       std::string ban_list_contents;
       if (is_ban_list_url(ban_list))
       {
-        ban_list_contents = fetch_ban_list(ban_list);
+        ban_list_contents = fetch_ban_list(ban_list, proxy);
       }
       else
       {
@@ -974,7 +985,7 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::init(const boost::program_options::variables_map& vm, const std::string& proxy, bool proxy_dns_leaks_allowed)
   {
-    bool res = handle_command_line(vm);
+    bool res = handle_command_line(vm, proxy);
     CHECK_AND_ASSERT_MES(res, false, "Failed to handle command line");
     if (proxy.size())
     {

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -38,6 +38,9 @@
 #include "unit_tests_utils.h"
 #include <condition_variable>
 #include <thread>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
 
 #define MAKE_IPV4_ADDRESS(a,b,c,d) epee::net_utils::ipv4_network_address{MAKE_IP(a,b,c,d),0}
 #define MAKE_IPV4_ADDRESS_PORT(a,b,c,d,e) epee::net_utils::ipv4_network_address{MAKE_IP(a,b,c,d),e}
@@ -45,6 +48,58 @@
 
 namespace
 {
+  // Serves a fixed body over plain HTTP on an ephemeral loopback port, for tests.
+  class scoped_http_file_server
+  {
+  public:
+    explicit scoped_http_file_server(std::string body)
+      : m_body(std::move(body))
+      , m_acceptor(m_ioc, boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0))
+    {
+      m_port = m_acceptor.local_endpoint().port();
+      do_accept();
+      m_thread = std::thread([this]{ m_ioc.run(); });
+    }
+    ~scoped_http_file_server()
+    {
+      m_ioc.stop(); // unblocks io_context::run() even while awaiting a connection
+      if (m_thread.joinable())
+        m_thread.join();
+    }
+    uint16_t port() const { return m_port; }
+  private:
+    void do_accept()
+    {
+      m_acceptor.async_accept([this](boost::system::error_code ec, boost::asio::ip::tcp::socket socket){
+        if (ec)
+          return;
+        serve(std::move(socket));
+        do_accept();
+      });
+    }
+    void serve(boost::asio::ip::tcp::socket socket)
+    {
+      namespace http = boost::beast::http;
+      boost::system::error_code ec;
+      boost::beast::flat_buffer buffer;
+      http::request<http::string_body> req;
+      http::read(socket, buffer, req, ec);
+      if (ec)
+        return;
+      http::response<http::string_body> res{http::status::ok, req.version()};
+      res.set(http::field::content_type, "text/plain");
+      res.body() = m_body;
+      res.prepare_payload();
+      http::write(socket, res, ec);
+      socket.shutdown(boost::asio::ip::tcp::socket::shutdown_send, ec);
+    }
+    std::string m_body;
+    boost::asio::io_context m_ioc{1};
+    boost::asio::ip::tcp::acceptor m_acceptor;
+    uint16_t m_port = 0;
+    std::thread m_thread;
+  };
+
   boost::filesystem::path create_temp_dir()
   {
     boost::system::error_code ec;
@@ -429,6 +484,134 @@ TEST(ban, file_banlist)
 
   // random IP
   EXPECT_FALSE( is_blocked(server, MAKE_IPV4_ADDRESS_PORT(145,036,205,235,9999)) );
+}
+
+TEST(ban, parse_ban_list_string)
+{
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  const auto node_dir = create_temp_dir();
+  ASSERT_TRUE(!node_dir.empty());
+  auto auto_remove_node_dir = epee::misc_utils::create_scope_leave_handler([&node_dir](){
+      boost::filesystem::remove_all(node_dir);
+    });
+
+  boost::program_options::variables_map vm;
+  boost::program_options::store(
+    boost::program_options::command_line_parser({
+      "--data-dir", node_dir.string()
+    }).options([]{
+      boost::program_options::options_description options_description{};
+      cryptonote::core::init_options(options_description);
+      Server::init_options(options_description);
+      return options_description;
+    }()).run(),
+    vm
+  );
+  ASSERT_TRUE(server.init(vm));
+
+  // host, subnet, inline comment, full-line comment, blank line, and an invalid line
+  const std::string ban_list =
+    "1.2.3.4            # a host\n"
+    "99.98.0.0/16       # a subnet\n"
+    "# a full-line comment\n"
+    "\n"
+    "not-an-ip-address  # ignored, logged as invalid\n";
+
+  const size_t applied = server.load_ban_list(ban_list);
+  EXPECT_EQ(2u, applied);
+
+  EXPECT_TRUE(  is_blocked(server, MAKE_IPV4_ADDRESS_PORT(1,2,3,4,9999)) );
+  EXPECT_TRUE(  is_blocked(server, MAKE_IPV4_ADDRESS_PORT(99,98,1,1,9999)) );
+  EXPECT_FALSE( is_blocked(server, MAKE_IPV4_ADDRESS_PORT(99,99,0,0,9999)) );
+}
+
+TEST(ban, url_banlist)
+{
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  const auto node_dir = create_temp_dir();
+  ASSERT_TRUE(!node_dir.empty());
+  auto auto_remove_node_dir = epee::misc_utils::create_scope_leave_handler([&node_dir](){
+      boost::filesystem::remove_all(node_dir);
+    });
+
+  std::string banlist;
+  ASSERT_TRUE(epee::file_io_utils::load_file_to_string(
+    (unit_test::data_dir / "node" / "banlist_1.txt").string(), banlist));
+  scoped_http_file_server http_server(banlist);
+  const std::string url = "http://127.0.0.1:" + std::to_string(http_server.port()) + "/block.txt";
+
+  boost::program_options::variables_map vm;
+  boost::program_options::store(
+    boost::program_options::command_line_parser({
+      "--data-dir", node_dir.string(),
+      "--ban-list", url
+    }).options([]{
+      boost::program_options::options_description options_description{};
+      cryptonote::core::init_options(options_description);
+      Server::init_options(options_description);
+      return options_description;
+    }()).run(),
+    vm
+  );
+
+  ASSERT_TRUE(server.init(vm));
+
+  // same matrix as ban.file_banlist (banlist_1.txt)
+  EXPECT_TRUE(  is_blocked(server, MAKE_IPV4_ADDRESS_PORT(255,255,255,0,9999)) );
+  EXPECT_TRUE(  is_blocked(server, MAKE_IPV4_ADDRESS_PORT(99,98,1,0,9999)) );
+  EXPECT_TRUE(  is_blocked(server, MAKE_IPV4_ADDRESS_PORT(1,2,3,4,9999)) );
+  EXPECT_TRUE(  is_blocked(server, MAKE_IPV4_ADDRESS_PORT(100,98,1,13,9999)) );
+  EXPECT_FALSE( is_blocked(server, MAKE_IPV4_ADDRESS_PORT(99,99,0,0,9999)) );
+  EXPECT_FALSE( is_blocked(server, MAKE_IPV4_ADDRESS_PORT(007,007,007,007,9999)) );
+}
+
+TEST(ban, url_banlist_unreachable)
+{
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  const auto node_dir = create_temp_dir();
+  ASSERT_TRUE(!node_dir.empty());
+  auto auto_remove_node_dir = epee::misc_utils::create_scope_leave_handler([&node_dir](){
+      boost::filesystem::remove_all(node_dir);
+    });
+
+  // Reserve an ephemeral port, then release it so the connection is refused.
+  uint16_t dead_port = 0;
+  {
+    boost::asio::io_context ioc;
+    boost::asio::ip::tcp::acceptor acceptor(ioc,
+      boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0));
+    dead_port = acceptor.local_endpoint().port();
+  }
+  const std::string url = "http://127.0.0.1:" + std::to_string(dead_port) + "/block.txt";
+
+  boost::program_options::variables_map vm;
+  boost::program_options::store(
+    boost::program_options::command_line_parser({
+      "--data-dir", node_dir.string(),
+      "--ban-list", url
+    }).options([]{
+      boost::program_options::options_description options_description{};
+      cryptonote::core::init_options(options_description);
+      Server::init_options(options_description);
+      return options_description;
+    }()).run(),
+    vm
+  );
+
+  // Fetch failure must be fatal: handle_command_line throws, init propagates.
+  EXPECT_ANY_THROW(server.init(vm));
 }
 
 TEST(node_server, bind_same_p2p_port)

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -614,6 +614,38 @@ TEST(ban, url_banlist_unreachable)
   EXPECT_ANY_THROW(server.init(vm));
 }
 
+TEST(ban, url_banlist_bad_proxy)
+{
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  const auto node_dir = create_temp_dir();
+  ASSERT_TRUE(!node_dir.empty());
+  auto auto_remove_node_dir = epee::misc_utils::create_scope_leave_handler([&node_dir](){
+      boost::filesystem::remove_all(node_dir);
+    });
+
+  boost::program_options::variables_map vm;
+  boost::program_options::store(
+    boost::program_options::command_line_parser({
+      "--data-dir", node_dir.string(),
+      "--ban-list", "http://127.0.0.1:1/block.txt"
+    }).options([]{
+      boost::program_options::options_description options_description{};
+      cryptonote::core::init_options(options_description);
+      Server::init_options(options_description);
+      return options_description;
+    }()).run(),
+    vm
+  );
+
+  // A malformed proxy must abort before any network access, so the URL host is
+  // never contacted directly and no IP leaks.
+  EXPECT_ANY_THROW(server.init(vm, "this_is_not_a_proxy"));
+}
+
 TEST(node_server, bind_same_p2p_port)
 {
   struct test_data_t


### PR DESCRIPTION
Implements the `--ban-list` URL support proposed and discussed in #10763. That issue covers the motivation (pointing a node at a maintained remote list and fetching the current version on each startup), the design decisions (in-memory, fetch once, strict TLS, fatal on failure), and the relationship to the adjacent PRs #10595, #10747, and #9591.

### What

Extends `--ban-list` to accept an `http://` or `https://` URL in addition to a local file path. When the value carries an http(s) scheme, the list is fetched once at startup, validated, and parsed by the same per-line parser used for local files. A local path behaves exactly as before.

### Behavior

The fetched list is held in memory and never written to disk, so each startup uses a fresh copy and there is no cache to manage across restarts.

For `https`, the server certificate is verified against the system trust store. An operator-supplied URL has no signed payload or DNS hash quorum, so certificate verification is the integrity check.

Any failure to obtain a usable list is fatal and aborts startup, matching the existing behavior for a missing or unreadable file. Failures include a malformed URL, a failed connection, a non-200 response, an empty body, and a body larger than a fixed 10 MiB cap.

Per-line parsing is unchanged: `#` comments, whitespace trimming, blank-line skipping, IPv4 addresses, IPv4 subnets, and single IPv6 addresses are handled as before. IPv6 subnets remain unsupported, as on the existing file path (noted as a possible follow-up in #10763).

### Implementation

The per-line parser is moved out of `handle_command_line` into a `load_ban_list` member so the file and URL paths share one implementation. URL detection is a scheme-prefix check, and the fetch uses epee's `http_simple_client`.

### Tests

unit_tests `ban` suite:
- `parse_ban_list_string` exercises the parser on hosts, subnets, comments, blank lines, and an invalid line.
- `url_banlist` performs an end-to-end fetch over a local HTTP server and asserts the same block matrix as the existing file test.
- `url_banlist_unreachable` confirms an unreachable URL aborts startup.

Manually verified against the built daemon: `--ban-list https://gui.xmr.pm/files/block.txt` loaded 1161 entries over verified TLS, a 404 URL and a refused connection each aborted startup with a clear message, and a local file path continued to work unchanged.
