### PR TITLE
readme: refresh stale info and remove dead sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Monero
 
-Copyright (c) 2014-2024, The Monero Project
+Copyright (c) 2014-2026, The Monero Project
 Portions Copyright (c) 2012-2013 The Cryptonote developers.
 
 ## Table of Contents
@@ -9,18 +9,18 @@ Portions Copyright (c) 2012-2013 The Cryptonote developers.
   - [Vulnerability response](#vulnerability-response)
   - [Research](#research)
   - [Announcements](#announcements)
-  - [Translations](#translations)
-  - [Coverage](#coverage)
   - [Introduction](#introduction)
   - [About this project](#about-this-project)
   - [Supporting the project](#supporting-the-project)
   - [License](#license)
   - [Contributing](#contributing)
-  - [Scheduled software upgrades](#scheduled-softwarenetwork-upgrades)
+  - [Scheduled software/network upgrades](#scheduled-softwarenetwork-upgrades)
   - [Release staging schedule and protocol](#release-staging-schedule-and-protocol)
   - [Compiling Monero from source](#compiling-monero-from-source)
     - [Dependencies](#dependencies)
     - [Guix builds](#guix-builds)
+  - [Installing Monero from a package](#installing-monero-from-a-package)
+  - [Running monerod](#running-monerod)
   - [Internationalization](#Internationalization)
   - [Using Tor](#using-tor)
   - [Pruning](#Pruning)
@@ -39,6 +39,8 @@ Portions Copyright (c) 2012-2013 The Cryptonote developers.
 
 - Our [Vulnerability Response Process](https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md) encourages responsible disclosure
 - We are also available via [HackerOne](https://hackerone.com/monero)
+- Monero is continuously fuzzed by [OSS-Fuzz](https://introspector.oss-fuzz.com/project-profile?project=monero)
+
 
 ## Research
 
@@ -49,21 +51,6 @@ The Monero research community is available on IRC in [#monero-research-lab on Li
 ## Announcements
 
 - You can subscribe to an [announcement listserv](https://lists.getmonero.org) to get critical announcements from the Monero core team. The announcement list can be very helpful for knowing when software updates are needed.
-
-## Translations
-The CLI wallet is available in different languages. If you want to help translate it, see our self-hosted localization platform, Weblate, on [translate.getmonero.org]( https://translate.getmonero.org/projects/monero/cli-wallet/). Every translation *must* be uploaded on the platform, pull requests directly editing the code in this repository will be closed. If you need help with Weblate, you can find a guide with screenshots [here](https://github.com/monero-ecosystem/monero-translations/blob/master/weblate.md).
-&nbsp;
-
-If you need help/support/info about translations, contact the localization workgroup. You can find the complete list of contacts on the repository of the workgroup: [monero-translations](https://github.com/monero-ecosystem/monero-translations#contacts).
-
-## Coverage
-
-| Type      | Status |
-|-----------|--------|
-| Coverity  | [![Coverity Status](https://scan.coverity.com/projects/9657/badge.svg)](https://scan.coverity.com/projects/9657/)
-| OSS Fuzz  | [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/monero.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:monero)
-| Coveralls | [![Coveralls Status](https://coveralls.io/repos/github/monero-project/monero/badge.svg?branch=master)](https://coveralls.io/github/monero-project/monero?branch=master)
-| License   | [![License](https://img.shields.io/badge/license-BSD3-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 ## Introduction
 
@@ -94,16 +81,18 @@ The Monero donation address is:
 Viewkey:  
 `f359631075708155cc3d92a32b75a7d02a5dcf27756707b47a2b31b21c389501`  
 Base address for restoring with address and viewkey:
-`44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A`  
+`44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A`
 
 The Bitcoin donation address is:  
 `1KTexdemPdxSBcG55heUuTjDRYqbC5ZL8H`
 
 Core development funding and/or some supporting services are also graciously provided by [sponsors](https://www.getmonero.org/community/sponsorships/):
 
-[<img width="150" src="https://www.getmonero.org/img/sponsors/tarilabs.png"/>](https://tarilabs.com/)
-[<img width="150" src="https://www.getmonero.org/img/sponsors/symas.png"/>](https://symas.com/)
-[<img width="150" src="https://www.getmonero.org/img/sponsors/macstadium.png"/>](https://www.macstadium.com/)
+[<img height="26" hspace="6" src="https://www.getmonero.org/img/sponsors/tarilabs.png"/>](https://tarilabs.com/)
+[<img height="30" hspace="6" src="https://www.getmonero.org/img/sponsors/macstadium.png"/>](https://www.macstadium.com/)
+[<img height="26" hspace="6" src="https://www.getmonero.org/img/sponsors/cakewallet.png"/>](https://cakewallet.com/)
+[<img height="30" hspace="6" src="https://www.getmonero.org/img/sponsors/symas.png"/>](https://symas.com/)
+[<img height="30" hspace="6" src="https://www.getmonero.org/img/sponsors/cypherstack.png"/>](https://cypherstack.com/)
 
 There are also several mining pools that kindly donate a portion of their fees, [a list of them can be found on our Bitcointalk post](https://bitcointalk.org/index.php?topic=583449.0).
 
@@ -120,7 +109,6 @@ If you want to help out, see [CONTRIBUTING](docs/CONTRIBUTING.md) for a set of g
 Monero uses a scheduled software/network upgrade (hard fork) mechanism to implement new features into the Monero software and network. This means that users of Monero (end users and service providers) should run current versions and upgrade their software when new releases are available. Software upgrades occur when new features are developed and implemented in the codebase. Network upgrades occur in tandem with software upgrades that modify the consensus rules of the Monero network. The required software for network upgrades will be available prior to the scheduled network upgrade date. Please check the repository prior to this date for the proper Monero software version. Below is the historical schedule and the projected schedule for the next upgrade.
 
 Dates are provided in the format YYYY-MM-DD. The "Minimum" is the software version that follows the new consensus rules. The "Recommended" version may include bug fixes and other new features that do not affect the consensus rules.
-
 
 | Software upgrade block height  | Date       | Fork version      | Minimum Monero version | Recommended Monero version | Details                                                                            |
 | ------------------------------ | -----------| ----------------- | ---------------------- | -------------------------- | ---------------------------------------------------------------------------------- |
@@ -212,7 +200,7 @@ Install all dependencies at once on macOS with the provided Brewfile:
 brew update && brew bundle --file=contrib/brew/Brewfile
 ```
 
-FreeBSD 12.1 one-liner required to build dependencies:
+FreeBSD one-liner required to build dependencies:
 
 ```
 pkg install git gmake cmake pkgconf boost-libs libzmq4 libsodium unbound
@@ -232,7 +220,7 @@ If you already have a repo cloned, initialize and update:
 cd monero && git submodule init && git submodule update
 ```
 
-*Note*: If there are submodule differences between branches, you may need 
+*Note*: If there are submodule differences between branches, you may need
 to use `git submodule sync && git submodule update` after changing branches
 to build successfully.
 
@@ -306,8 +294,8 @@ Tested on a Raspberry Pi 5B with a clean installation of Raspberry Pi OS (64-bit
 * **Optional**: increase the system swap size:
 
     ```bash
-    sudo /etc/init.d/dphys-swapfile stop  
-    sudo nano /etc/dphys-swapfile  
+    sudo /etc/init.d/dphys-swapfile stop
+    sudo nano /etc/dphys-swapfile
     CONF_SWAPSIZE=2048
     sudo /etc/init.d/dphys-swapfile start
     ```
@@ -396,7 +384,6 @@ application.
 
    The resulting executables can be found in `build/release/bin`
 
-
 * **Optional**: to build Windows binaries suitable for debugging, run:
 
     ```bash
@@ -407,7 +394,7 @@ application.
 
 ### On FreeBSD:
 
-The project can be built from scratch by following instructions for Linux above(but use `gmake` instead of `make`). 
+The project can be built from scratch by following instructions for Linux above (but use `gmake` instead of `make`).
 If you are running Monero in a jail, you need to add `sysvsem="new"` to your jail configuration, otherwise lmdb will throw the error message: `Failed to open lmdb environment: Function not implemented`.
 
 Monero is also available as a port or package as `monero-cli`.
@@ -432,11 +419,11 @@ Then you need to increase the data ulimit size to 2GB and try again: `ulimit -d 
 
 ### On NetBSD:
 
-Check that the dependencies are present: `pkg_info -c libexecinfo boost-headers boost-libs protobuf readline libusb1 zeromq git-base pkgconf gmake cmake | more`, and install any that are reported missing, using `pkg_add` or from your pkgsrc tree.  Readline is optional but worth having.
+Check that the dependencies are present: `pkg_info -c libexecinfo boost-headers boost-libs protobuf readline libusb1 zeromq git-base pkgconf gmake cmake | more`, and install any that are reported missing, using `pkg_add` or from your pkgsrc tree. Readline is optional but worth having.
 
 Third-party dependencies are usually under `/usr/pkg/`, but if you have a custom setup, adjust the "/usr/pkg" (below) accordingly.
 
-Clone the monero repository recursively and checkout the most recent release as described above. Then build monero: `gmake BOOST_ROOT=/usr/pkg LDFLAGS="-Wl,-R/usr/pkg/lib" release`.  The resulting executables can be found in `build/NetBSD/[Release version]/Release/bin/`.
+Clone the monero repository recursively and checkout the most recent release as described above. Then build monero: `gmake BOOST_ROOT=/usr/pkg LDFLAGS="-Wl,-R/usr/pkg/lib" release`. The resulting executables can be found in `build/NetBSD/[Release version]/Release/bin/`.
 
 ### On Solaris:
 
@@ -455,39 +442,38 @@ Then you can run make as usual.
 
 You can also cross-compile static binaries on Linux for Windows and macOS with the `depends` system.
 
-* ```make depends target=x86_64-linux-gnu``` for 64-bit linux binaries.
-* ```make depends target=x86_64-w64-mingw32``` for 64-bit windows binaries.
+* `make depends target=x86_64-linux-gnu` for 64-bit linux binaries.
+* `make depends target=x86_64-w64-mingw32` for 64-bit windows binaries.
   * Requires: `g++-mingw-w64-x86-64`
   * You also need to run:
     ```shell
     update-alternatives --set x86_64-w64-mingw32-g++ $(which x86_64-w64-mingw32-g++-posix) && \
     update-alternatives --set x86_64-w64-mingw32-gcc $(which x86_64-w64-mingw32-gcc-posix)
     ```
-* ```make depends target=x86_64-apple-darwin``` for Intel macOS binaries.
-  * Requires: `clang-18 lld-18`
-* ```make depends target=arm64-apple-darwin``` for Apple Silicon macOS binaries.
-  * Requires: `clang-18 lld-18`
+* `make depends target=x86_64-apple-darwin` for Intel macOS binaries.
+  * Requires: `clang-19 lld-19`
+* `make depends target=arm64-apple-darwin` for Apple Silicon macOS binaries.
+  * Requires: `clang-19 lld-19`
   * You also need to run:
     ```shell
-    export PATH="/usr/lib/llvm-18/bin/:$PATH"
+    export PATH="/usr/lib/llvm-19/bin/:$PATH"
     ```
-* ```make depends target=i686-linux-gnu``` for 32-bit linux binaries.
+* `make depends target=i686-linux-gnu` for 32-bit linux binaries.
   * Requires: `g++-multilib bc`
-* ```make depends target=i686-w64-mingw32``` for 32-bit windows binaries.
+* `make depends target=i686-w64-mingw32` for 32-bit windows binaries.
   * Requires: `python3 g++-mingw-w64-i686`
-* ```make depends target=arm-linux-gnueabihf``` for armv7 binaries.
+* `make depends target=arm-linux-gnueabihf` for armv7 binaries.
   * Requires: `g++-arm-linux-gnueabihf`
-* ```make depends target=aarch64-linux-gnu``` for armv8 binaries.
+* `make depends target=aarch64-linux-gnu` for armv8 binaries.
   * Requires: `g++-aarch64-linux-gnu`
-* ```make depends target=riscv64-linux-gnu``` for RISC V 64 bit binaries.
+* `make depends target=riscv64-linux-gnu` for RISC V 64 bit binaries.
   * Requires: `g++-riscv64-linux-gnu`
-* ```make depends target=x86_64-unknown-freebsd``` for freebsd binaries.
-  * Requires: `clang-8`
-* ```make depends target=arm-linux-android``` for 32bit android binaries
-* ```make depends target=aarch64-linux-android``` for 64bit android binaries
+* `make depends target=x86_64-unknown-freebsd` for freebsd binaries.
+  * Requires: `clang`
+* `make depends target=arm-linux-android` for 32bit android binaries
+* `make depends target=aarch64-linux-android` for 64bit android binaries
 
-
-The required packages are the names for each toolchain on apt. Depending on your distro, they may have different names. The `depends` system has been tested on Ubuntu 18.04 and 20.04.
+The required packages are the names for each toolchain on apt. Depending on your distro, they may have different names.
 
 Using `depends` might also be easier to compile Monero on Windows than using MSYS. Activate Windows Subsystem for Linux (WSL) with a distro (for example Ubuntu), install the apt build-essentials and follow the `depends` steps as depicted above.
 
@@ -495,7 +481,7 @@ The produced binaries still link libc dynamically. If the binary is compiled on 
 
 ### Trezor hardware wallet support
 
-If you have an issue with building Monero with Trezor support, you can disable it by setting `USE_DEVICE_TREZOR=OFF`, e.g., 
+If you have an issue with building Monero with Trezor support, you can disable it by setting `USE_DEVICE_TREZOR=OFF`
 
 ```bash
 USE_DEVICE_TREZOR=OFF make release
@@ -520,7 +506,6 @@ Packages are available for
     ```
   More info and versions in the [Debian package tracker](https://tracker.debian.org/pkg/monero).
 
-
 * Arch Linux:
 
     ```bash
@@ -537,16 +522,6 @@ Packages are available for
 
     ```bash
     guix package -i monero
-    ```
-
-* Gentoo [Monero overlay](https://github.com/gentoo-monero/gentoo-monero)
-
-    ```bash
-    emerge --noreplace eselect-repository
-    eselect repository enable monero
-    emaint sync -r monero
-    echo '*/*::monero ~amd64' >> /etc/portage/package.accept_keywords
-    emerge net-p2p/monero
     ```
 
 * Alpine Linux:
@@ -585,9 +560,9 @@ foreground:
 ./bin/monerod
 ```
 
-To list all available options, run `./bin/monerod --help`.  Options can be
+To list all available options, run `./bin/monerod --help`. Options can be
 specified either on the command line or in a configuration file passed by the
-`--config-file` argument.  To specify an option in the configuration file, add
+`--config-file` argument. To specify an option in the configuration file, add
 a line with the syntax `argumentname=value`, where `argumentname` is the name
 of the argument without the leading dashes, for example, `log-level=1`.
 
@@ -650,7 +625,7 @@ DNS_PUBLIC=tcp torsocks ./monerod --p2p-bind-ip 127.0.0.1 --rpc-bind-ip 127.0.0.
 
 ## Pruning
 
-As of April 2022, the full Monero blockchain file is about 130 GB. One can store a pruned blockchain, which is about 45 GB.
+As of June 2026, the full Monero blockchain file is about 280 GB. One can store a pruned blockchain, which is about 95 GB.
 A pruned blockchain can only serve part of the historical chain data to other peers, but is otherwise identical in
 functionality to the full blockchain.
 To use a pruned blockchain, it is best to start the initial sync with `--prune-blockchain`. However, it is also possible
@@ -693,7 +668,7 @@ When it terminates with an output along the lines of "Segmentation fault (core d
 You can now analyse this core dump with `gdb` as follows:
 
 ```bash
-gdb /path/to/monerod /path/to/dumpfile`
+gdb /path/to/monerod /path/to/dumpfile
 ```
 
 Print the stack trace with `bt`
@@ -754,11 +729,11 @@ These records are dumped as hex data, where the first line is the key and the se
 
 Because of the nature of the socket-based protocols that drive monero, certain protocol weaknesses are somewhat unavoidable at this time. While these weaknesses can theoretically be fully mitigated, the effort required (the means) may not justify the ends. As such, please consider taking the following precautions if you are a monero node operator:
 
-- Run `monerod` on a "secured" machine. If operational security is not your forte, at a very minimum, have a dedicated a computer running `monerod` and **do not** browse the web, use email clients, or use any other potentially harmful apps on your `monerod` machine. **Do not click links or load URL/MUA content on the same machine**. Doing so may potentially exploit weaknesses in commands which accept "localhost" and "127.0.0.1".
+- Run `monerod` on a "secured" machine. If operational security is not your forte, at a very minimum, have a dedicated computer running `monerod` and **do not** browse the web, use email clients, or use any other potentially harmful apps on your `monerod` machine. **Do not click links or load URL/MUA content on the same machine**. Doing so may potentially exploit weaknesses in commands which accept "localhost" and "127.0.0.1".
 - If you plan on hosting a public "remote" node, start `monerod` with `--restricted-rpc`. This is a must.
 
 ### Blockchain-based
 
-Certain blockchain "features" can be considered "bugs" if misused correctly. Consequently, please consider the following:
+Certain blockchain "features" can be considered "bugs" if misused. Consequently, please consider the following:
 
 - When receiving monero, be aware that it may be locked for an arbitrary time if the sender elected to, preventing you from spending that monero until the lock time expires. You may want to hold off acting upon such a transaction until the unlock time lapses. To get a sense of that time, you can consider the remaining blocktime until unlock as seen in the `show_transfers` command.


### PR DESCRIPTION
Few nits changes and notably:

- Bump depends macOS toolchain clang-18/lld-18 -> clang-19/lld-19 and the llvm-18 PATH -> llvm-19 to match .github/workflows/depends.yml; FreeBSD depends clang-8 -> clang
- Remove dead content: Gentoo install steps (closing #9810) and the whole Coverage section
- Update blockchain size figures (full ~130 -> ~280 GB, pruned ~45 -> ~95 GB)
- Add Cake Wallet and Cypher Stack to the sponsors list to match the getmonero.org sponsorships page, reorder to match it, and size every logo by a fixed height so they render at a consistent size

Let me know for pruned chain size, not sure it's accurate