### PR TITLE
trezor: stop warning about deprecations we don't control

### DIFF
--- a/cmake/CheckTrezor.cmake
+++ b/cmake/CheckTrezor.cmake
@@ -152,6 +152,18 @@ if(Protobuf_FOUND AND USE_DEVICE_TREZOR)
         file(WRITE "${_proto_out_dir}/messages-monero.pb.h" "${updated_content}")
     endif()
 
+    set(_deprecated_enum_files
+            "messages-common.pb.h"
+            "messages-management.pb.h"
+    )
+
+    foreach(file IN LISTS _deprecated_enum_files)
+        file(READ "${_proto_out_dir}/${file}" file_content)
+        string(REPLACE "PROTOBUF_DEPRECATED_ENUM" ""
+                updated_content "${file_content}")
+        file(WRITE "${_proto_out_dir}/${file}" "${updated_content}")
+    endforeach ()
+
     message(STATUS "Trezor: protobuf messages regenerated out.")
     set(DEVICE_TREZOR_READY 1)
     add_definitions(-DDEVICE_TREZOR_READY=1)


### PR DESCRIPTION
```
[13/15] Building CXX object src/wallet/CMakeFiles/obj_wallet.dir/wallet2.cpp.o
In file included from /monero/src/device_trezor/trezor/transport.hpp:52,
                 from /monero/src/device_trezor/trezor.hpp:36,
                 from /monero/src/device_trezor/device_trezor.hpp:33,
                 from /monero/src/wallet/wallet2.cpp:94:
/monero/src/device_trezor/trezor/messages/messages-common.pb.h:774:5: warning: ‘hw::trezor::messages::common::ButtonRequest_ButtonRequestType__Deprecated_ButtonRequest_PassphraseType’ is deprecated [-Wdeprecated-declarations]
  774 |     ButtonRequest_ButtonRequestType__Deprecated_ButtonRequest_PassphraseType;
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/monero/src/device_trezor/trezor/messages/messages-common.pb.h:168:3: note: declared here
  168 |   ButtonRequest_ButtonRequestType__Deprecated_ButtonRequest_PassphraseType PROTOBUF_DEPRECATED_ENUM = 14,
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /monero/src/device_trezor/trezor/transport.hpp:53:
/monero/src/device_trezor/trezor/messages/messages-management.pb.h:864:5: warning: ‘hw::trezor::messages::management::Features_Capability_Capability_Lisk’ is deprecated [-Wdeprecated-declarations]
  864 |     Features_Capability_Capability_Lisk;
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/monero/src/device_trezor/trezor/messages/messages-management.pb.h:230:3: note: declared here
  230 |   Features_Capability_Capability_Lisk PROTOBUF_DEPRECATED_ENUM = 8,
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This gets spammed 7 times in a row. You would think there is a `protoc` flag to turn this madness off, there is not.