### PR TITLE
depends: boost: remove headers of unused libraries

### DIFF
--- a/contrib/depends/packages/boost.mk
+++ b/contrib/depends/packages/boost.mk
@@ -41,3 +41,78 @@ endef
 define $(package)_stage_cmds
   ./b2 -d0 -j4 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) install
 endef
+
+ifeq ($(release_type),release)
+define $(package)_postprocess_cmds
+  cd include/boost && \
+  find . -mindepth 1 -maxdepth 1 -type d \
+    ! -name algorithm \
+    ! -name align \
+    ! -name any \
+    ! -name archive \
+    ! -name asio \
+    ! -name assert \
+    ! -name atomic \
+    ! -name bimap \
+    ! -name bind \
+    ! -name chrono \
+    ! -name circular_buffer \
+    ! -name concept \
+    ! -name config \
+    ! -name container \
+    ! -name container_hash \
+    ! -name core \
+    ! -name date_time \
+    ! -name describe \
+    ! -name detail \
+    ! -name endian \
+    ! -name exception \
+    ! -name filesystem \
+    ! -name format \
+    ! -name function \
+    ! -name function_types \
+    ! -name functional \
+    ! -name fusion \
+    ! -name integer \
+    ! -name intrusive \
+    ! -name io \
+    ! -name iostreams \
+    ! -name iterator \
+    ! -name lambda \
+    ! -name lexical_cast \
+    ! -name locale \
+    ! -name logic \
+    ! -name math \
+    ! -name move \
+    ! -name mp11 \
+    ! -name mpl \
+    ! -name multi_index \
+    ! -name multiprecision \
+    ! -name numeric \
+    ! -name optional \
+    ! -name phoenix \
+    ! -name predef \
+    ! -name preprocessor \
+    ! -name program_options \
+    ! -name proto \
+    ! -name range \
+    ! -name ratio \
+    ! -name regex \
+    ! -name serialization \
+    ! -name smart_ptr \
+    ! -name spirit \
+    ! -name system \
+    ! -name thread \
+    ! -name tuple \
+    ! -name type_index \
+    ! -name type_traits \
+    ! -name typeof \
+    ! -name unordered \
+    ! -name utility \
+    ! -name uuid \
+    ! -name variant \
+    ! -name variant2 \
+    ! -name winapi \
+    -exec rm -rf {} +
+endef
+endif


### PR DESCRIPTION
- This removes 79 out of 146 libraries.
- Boost depends cache archive: `19.2 MB -> 11.0 MB (-43%)`
- Extracted size: `164 MB -> 105 MB (-36%)`
- Saves about: `10 targets * 8.2 MB = 82 MB` of GitHub actions cache per run.

This essentially creates a whitelist of Boost libraries for release builds. It prevents us from unintentionally introducing new dependencies on Boost libraries without warning. We can always choose to add libraries to the list if desired. The point is that we'll have a record of when that happens.

It might also motivate us to reduce our dependency on Boost a bit, because I really wish this list was shorter..

I ran builds with and without this patch and compared the binaries, there are no differences.