### PR TITLE
cmake: add build translations option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,6 +410,7 @@ endif()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 enable_testing()
 
+option(BUILD_TRANSLATIONS "Build translations using lrelease (Qt)" OFF)
 option(BUILD_DOCUMENTATION "Build the Doxygen documentation." ON)
 option(BUILD_TESTS "Build tests." OFF)
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -632,8 +633,9 @@ function (monero_add_library_with_deps)
     PRIVATE $<TARGET_PROPERTY:${MONERO_ADD_LIBRARY_NAME},INTERFACE_COMPILE_DEFINITIONS>)
 endfunction ()
 
+if(BUILD_TRANSLATIONS)
 # Generate header for embedded translations
-# Generate header for embedded translations, use target toolchain if depends, otherwise use the
+# use target toolchain if depends, otherwise use the
 # lrelease and lupdate binaries from the host
 include(ExternalProject)
 ExternalProject_Add(generate_translations_header
@@ -643,6 +645,8 @@ ExternalProject_Add(generate_translations_header
   CMAKE_ARGS -DLRELEASE_PATH=${LRELEASE_PATH}
   INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "")
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/translations")
+endif()
+
 add_subdirectory(external)
 
 # Final setup for libunbound

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -61,8 +61,12 @@ monero_private_headers(common
 monero_add_library(common
   ${common_sources}
   ${common_headers}
-  ${common_private_headers}
-  DEPENDS generate_translations_header)
+  ${common_private_headers})
+
+if(BUILD_TRANSLATIONS)
+  add_dependencies(obj_common generate_translations_header)
+endif()
+
 target_link_libraries(common
   PUBLIC
     cncrypto

--- a/src/common/i18n.cpp
+++ b/src/common/i18n.cpp
@@ -33,7 +33,14 @@
 #include <map>
 #include "file_io_utils.h"
 #include "common/i18n.h"
+
+#if __has_include("translation_files.h")
 #include "translation_files.h"
+#else
+static bool find_embedded_file(const std::string &name, std::string &data) {
+  return false;
+}
+#endif
 
 #include <boost/system/error_code.hpp>
 #include <boost/filesystem.hpp>


### PR DESCRIPTION
```
[  0%] Creating directories for 'generate_translations_header'
[  0%] No download step for 'generate_translations_header'
[  0%] No update step for 'generate_translations_header'
[  0%] No patch step for 'generate_translations_header'
[  0%] Performing configure step for 'generate_translations_header'
-- The C compiler identification is GNU 14.3.0
-- The CXX compiler identification is GNU 14.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/user/.guix-profile/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /home/user/.guix-profile/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Warning at CMakeLists.txt:53 (message):
  lrelease program not found, translation files not built                                                                                                                                             
                                                                                                                                                                                                      
                                                                                                                                                                                                      
-- Configuring done (0.2s)
-- Generating done (0.0s)
-- Build files have been written to: /distsrc-base/build/distsrc-6476ec8f2ce3-x86_64-linux-gnu/build/translations
[  1%] Performing build step for 'generate_translations_header'
[ 50%] Building C object CMakeFiles/generate_translations_header.dir/generate_translations_header.c.o
[100%] Linking C executable generate_translations_header
Generating embedded translations header
[100%] Built target generate_translations_header
[  2%] Performing install step for 'generate_translations_header'

[  2%] Completed 'generate_translations_header'
[  2%] Built target generate_translations_header
```

No more!