### PR TITLE
wallet_rpc: replace wallet2 with Wallet API

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -82,7 +82,7 @@ if(NOT IOS)
 
   target_link_libraries(wallet_rpc_server
     PRIVATE
-      wallet
+      wallet_api
       rpc_base
       cryptonote_core
       cncrypto

--- a/src/wallet/api/CMakeLists.txt
+++ b/src/wallet/api/CMakeLists.txt
@@ -33,6 +33,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(wallet_api_sources
   wallet.cpp
   wallet_manager.cpp
+  enote_details.cpp
   transaction_info.cpp
   transaction_history.cpp
   pending_transaction.cpp
@@ -48,6 +49,7 @@ set(wallet_api_headers
 set(wallet_api_private_headers
   wallet.h
   wallet_manager.h
+  enote_details.h
   transaction_info.h
   transaction_history.h
   pending_transaction.h

--- a/src/wallet/api/address_book.cpp
+++ b/src/wallet/api/address_book.cpp
@@ -70,6 +70,31 @@ bool AddressBookImpl::addRow(const std::string &dst_addr , const std::string &pa
   return r;
 }
 
+bool AddressBookImpl::setAddress(std::size_t index, const std::string &address)
+{
+    clearStatus();
+
+    const auto ab = m_wallet->m_wallet->get_address_book();
+    if (index >= ab.size()){
+        return false;
+    }
+
+    cryptonote::address_parse_info info;
+    if (!cryptonote::get_account_address_from_str(info, m_wallet->m_wallet->nettype(), address)) {
+      m_errorString = tr("Invalid destination address");
+      m_errorCode = Invalid_Address;
+      return false;
+    }
+
+    tools::wallet2::address_book_row entry = ab[index];
+    bool r =  m_wallet->m_wallet->set_address_book_row(index, info.address, info.has_payment_id ? &info.payment_id : nullptr, entry.m_description, info.is_subaddress);
+    if (r)
+        refresh();
+    else
+        m_errorCode = General_Error;
+    return r;
+}
+
 bool AddressBookImpl::setDescription(std::size_t index, const std::string &description)
 {
     clearStatus();

--- a/src/wallet/api/address_book.h
+++ b/src/wallet/api/address_book.h
@@ -45,6 +45,7 @@ public:
     void refresh() override;
     std::vector<AddressBookRow*> getAll() const override;
     bool addRow(const std::string &dst_addr , const std::string &payment_id, const std::string &description) override;
+    bool setAddress(std::size_t index, const std::string &address) override;
     bool setDescription(std::size_t index, const std::string &description) override;
     bool deleteRow(std::size_t rowId) override;
      

--- a/src/wallet/api/enote_details.cpp
+++ b/src/wallet/api/enote_details.cpp
@@ -36,13 +36,14 @@ EnoteDetails::~EnoteDetails() {}
 
 EnoteDetailsImpl::EnoteDetailsImpl():
     m_block_height(0),
+    m_unlock_time(0),
     m_internal_enote_index(0),
     m_global_enote_index(0),
     m_spent(false),
     m_frozen(false),
     m_spent_height(0),
     m_amount(0),
-    m_protocol_version(TxProtocol_CryptoNote),
+    m_protocol_version(TxProtocol::TxProtocol_CryptoNote),
     m_key_image_known(false),
     m_key_image_request(false),
     m_pk_index(0),
@@ -56,8 +57,14 @@ std::string EnoteDetailsImpl::onetimeAddress() const
 { return m_onetime_address; }
 std::string EnoteDetailsImpl::viewTag() const
 { return m_view_tag; }
+std::string EnoteDetailsImpl::paymentId() const
+{ return m_payment_id; }
 std::uint64_t EnoteDetailsImpl::blockHeight() const
 { return m_block_height; }
+std::uint64_t EnoteDetailsImpl::unlockTime() const
+{ return m_unlock_time; }
+bool EnoteDetailsImpl::isUnlocked() const
+{ return m_is_unlocked; }
 std::string EnoteDetailsImpl::txId() const
 { return m_tx_id; }
 std::uint64_t EnoteDetailsImpl::internalEnoteIndex() const
@@ -86,9 +93,13 @@ std::uint64_t EnoteDetailsImpl::pkIndex() const
 { return m_pk_index; }
 std::vector<std::pair<std::uint64_t, std::string>> EnoteDetailsImpl::uses() const
 { return m_uses; }
+std::uint32_t EnoteDetailsImpl::subaddressIndexMajor() const
+{ return m_subaddress_index_major; }
+std::uint32_t EnoteDetailsImpl::subaddressIndexMinor() const
+{ return m_subaddress_index_minor; }
 
 // Multisig
 bool EnoteDetailsImpl::isKeyImagePartial() const
 { return m_key_image_partial; }
 
-} // namespace
+} // namespace Monero

--- a/src/wallet/api/enote_details.cpp
+++ b/src/wallet/api/enote_details.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2014-2025, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "enote_details.h"
+
+
+namespace Monero {
+
+EnoteDetails::~EnoteDetails() {}
+
+
+EnoteDetailsImpl::EnoteDetailsImpl():
+    m_block_height(0),
+    m_internal_enote_index(0),
+    m_global_enote_index(0),
+    m_spent(false),
+    m_frozen(false),
+    m_spent_height(0),
+    m_amount(0),
+    m_protocol_version(TxProtocol_CryptoNote),
+    m_key_image_known(false),
+    m_key_image_request(false),
+    m_pk_index(0),
+    m_key_image_partial(false)
+{
+}
+
+EnoteDetailsImpl::~EnoteDetailsImpl() {}
+
+std::string EnoteDetailsImpl::onetimeAddress() const
+{ return m_onetime_address; }
+std::string EnoteDetailsImpl::viewTag() const
+{ return m_view_tag; }
+std::uint64_t EnoteDetailsImpl::blockHeight() const
+{ return m_block_height; }
+std::string EnoteDetailsImpl::txId() const
+{ return m_tx_id; }
+std::uint64_t EnoteDetailsImpl::internalEnoteIndex() const
+{ return m_internal_enote_index; }
+std::uint64_t EnoteDetailsImpl::globalEnoteIndex() const
+{ return m_global_enote_index; }
+bool EnoteDetailsImpl::isSpent() const
+{ return m_spent; }
+bool EnoteDetailsImpl::isFrozen() const
+{ return m_frozen; }
+std::uint64_t EnoteDetailsImpl::spentHeight() const
+{ return m_spent_height; }
+std::string EnoteDetailsImpl::keyImage() const
+{ return m_key_image; }
+std::string EnoteDetailsImpl::mask() const
+{ return m_mask; }
+std::uint64_t EnoteDetailsImpl::amount() const
+{ return m_amount; }
+EnoteDetails::TxProtocol EnoteDetailsImpl::protocolVersion() const
+{ return m_protocol_version; }
+bool EnoteDetailsImpl::isKeyImageKnown() const
+{ return m_key_image_known; }
+bool EnoteDetailsImpl::isKeyImageRequest() const
+{ return m_key_image_request; }
+std::uint64_t EnoteDetailsImpl::pkIndex() const
+{ return m_pk_index; }
+std::vector<std::pair<std::uint64_t, std::string>> EnoteDetailsImpl::uses() const
+{ return m_uses; }
+
+// Multisig
+bool EnoteDetailsImpl::isKeyImagePartial() const
+{ return m_key_image_partial; }
+
+} // namespace

--- a/src/wallet/api/enote_details.h
+++ b/src/wallet/api/enote_details.h
@@ -26,6 +26,8 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#pragma once
+
 #include "wallet/api/wallet2_api.h"
 
 
@@ -38,7 +40,10 @@ public:
     ~EnoteDetailsImpl() override;
     std::string onetimeAddress() const override;
     std::string viewTag() const override;
+    std::string paymentId() const override;
     std::uint64_t blockHeight() const override;
+    std::uint64_t unlockTime() const override;
+    bool isUnlocked() const override;
     std::string txId() const override;
     std::uint64_t internalEnoteIndex() const override;
     std::uint64_t globalEnoteIndex() const override;
@@ -53,6 +58,8 @@ public:
     bool isKeyImageRequest() const override;
     std::uint64_t pkIndex() const override;
     std::vector<std::pair<std::uint64_t, std::string>> uses() const override;
+    std::uint32_t subaddressIndexMajor() const override;
+    std::uint32_t subaddressIndexMinor() const override;
 
     // Multisig
     bool isKeyImagePartial() const override;
@@ -60,48 +67,31 @@ public:
 private:
     friend class WalletImpl;
 
-    // Ko
     std::string m_onetime_address;
-    // view_tag
     std::string m_view_tag;
-    // this enote was received at block height
+    std::string m_payment_id;
     std::uint64_t m_block_height;
-    // tx id in which tx enote was received
+    std::uint64_t m_unlock_time;
+    bool m_is_unlocked;
     std::string m_tx_id;
-    // relative index in tx
     std::uint64_t m_internal_enote_index;
-    // absolute index from `cryptonote::COMMAND_RPC_GET_TRANSACTIONS::entry.output_indices`
     std::uint64_t m_global_enote_index;
-    // is spent
     bool m_spent;
-    // is frozen
     bool m_frozen;
-    // blockchain height, set if spent
     std::uint64_t m_spent_height;
-    // key image
     std::string m_key_image;
-    // x, blinding factor in amount commitment C = x G + a H
     std::string m_mask;
-    // a
     std::uint64_t m_amount;
-    // protocol version : TxProtocol_CryptoNote / TxProtocol_RingCT
     TxProtocol m_protocol_version;
-    // is key image known
     bool m_key_image_known;
-    // view wallets: we want to request it; cold wallets: it was requested
     bool m_key_image_request;
-    // public key index in tx_extra
     std::uint64_t m_pk_index;
-    // track uses of this enote in the blockchain in the format [ [block_height, tx_id], ... ] if `wallet2::m_track_uses` is true (default is false)
     std::vector<std::pair<std::uint64_t, std::string>> m_uses;
+    std::uint32_t m_subaddress_index_major;
+    std::uint32_t m_subaddress_index_minor;
 
     // Multisig
     bool m_key_image_partial;
-    // NOTE : These multisig members are part of wallet2 transfer_details and may need to get added here.
-/*
-    std::vector<rct::key> m_multisig_k;
-    std::vector<multisig_info> m_multisig_info; // one per other participant
-*/
 };
 
-} // namespace
+} // namespace Monero

--- a/src/wallet/api/enote_details.h
+++ b/src/wallet/api/enote_details.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2014-2025, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "wallet/api/wallet2_api.h"
+
+
+namespace Monero {
+
+class EnoteDetailsImpl : public EnoteDetails
+{
+public:
+    EnoteDetailsImpl();
+    ~EnoteDetailsImpl() override;
+    std::string onetimeAddress() const override;
+    std::string viewTag() const override;
+    std::uint64_t blockHeight() const override;
+    std::string txId() const override;
+    std::uint64_t internalEnoteIndex() const override;
+    std::uint64_t globalEnoteIndex() const override;
+    bool isSpent() const override;
+    bool isFrozen() const override;
+    std::uint64_t spentHeight() const override;
+    std::string keyImage() const override;
+    std::string mask() const override;
+    std::uint64_t amount() const override;
+    TxProtocol protocolVersion() const override;
+    bool isKeyImageKnown() const override;
+    bool isKeyImageRequest() const override;
+    std::uint64_t pkIndex() const override;
+    std::vector<std::pair<std::uint64_t, std::string>> uses() const override;
+
+    // Multisig
+    bool isKeyImagePartial() const override;
+
+private:
+    friend class WalletImpl;
+
+    // Ko
+    std::string m_onetime_address;
+    // view_tag
+    std::string m_view_tag;
+    // this enote was received at block height
+    std::uint64_t m_block_height;
+    // tx id in which tx enote was received
+    std::string m_tx_id;
+    // relative index in tx
+    std::uint64_t m_internal_enote_index;
+    // absolute index from `cryptonote::COMMAND_RPC_GET_TRANSACTIONS::entry.output_indices`
+    std::uint64_t m_global_enote_index;
+    // is spent
+    bool m_spent;
+    // is frozen
+    bool m_frozen;
+    // blockchain height, set if spent
+    std::uint64_t m_spent_height;
+    // key image
+    std::string m_key_image;
+    // x, blinding factor in amount commitment C = x G + a H
+    std::string m_mask;
+    // a
+    std::uint64_t m_amount;
+    // protocol version : TxProtocol_CryptoNote / TxProtocol_RingCT
+    TxProtocol m_protocol_version;
+    // is key image known
+    bool m_key_image_known;
+    // view wallets: we want to request it; cold wallets: it was requested
+    bool m_key_image_request;
+    // public key index in tx_extra
+    std::uint64_t m_pk_index;
+    // track uses of this enote in the blockchain in the format [ [block_height, tx_id], ... ] if `wallet2::m_track_uses` is true (default is false)
+    std::vector<std::pair<std::uint64_t, std::string>> m_uses;
+
+    // Multisig
+    bool m_key_image_partial;
+    // NOTE : These multisig members are part of wallet2 transfer_details and may need to get added here.
+/*
+    std::vector<rct::key> m_multisig_k;
+    std::vector<multisig_info> m_multisig_info; // one per other participant
+*/
+};
+
+} // namespace

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -162,6 +162,29 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
     return m_status == Status_Ok;
 }
 
+std::string PendingTransactionImpl::convertTxToStr()
+{
+    std::string tx;
+    LOG_PRINT_L3("m_pending_tx size: " << m_pending_tx.size());
+
+    try {
+        tx = m_wallet.m_wallet->dump_tx_to_str(m_pending_tx);
+        m_status = Status_Ok;
+        return tx;
+    } catch (const tools::error::wallet_internal_error&) {
+        m_errorString = tr("Wallet internal eror.");
+        m_status = Status_Error;
+    } catch (const std::exception &e) {
+        m_errorString = string(tr("Unknown exception: ")) + e.what();
+        m_status = Status_Error;
+    } catch (...) {
+        m_errorString = tr("Unhandled exception");
+        LOG_ERROR(m_errorString);
+        m_status = Status_Error;
+    }
+    return ""; // m_status != Status_Ok
+}
+
 uint64_t PendingTransactionImpl::amount() const
 {
     uint64_t result = 0;

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -29,6 +29,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include "pending_transaction.h"
+#include "string_tools.h"
 #include "wallet.h"
 #include "common_defines.h"
 
@@ -83,6 +84,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
 
     LOG_PRINT_L3("m_pending_tx size: " << m_pending_tx.size());
 
+    bool warn_of_possible_attack = !m_wallet.trustedDaemon();
     try {
       // Save tx to file
       if (!filename.empty()) {
@@ -134,13 +136,57 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
             m_pending_tx.pop_back();
         } // TODO: extract method;
       }
-    } catch (const tools::error::daemon_busy&) {
-        // TODO: make it translatable with "tr"?
-        m_errorString = tr("daemon is busy. Please try again later.");
+    } catch (const tools::error::deprecated_rpc_access&) {
+        m_errorString = tr("Daemon requires deprecated RPC payment. See https://github.com/monero-project/monero/issues/8722");
         m_status = Status_Error;
     } catch (const tools::error::no_connection_to_daemon&) {
         m_errorString = tr("no connection to daemon. Please make sure daemon is running.");
         m_status = Status_Error;
+    } catch (const tools::error::daemon_busy&) {
+        m_errorString = tr("daemon is busy. Please try again later.");
+        m_status = Status_Error;
+    } catch (const tools::error::wallet_rpc_error& e) {
+        m_errorString = (boost::format(tr("RPC error: %s")) % e.what()).str();
+        m_status = Status_Error;
+        LOG_ERROR(tr("RPC error: ") << e.what());
+    } catch (const tools::error::get_outs_error &e) {
+        m_errorString = (boost::format(tr("failed to get random outputs to mix: %s")) % e.what()).str();
+        m_status = Status_Error;
+    } catch (const tools::error::not_enough_unlocked_money& e) {
+        m_errorString = (boost::format("not enough unlocked money to transfer, available only %s, sent amount %s")
+                            % cryptonote::print_money(e.available())
+                            % cryptonote::print_money(e.tx_amount())).str();
+        m_status = Status_Error;
+        LOG_PRINT_L0(m_errorString);
+        warn_of_possible_attack = false;
+    } catch (const tools::error::not_enough_money& e) {
+        m_errorString = (boost::format("not enough money to transfer, available only %s, sent amount %s")
+                            % cryptonote::print_money(e.available())
+                            % cryptonote::print_money(e.tx_amount())).str();
+        m_status = Status_Error;
+        LOG_PRINT_L0(m_errorString);
+        warn_of_possible_attack = false;
+    } catch (const tools::error::tx_not_possible& e) {
+        m_errorString = (boost::format("Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees, available only %s, transaction amount %s = %s + %s (fee)")
+                            % cryptonote::print_money(e.available())
+                            % cryptonote::print_money(e.tx_amount() + e.fee())
+                            % cryptonote::print_money(e.tx_amount())
+                            % cryptonote::print_money(e.fee())).str();
+        m_status = Status_Error;
+        LOG_PRINT_L0(m_errorString);
+        warn_of_possible_attack = false;
+    } catch (const tools::error::not_enough_outs_to_mix& e) {
+        std::ostringstream writer(m_errorString);
+        writer << tr("not enough outputs for specified ring size") << " = " << (e.mixin_count() + 1) << ":";
+        for (std::pair<uint64_t, uint64_t> outs_for_amount : e.scanty_outs())
+            writer << "\n" << tr("output amount") << " = " << cryptonote::print_money(outs_for_amount.first) << ", " << tr("found outputs to use") << " = " << outs_for_amount.second;
+        m_errorString = writer.str();
+        m_status = Status_Error;
+        LOG_PRINT_L0(m_errorString);
+    } catch (const tools::error::tx_not_constructed&) {
+        m_errorString = tr("transaction was not constructed");
+        m_status = Status_Error;
+        warn_of_possible_attack = false;
     } catch (const tools::error::tx_rejected& e) {
         std::ostringstream writer(m_errorString);
         writer << (boost::format(tr("transaction %s was rejected by daemon with status: ")) % get_transaction_hash(e.tx())) <<  e.status();
@@ -149,6 +195,35 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
         m_errorString = writer.str();
         if (!reason.empty())
           m_errorString  += string(tr(". Reason: ")) + reason;
+    } catch (const tools::error::tx_sum_overflow& e) {
+        m_errorString = e.what();
+        m_status = Status_Error;
+        warn_of_possible_attack = false;
+    } catch (const tools::error::zero_amount&) {
+        m_errorString = tr("destination amount is zero");
+        m_status = Status_Error;
+        warn_of_possible_attack = false;
+    } catch (const tools::error::zero_destination&) {
+        m_errorString = tr("transaction has no destination");
+        m_status = Status_Error;
+        warn_of_possible_attack = false;
+    } catch (const tools::error::tx_too_big& e) {
+        m_errorString = tr("failed to find a suitable way to split transactions");
+        m_status = Status_Error;
+        warn_of_possible_attack = false;
+    } catch (const tools::error::transfer_error& e) {
+        m_errorString = (boost::format(tr("unknown transfer error: %s")) % e.what()).str();
+        m_status = Status_Error;
+        LOG_ERROR("unknown transfer error: " << e.to_string());
+    } catch (const tools::error::multisig_export_needed& e) {
+        m_errorString = (boost::format(tr("Multisig error: ")) % e.what()).str();
+        m_status = Status_Error;
+        LOG_ERROR("Multisig error: " << e.to_string());
+        warn_of_possible_attack = false;
+    } catch (const tools::error::wallet_internal_error& e) {
+        m_errorString = (boost::format(tr("internal error: ")) % e.what()).str();
+        m_status = Status_Error;
+        LOG_ERROR("internal error: " << e.to_string());
     } catch (const std::exception &e) {
         m_errorString = string(tr("Unknown exception: ")) + e.what();
         m_status = Status_Error;
@@ -157,32 +232,11 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
         LOG_ERROR(m_errorString);
         m_status = Status_Error;
     }
+    if (warn_of_possible_attack && m_status != Status_Ok)
+      m_errorString += tr("\nThere was an error, which could mean the node may be trying to get you to retry creating a transaction, and zero in on which outputs you own. Or it could be a bona fide error. It may be prudent to disconnect from this node, and not try to send a transaction immediately. Alternatively, connect to another node so the original node cannot correlate information.");
 
     m_wallet.startRefresh();
     return m_status == Status_Ok;
-}
-
-std::string PendingTransactionImpl::convertTxToStr()
-{
-    std::string tx;
-    LOG_PRINT_L3("m_pending_tx size: " << m_pending_tx.size());
-
-    try {
-        tx = m_wallet.m_wallet->dump_tx_to_str(m_pending_tx);
-        m_status = Status_Ok;
-        return tx;
-    } catch (const tools::error::wallet_internal_error&) {
-        m_errorString = tr("Wallet internal eror.");
-        m_status = Status_Error;
-    } catch (const std::exception &e) {
-        m_errorString = string(tr("Unknown exception: ")) + e.what();
-        m_status = Status_Error;
-    } catch (...) {
-        m_errorString = tr("Unhandled exception");
-        LOG_ERROR(m_errorString);
-        m_status = Status_Error;
-    }
-    return ""; // m_status != Status_Ok
 }
 
 uint64_t PendingTransactionImpl::amount() const
@@ -205,11 +259,30 @@ uint64_t PendingTransactionImpl::dust() const
     return result;
 }
 
+uint64_t PendingTransactionImpl::dustInFee() const
+{
+    uint64_t result = 0;
+    for (const auto & ptx : m_pending_tx) {
+        if (ptx.dust_added_to_fee)
+            result += ptx.dust;
+    }
+    return result;
+}
+
 uint64_t PendingTransactionImpl::fee() const
 {
     uint64_t result = 0;
     for (const auto &ptx : m_pending_tx) {
         result += ptx.fee;
+    }
+    return result;
+}
+
+uint64_t PendingTransactionImpl::change() const
+{
+    uint64_t result = 0;
+    for (const auto &ptx : m_pending_tx) {
+        result += ptx.change_dts.amount;
     }
     return result;
 }
@@ -235,6 +308,147 @@ std::vector<std::set<uint32_t>> PendingTransactionImpl::subaddrIndices() const
     return result;
 }
 
+std::string PendingTransactionImpl::convertTxToStr()
+{
+    std::string tx;
+    LOG_PRINT_L3("m_pending_tx size: " << m_pending_tx.size());
+
+    try {
+        tx = m_wallet.m_wallet->dump_tx_to_str(m_pending_tx);
+        m_status = Status_Ok;
+        return tx;
+    } catch (const tools::error::wallet_internal_error &e) {
+        m_errorString = std::string(tr("wallet internal error: ")) + e.what();
+        m_status = Status_Error;
+        LOG_ERROR(std::string(tr("wallet internal error: ")) + e.to_string());
+    } catch (const std::exception &e) {
+        m_errorString = string(tr("Unknown exception: ")) + e.what();
+        m_status = Status_Error;
+    } catch (...) {
+        m_errorString = tr("Unhandled exception");
+        m_status = Status_Error;
+    }
+    return ""; // m_status != Status_Ok
+}
+
+std::vector<std::string> PendingTransactionImpl::convertTxToRawBlobStr()
+{
+    std::vector<std::string> tx_blobs{};
+    m_status = Status_Ok;
+    m_errorString = "";
+    for (const auto &ptx : m_pending_tx)
+    {
+        std::string tx_blob;
+        if (cryptonote::tx_to_blob(ptx.tx, tx_blob))
+            tx_blobs.push_back(tx_blob);
+        else
+        {
+            m_status = Status_Error;
+            m_errorString = tr("failed to serialize tx");
+            return {};
+        }
+    }
+    return tx_blobs;
+}
+
+double PendingTransactionImpl::getWorstFeePerByte() const
+{
+    double worst_fee_per_byte = std::numeric_limits<double>::max();
+    for (size_t n = 0; n < m_pending_tx.size(); ++n)
+    {
+        const uint64_t blob_size = cryptonote::tx_to_blob(m_pending_tx[n].tx).size();
+        const double fee_per_byte = m_pending_tx[n].fee / (double)blob_size;
+        if (fee_per_byte < worst_fee_per_byte)
+            worst_fee_per_byte = fee_per_byte;
+    }
+    return worst_fee_per_byte;
+}
+
+std::vector<std::vector<std::vector<std::uint64_t>>> PendingTransactionImpl::vinOffsets() const
+{
+    std::vector<std::vector<std::vector<std::uint64_t>>> vin_offsets;
+    for (size_t n = 0; n < m_pending_tx.size(); ++n)
+    {
+        const cryptonote::transaction &tx = m_pending_tx[n].tx;
+        vin_offsets.push_back({});
+        for (size_t i = 0; i < tx.vin.size(); ++i)
+        {
+            if (tx.vin[i].type() != typeid(cryptonote::txin_to_key))
+                continue;
+            const cryptonote::txin_to_key& in_key = boost::get<cryptonote::txin_to_key>(tx.vin[i]);
+            vin_offsets[n].push_back(in_key.key_offsets);
+        }
+    }
+    return vin_offsets;
+}
+
+std::vector<std::vector<std::uint64_t>> PendingTransactionImpl::constructionDataRealOutputIndices() const
+{
+    std::vector<std::vector<std::uint64_t>> vin_real_output_indices;
+    for (size_t n = 0; n < m_pending_tx.size(); ++n)
+    {
+        const cryptonote::transaction &tx = m_pending_tx[n].tx;
+        const tools::wallet2::tx_construction_data &construction_data = m_pending_tx[n].construction_data;
+        vin_real_output_indices.push_back({});
+        for (size_t i = 0; i < tx.vin.size(); ++i)
+        {
+            if (tx.vin[i].type() != typeid(cryptonote::txin_to_key))
+                continue;
+            const tools::wallet2::transfer_details &td = m_wallet.m_wallet->get_transfer_details(construction_data.selected_transfers[i]);
+            const cryptonote::tx_source_entry *sptr = NULL;
+            for (const auto &src: construction_data.sources)
+                if (src.outputs[src.real_output].second.dest == td.get_public_key())
+                    sptr = &src;
+            if (!sptr)
+                return {};
+            vin_real_output_indices[n].push_back(sptr->real_output);
+        }
+    }
+    return vin_real_output_indices;
+}
+
+std::vector<std::vector<std::uint64_t>> PendingTransactionImpl::vinAmounts() const
+{
+    std::vector<std::vector<std::uint64_t>> vin_amounts;
+    for (size_t n = 0; n < m_pending_tx.size(); ++n)
+    {
+        cryptonote::transaction tx = m_pending_tx[n].tx;
+        vin_amounts.push_back({});
+        for (size_t i = 0; i < tx.vin.size(); ++i)
+        {
+            if (tx.vin[i].type() != typeid(cryptonote::txin_to_key))
+                continue;
+            const cryptonote::txin_to_key& in_key = boost::get<cryptonote::txin_to_key>(tx.vin[i]);
+            vin_amounts[n].push_back(in_key.amount);
+        }
+    }
+    return vin_amounts;
+}
+
+std::vector<std::vector<std::unique_ptr<EnoteDetails>>> PendingTransactionImpl::getEnoteDetailsIn() const
+{
+    std::vector<std::unique_ptr<EnoteDetails>> eds = m_wallet.getEnoteDetails();
+    std::vector<std::vector<std::unique_ptr<EnoteDetails>>> eds_out;
+    for (const auto &ptx: m_pending_tx)
+    {
+        eds_out.push_back({});
+        for (const auto i: ptx.selected_transfers)
+            eds_out.back().push_back(std::move(eds[i]));
+    }
+    return eds_out;
+}
+
+bool PendingTransactionImpl::finishParsingTx()
+{
+    // import key images
+    bool r = m_wallet.m_wallet->import_key_images(m_key_images);
+    if (!r) return false;
+
+    // remember key images for this tx, for when we get those txes from the blockchain
+    m_wallet.m_wallet->insert_cold_key_images(m_tx_key_images);
+    return true;
+}
+
 std::string PendingTransactionImpl::multisigSignData() {
     try {
         if (!m_wallet.multisig().isMultisig) {
@@ -255,7 +469,7 @@ std::string PendingTransactionImpl::multisigSignData() {
     return std::string();
 }
 
-void PendingTransactionImpl::signMultisigTx() {
+void PendingTransactionImpl::signMultisigTx(std::vector<std::string> *txids /* = nullptr */) {
     try {
         std::vector<crypto::hash> ignore;
 
@@ -267,6 +481,11 @@ void PendingTransactionImpl::signMultisigTx() {
             throw std::runtime_error("couldn't sign multisig transaction");
         }
 
+        if (txids && !ignore.empty())
+        {
+            for (const auto &txid : ignore)
+                txids->emplace_back(epee::string_tools::pod_to_hex(txid));
+        }
         std::swap(m_pending_tx, txSet.m_ptx);
         std::swap(m_signers, txSet.m_signers);
     } catch (const std::exception& e) {
@@ -285,5 +504,161 @@ std::vector<std::string> PendingTransactionImpl::signersKeys() const {
 
     return keys;
 }
+
+void PendingTransactionImpl::finishRestoringMultisigTransaction() {
+    tools::wallet2::multisig_tx_set exported_txs;
+    exported_txs.m_ptx = m_pending_tx;
+    exported_txs.m_signers = m_signers;
+    m_wallet.m_wallet->finish_loading_accepted_multisig_tx(exported_txs);
+}
+
+//----------------------------------------------------------------------------------------------------
+bool PendingTransactionImpl::checkLoadedTx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message)
+{
+  // gather info to ask the user
+  uint64_t amount = 0, amount_to_dests = 0, change = 0;
+  size_t min_ring_size = ~0;
+  std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
+  int first_known_non_zero_change_index = -1;
+  std::string payment_id_string = "";
+  for (size_t n = 0; n < get_num_txes(); ++n)
+  {
+    const tools::wallet2::tx_construction_data &cd = get_tx(n);
+
+    std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+    bool has_encrypted_payment_id = false;
+    crypto::hash8 payment_id8 = crypto::null_hash8;
+    if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
+    {
+      cryptonote::tx_extra_nonce extra_nonce;
+      if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+      {
+        crypto::hash payment_id;
+        if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+        {
+          if (!payment_id_string.empty())
+            payment_id_string += ", ";
+
+          // if none of the addresses are integrated addresses, it's a dummy one
+          bool is_dummy = true;
+          for (const auto &e: cd.dests)
+            if (e.is_integrated)
+              is_dummy = false;
+
+          if (is_dummy)
+            payment_id_string += std::string("dummy encrypted payment ID");
+          else
+          {
+            payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
+            has_encrypted_payment_id = true;
+          }
+        }
+        else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+        {
+          if (!payment_id_string.empty())
+            payment_id_string += ", ";
+          payment_id_string = std::string("unencrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id);
+          payment_id_string += " (OBSOLETE)";
+        }
+      }
+    }
+
+    for (size_t s = 0; s < cd.sources.size(); ++s)
+    {
+      amount += cd.sources[s].amount;
+      size_t ring_size = cd.sources[s].outputs.size();
+      if (ring_size < min_ring_size)
+        min_ring_size = ring_size;
+    }
+    for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
+    {
+      const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
+      std::string address, standard_address = get_account_address_as_str(m_wallet.m_wallet->nettype(), entry.is_subaddress, entry.addr);
+      if (has_encrypted_payment_id && !entry.is_subaddress)
+      {
+        address = get_account_integrated_address_as_str(m_wallet.m_wallet->nettype(), entry.addr, payment_id8);
+        address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");
+      }
+      else
+        address = standard_address;
+      auto i = dests.find(entry.addr);
+      if (i == dests.end())
+        dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
+      else
+        i->second.second += entry.amount;
+      amount_to_dests += entry.amount;
+    }
+    if (cd.change_dts.amount > 0)
+    {
+      auto it = dests.find(cd.change_dts.addr);
+      if (it == dests.end())
+      {
+        m_status = Status_Error;
+        m_errorString = tr("Claimed change does not go to a paid address");
+        return false;
+      }
+      if (it->second.second < cd.change_dts.amount)
+      {
+        m_status = Status_Error;
+        m_errorString = tr("Claimed change is larger than payment to the change address");
+        return  false;
+      }
+      if (cd.change_dts.amount > 0)
+      {
+        if (first_known_non_zero_change_index == -1)
+          first_known_non_zero_change_index = n;
+        if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
+        {
+          m_status = Status_Error;
+          m_errorString = tr("Change goes to more than one address");
+          return false;
+        }
+      }
+      change += cd.change_dts.amount;
+      it->second.second -= cd.change_dts.amount;
+      if (it->second.second == 0)
+        dests.erase(cd.change_dts.addr);
+    }
+  }
+
+  if (payment_id_string.empty())
+    payment_id_string = "no payment ID";
+
+  std::string dest_string;
+  size_t n_dummy_outputs = 0;
+  for (auto i = dests.begin(); i != dests.end(); )
+  {
+    if (i->second.second > 0)
+    {
+      if (!dest_string.empty())
+        dest_string += ", ";
+      dest_string += (boost::format(tr("sending %s to %s")) % cryptonote::print_money(i->second.second) % i->second.first).str();
+    }
+    else
+      ++n_dummy_outputs;
+    ++i;
+  }
+  if (n_dummy_outputs > 0)
+  {
+    if (!dest_string.empty())
+      dest_string += ", ";
+    dest_string += std::to_string(n_dummy_outputs) + tr(" dummy output(s)");
+  }
+  if (dest_string.empty())
+    dest_string = tr("with no destinations");
+
+  std::string change_string;
+  if (change > 0)
+  {
+    std::string address = get_account_address_as_str(m_wallet.m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
+    change_string += (boost::format(tr("%s change to %s")) % cryptonote::print_money(change) % address).str();
+  }
+  else
+    change_string += tr("no change");
+  uint64_t fee = amount - amount_to_dests;
+  m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
+  return true;
+}
+
 
 }

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -66,6 +66,11 @@ int PendingTransactionImpl::status() const
     return m_status;
 }
 
+int PendingTransactionImpl::extendedStatus() const
+{
+    return m_extendedStatus;
+}
+
 string PendingTransactionImpl::errorString() const
 {
     return m_errorString;
@@ -142,9 +147,11 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
     } catch (const tools::error::no_connection_to_daemon&) {
         m_errorString = tr("no connection to daemon. Please make sure daemon is running.");
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_NoDaemonConnection;
     } catch (const tools::error::daemon_busy&) {
         m_errorString = tr("daemon is busy. Please try again later.");
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_DaemonIsBusy;
     } catch (const tools::error::wallet_rpc_error& e) {
         m_errorString = (boost::format(tr("RPC error: %s")) % e.what()).str();
         m_status = Status_Error;
@@ -157,6 +164,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
                             % cryptonote::print_money(e.available())
                             % cryptonote::print_money(e.tx_amount())).str();
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_NotEnoughUnlockedMoney;
         LOG_PRINT_L0(m_errorString);
         warn_of_possible_attack = false;
     } catch (const tools::error::not_enough_money& e) {
@@ -164,6 +172,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
                             % cryptonote::print_money(e.available())
                             % cryptonote::print_money(e.tx_amount())).str();
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_NotEnoughMoney;
         LOG_PRINT_L0(m_errorString);
         warn_of_possible_attack = false;
     } catch (const tools::error::tx_not_possible& e) {
@@ -173,6 +182,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
                             % cryptonote::print_money(e.tx_amount())
                             % cryptonote::print_money(e.fee())).str();
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_TxNotPossible;
         LOG_PRINT_L0(m_errorString);
         warn_of_possible_attack = false;
     } catch (const tools::error::not_enough_outs_to_mix& e) {
@@ -182,6 +192,7 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
             writer << "\n" << tr("output amount") << " = " << cryptonote::print_money(outs_for_amount.first) << ", " << tr("found outputs to use") << " = " << outs_for_amount.second;
         m_errorString = writer.str();
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_NotEnoughOutsToMix;
         LOG_PRINT_L0(m_errorString);
     } catch (const tools::error::tx_not_constructed&) {
         m_errorString = tr("transaction was not constructed");
@@ -202,10 +213,12 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
     } catch (const tools::error::zero_amount&) {
         m_errorString = tr("destination amount is zero");
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_ZeroAmount;
         warn_of_possible_attack = false;
     } catch (const tools::error::zero_destination&) {
         m_errorString = tr("transaction has no destination");
         m_status = Status_Error;
+        m_extendedStatus = Wallet::ExtendedStatus_ZeroDestination;
         warn_of_possible_attack = false;
     } catch (const tools::error::tx_too_big& e) {
         m_errorString = tr("failed to find a suitable way to split transactions");
@@ -250,6 +263,19 @@ uint64_t PendingTransactionImpl::amount() const
     return result;
 }
 
+std::vector<std::vector<std::uint64_t>> PendingTransactionImpl::amountsPerDestination() const
+{
+    std::vector<std::vector<std::uint64_t>> result{};
+    for (const auto &ptx : m_pending_tx)   {
+        std::vector<std::uint64_t> amounts_per_tx{};
+        for (const auto &dest : ptx.dests) {
+            amounts_per_tx.push_back(dest.amount);
+        }
+        result.push_back(amounts_per_tx);
+    }
+    return result;
+}
+
 uint64_t PendingTransactionImpl::dust() const
 {
     uint64_t result = 0;
@@ -274,6 +300,15 @@ uint64_t PendingTransactionImpl::fee() const
     uint64_t result = 0;
     for (const auto &ptx : m_pending_tx) {
         result += ptx.fee;
+    }
+    return result;
+}
+
+std::vector<std::uint64_t> PendingTransactionImpl::fees() const
+{
+    std::vector<std::uint64_t> result{};
+    for (const auto &ptx : m_pending_tx) {
+        result.push_back(ptx.fee);
     }
     return result;
 }
@@ -351,6 +386,50 @@ std::vector<std::string> PendingTransactionImpl::convertTxToRawBlobStr()
     return tx_blobs;
 }
 
+std::vector<std::string> PendingTransactionImpl::asHexStr()
+{
+    std::vector<std::string> tx_hex_strings{};
+    m_status = Status_Ok;
+    m_errorString = "";
+    for (const auto &ptx : m_pending_tx)
+    {
+        std::ostringstream oss;
+        binary_archive<true> ar(oss);
+        try
+        {
+            if (::serialization::serialize(ar, const_cast<tools::wallet2::pending_tx&>(ptx)))
+                tx_hex_strings.push_back(epee::string_tools::buff_to_hex_nodelimer(oss.str()));
+            else
+            {
+                m_status = Status_Error;
+                m_errorString = tr("failed to serialize tx");
+                return {};
+            }
+        }
+        catch (...)
+        {
+            m_status = Status_Error;
+            m_errorString = tr("failed to serialize tx");
+            return {};
+        }
+    }
+    return tx_hex_strings;
+}
+
+std::vector<std::uint64_t> PendingTransactionImpl::txWeights()
+{
+    std::vector<std::uint64_t> tx_weights{};
+    try {
+        for (const auto &ptx : m_pending_tx)
+            tx_weights.push_back(cryptonote::get_transaction_weight(ptx.tx));
+        m_status = Status_Ok;
+    } catch (const std::exception &e) {
+        m_errorString = string(tr("failed to get transaction weight: ")) + e.what();
+        m_status = Status_Error;
+    }
+    return tx_weights;
+}
+
 double PendingTransactionImpl::getWorstFeePerByte() const
 {
     double worst_fee_per_byte = std::numeric_limits<double>::max();
@@ -425,6 +504,18 @@ std::vector<std::vector<std::uint64_t>> PendingTransactionImpl::vinAmounts() con
     return vin_amounts;
 }
 
+std::vector<std::string> PendingTransactionImpl::getTxKeys() const
+{
+    std::vector<std::string> tx_keys{};
+    for (const auto &ptx : m_pending_tx)
+    {
+        epee::wipeable_string s = epee::to_hex::wipeable_string(ptx.tx_key);
+        for (const crypto::secret_key& additional_tx_key : ptx.additional_tx_keys)
+            s += epee::to_hex::wipeable_string(additional_tx_key);
+        tx_keys.push_back(std::string(s.data(), s.size()));
+    }
+    return tx_keys;
+}
 std::vector<std::vector<std::unique_ptr<EnoteDetails>>> PendingTransactionImpl::getEnoteDetailsIn() const
 {
     std::vector<std::unique_ptr<EnoteDetails>> eds = m_wallet.getEnoteDetails();
@@ -447,6 +538,15 @@ bool PendingTransactionImpl::finishParsingTx()
     // remember key images for this tx, for when we get those txes from the blockchain
     m_wallet.m_wallet->insert_cold_key_images(m_tx_key_images);
     return true;
+}
+
+std::unique_ptr<TransactionDescription> PendingTransactionImpl::getTransactionDescription()
+{
+    std::vector<tools::wallet2::tx_construction_data> tx_construction_data;
+    for (size_t i = 0; i < m_pending_tx.size(); ++i)
+        tx_construction_data.push_back(m_pending_tx[i].construction_data);
+
+    return m_wallet.getTxDescription(tx_construction_data, m_status, m_errorString);
 }
 
 std::string PendingTransactionImpl::multisigSignData() {
@@ -515,149 +615,149 @@ void PendingTransactionImpl::finishRestoringMultisigTransaction() {
 //----------------------------------------------------------------------------------------------------
 bool PendingTransactionImpl::checkLoadedTx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message)
 {
-  // gather info to ask the user
-  uint64_t amount = 0, amount_to_dests = 0, change = 0;
-  size_t min_ring_size = ~0;
-  std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
-  int first_known_non_zero_change_index = -1;
-  std::string payment_id_string = "";
-  for (size_t n = 0; n < get_num_txes(); ++n)
-  {
-    const tools::wallet2::tx_construction_data &cd = get_tx(n);
-
-    std::vector<cryptonote::tx_extra_field> tx_extra_fields;
-    bool has_encrypted_payment_id = false;
-    crypto::hash8 payment_id8 = crypto::null_hash8;
-    if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
+    // gather info to ask the user
+    uint64_t amount = 0, amount_to_dests = 0, change = 0;
+    size_t min_ring_size = ~0;
+    std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
+    int first_known_non_zero_change_index = -1;
+    std::string payment_id_string = "";
+    for (size_t n = 0; n < get_num_txes(); ++n)
     {
-      cryptonote::tx_extra_nonce extra_nonce;
-      if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
-      {
-        crypto::hash payment_id;
-        if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+        const tools::wallet2::tx_construction_data &cd = get_tx(n);
+
+        std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+        bool has_encrypted_payment_id = false;
+        crypto::hash8 payment_id8 = crypto::null_hash8;
+        if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
         {
-          if (!payment_id_string.empty())
-            payment_id_string += ", ";
+            cryptonote::tx_extra_nonce extra_nonce;
+            if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+            {
+                crypto::hash payment_id;
+                if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+                {
+                    if (!payment_id_string.empty())
+                        payment_id_string += ", ";
 
-          // if none of the addresses are integrated addresses, it's a dummy one
-          bool is_dummy = true;
-          for (const auto &e: cd.dests)
-            if (e.is_integrated)
-              is_dummy = false;
+                    // if none of the addresses are integrated addresses, it's a dummy one
+                    bool is_dummy = true;
+                    for (const auto &e: cd.dests)
+                        if (e.is_integrated)
+                            is_dummy = false;
 
-          if (is_dummy)
-            payment_id_string += std::string("dummy encrypted payment ID");
-          else
-          {
-            payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
-            has_encrypted_payment_id = true;
-          }
+                    if (is_dummy)
+                        payment_id_string += std::string("dummy encrypted payment ID");
+                    else
+                    {
+                        payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
+                        has_encrypted_payment_id = true;
+                    }
+                }
+                else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+                {
+                    if (!payment_id_string.empty())
+                        payment_id_string += ", ";
+                    payment_id_string = std::string("unencrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id);
+                    payment_id_string += " (OBSOLETE)";
+                }
+            }
         }
-        else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+
+        for (size_t s = 0; s < cd.sources.size(); ++s)
         {
-          if (!payment_id_string.empty())
-            payment_id_string += ", ";
-          payment_id_string = std::string("unencrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id);
-          payment_id_string += " (OBSOLETE)";
+            amount += cd.sources[s].amount;
+            size_t ring_size = cd.sources[s].outputs.size();
+            if (ring_size < min_ring_size)
+                min_ring_size = ring_size;
         }
-      }
-    }
-
-    for (size_t s = 0; s < cd.sources.size(); ++s)
-    {
-      amount += cd.sources[s].amount;
-      size_t ring_size = cd.sources[s].outputs.size();
-      if (ring_size < min_ring_size)
-        min_ring_size = ring_size;
-    }
-    for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
-    {
-      const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
-      std::string address, standard_address = get_account_address_as_str(m_wallet.m_wallet->nettype(), entry.is_subaddress, entry.addr);
-      if (has_encrypted_payment_id && !entry.is_subaddress)
-      {
-        address = get_account_integrated_address_as_str(m_wallet.m_wallet->nettype(), entry.addr, payment_id8);
-        address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");
-      }
-      else
-        address = standard_address;
-      auto i = dests.find(entry.addr);
-      if (i == dests.end())
-        dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
-      else
-        i->second.second += entry.amount;
-      amount_to_dests += entry.amount;
-    }
-    if (cd.change_dts.amount > 0)
-    {
-      auto it = dests.find(cd.change_dts.addr);
-      if (it == dests.end())
-      {
-        m_status = Status_Error;
-        m_errorString = tr("Claimed change does not go to a paid address");
-        return false;
-      }
-      if (it->second.second < cd.change_dts.amount)
-      {
-        m_status = Status_Error;
-        m_errorString = tr("Claimed change is larger than payment to the change address");
-        return  false;
-      }
-      if (cd.change_dts.amount > 0)
-      {
-        if (first_known_non_zero_change_index == -1)
-          first_known_non_zero_change_index = n;
-        if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
+        for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
         {
-          m_status = Status_Error;
-          m_errorString = tr("Change goes to more than one address");
-          return false;
+            const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
+            std::string address, standard_address = get_account_address_as_str(m_wallet.m_wallet->nettype(), entry.is_subaddress, entry.addr);
+            if (has_encrypted_payment_id && !entry.is_subaddress)
+            {
+                address = get_account_integrated_address_as_str(m_wallet.m_wallet->nettype(), entry.addr, payment_id8);
+                address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");
+            }
+            else
+                address = standard_address;
+            auto i = dests.find(entry.addr);
+            if (i == dests.end())
+                dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
+            else
+                i->second.second += entry.amount;
+            amount_to_dests += entry.amount;
         }
-      }
-      change += cd.change_dts.amount;
-      it->second.second -= cd.change_dts.amount;
-      if (it->second.second == 0)
-        dests.erase(cd.change_dts.addr);
+        if (cd.change_dts.amount > 0)
+        {
+            auto it = dests.find(cd.change_dts.addr);
+            if (it == dests.end())
+            {
+                m_status = Status_Error;
+                m_errorString = tr("Claimed change does not go to a paid address");
+                return false;
+            }
+            if (it->second.second < cd.change_dts.amount)
+            {
+                m_status = Status_Error;
+                m_errorString = tr("Claimed change is larger than payment to the change address");
+                return  false;
+            }
+            if (cd.change_dts.amount > 0)
+            {
+                if (first_known_non_zero_change_index == -1)
+                    first_known_non_zero_change_index = n;
+                if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
+                {
+                    m_status = Status_Error;
+                    m_errorString = tr("Change goes to more than one address");
+                    return false;
+                }
+            }
+            change += cd.change_dts.amount;
+            it->second.second -= cd.change_dts.amount;
+            if (it->second.second == 0)
+                dests.erase(cd.change_dts.addr);
+        }
     }
-  }
 
-  if (payment_id_string.empty())
-    payment_id_string = "no payment ID";
+    if (payment_id_string.empty())
+        payment_id_string = "no payment ID";
 
-  std::string dest_string;
-  size_t n_dummy_outputs = 0;
-  for (auto i = dests.begin(); i != dests.end(); )
-  {
-    if (i->second.second > 0)
+    std::string dest_string;
+    size_t n_dummy_outputs = 0;
+    for (auto i = dests.begin(); i != dests.end(); )
     {
-      if (!dest_string.empty())
-        dest_string += ", ";
-      dest_string += (boost::format(tr("sending %s to %s")) % cryptonote::print_money(i->second.second) % i->second.first).str();
+        if (i->second.second > 0)
+        {
+            if (!dest_string.empty())
+                dest_string += ", ";
+            dest_string += (boost::format(tr("sending %s to %s")) % cryptonote::print_money(i->second.second) % i->second.first).str();
+        }
+        else
+            ++n_dummy_outputs;
+        ++i;
+    }
+    if (n_dummy_outputs > 0)
+    {
+        if (!dest_string.empty())
+            dest_string += ", ";
+        dest_string += std::to_string(n_dummy_outputs) + tr(" dummy output(s)");
+    }
+    if (dest_string.empty())
+        dest_string = tr("with no destinations");
+
+    std::string change_string;
+    if (change > 0)
+    {
+        std::string address = get_account_address_as_str(m_wallet.m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
+        change_string += (boost::format(tr("%s change to %s")) % cryptonote::print_money(change) % address).str();
     }
     else
-      ++n_dummy_outputs;
-    ++i;
-  }
-  if (n_dummy_outputs > 0)
-  {
-    if (!dest_string.empty())
-      dest_string += ", ";
-    dest_string += std::to_string(n_dummy_outputs) + tr(" dummy output(s)");
-  }
-  if (dest_string.empty())
-    dest_string = tr("with no destinations");
-
-  std::string change_string;
-  if (change > 0)
-  {
-    std::string address = get_account_address_as_str(m_wallet.m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
-    change_string += (boost::format(tr("%s change to %s")) % cryptonote::print_money(change) % address).str();
-  }
-  else
-    change_string += tr("no change");
-  uint64_t fee = amount - amount_to_dests;
-  m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
-  return true;
+        change_string += tr("no change");
+    uint64_t fee = amount - amount_to_dests;
+    m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
+    return true;
 }
 
 

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -45,27 +45,42 @@ public:
     ~PendingTransactionImpl();
     int status() const override;
     std::string errorString() const override;
+    std::string confirmationMessage() const override { return m_confirmationMessage; }
     bool commit(const std::string &filename = "", bool overwrite = false) override;
     uint64_t amount() const override;
     uint64_t dust() const override;
+    uint64_t dustInFee() const override;
     uint64_t fee() const override;
+    uint64_t change() const override;
     std::vector<std::string> txid() const override;
     uint64_t txCount() const override;
     std::vector<uint32_t> subaddrAccount() const override;
     std::vector<std::set<uint32_t>> subaddrIndices() const override;
+    std::string convertTxToStr() override;
+    std::vector<std::string> convertTxToRawBlobStr() override;
+    double getWorstFeePerByte() const override;
+    std::vector<std::vector<std::vector<std::uint64_t>>> vinOffsets() const override;
+    std::vector<std::vector<std::uint64_t>> constructionDataRealOutputIndices() const override;
+    std::vector<std::vector<std::uint64_t>> vinAmounts() const override;
+    std::vector<std::vector<std::unique_ptr<EnoteDetails>>> getEnoteDetailsIn() const override;
+    bool finishParsingTx() override;
     // TODO: continue with interface;
 
     std::string multisigSignData() override;
-    void signMultisigTx() override;
+    void signMultisigTx(std::vector<std::string> *txids = nullptr) override;
     std::vector<std::string> signersKeys() const override;
-    std::string convertTxToStr() override;
+    void finishRestoringMultisigTransaction() override;
 
 private:
+    // Callback function to check all loaded tx's and generate confirmationMessage
+    bool checkLoadedTx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message);
+
     friend class WalletImpl;
     WalletImpl &m_wallet;
 
     int  m_status;
     std::string m_errorString;
+    std::string m_confirmationMessage;
     std::vector<tools::wallet2::pending_tx> m_pending_tx;
     std::unordered_set<crypto::public_key> m_signers;
     std::vector<std::string> m_tx_device_aux;

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -58,6 +58,7 @@ public:
     std::string multisigSignData() override;
     void signMultisigTx() override;
     std::vector<std::string> signersKeys() const override;
+    std::string convertTxToStr() override;
 
 private:
     friend class WalletImpl;
@@ -69,6 +70,8 @@ private:
     std::unordered_set<crypto::public_key> m_signers;
     std::vector<std::string> m_tx_device_aux;
     std::vector<crypto::key_image> m_key_images;
+    // wallet2 m_cold_key_images
+    std::unordered_map<crypto::public_key, crypto::key_image> m_tx_key_images;
 };
 
 

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -45,12 +45,15 @@ public:
     ~PendingTransactionImpl();
     int status() const override;
     std::string errorString() const override;
+    int extendedStatus() const override;
     std::string confirmationMessage() const override { return m_confirmationMessage; }
     bool commit(const std::string &filename = "", bool overwrite = false) override;
     uint64_t amount() const override;
+    std::vector<std::vector<uint64_t>> amountsPerDestination() const override;
     uint64_t dust() const override;
     uint64_t dustInFee() const override;
     uint64_t fee() const override;
+    std::vector<std::uint64_t> fees() const override;
     uint64_t change() const override;
     std::vector<std::string> txid() const override;
     uint64_t txCount() const override;
@@ -58,12 +61,16 @@ public:
     std::vector<std::set<uint32_t>> subaddrIndices() const override;
     std::string convertTxToStr() override;
     std::vector<std::string> convertTxToRawBlobStr() override;
+    std::vector<std::string> asHexStr() override;
+    std::vector<std::uint64_t> txWeights() override;
     double getWorstFeePerByte() const override;
     std::vector<std::vector<std::vector<std::uint64_t>>> vinOffsets() const override;
     std::vector<std::vector<std::uint64_t>> constructionDataRealOutputIndices() const override;
     std::vector<std::vector<std::uint64_t>> vinAmounts() const override;
+    std::vector<std::string> getTxKeys() const override;
     std::vector<std::vector<std::unique_ptr<EnoteDetails>>> getEnoteDetailsIn() const override;
     bool finishParsingTx() override;
+    std::unique_ptr<TransactionDescription> getTransactionDescription() override;
     // TODO: continue with interface;
 
     std::string multisigSignData() override;
@@ -79,6 +86,7 @@ private:
     WalletImpl &m_wallet;
 
     int  m_status;
+    int  m_extendedStatus;
     std::string m_errorString;
     std::string m_confirmationMessage;
     std::vector<tools::wallet2::pending_tx> m_pending_tx;

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -150,6 +150,11 @@ void TransactionHistoryImpl::refresh()
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = (wallet_height > pd.m_block_height) ? wallet_height - pd.m_block_height : 0;
         ti->m_unlock_time = pd.m_unlock_time;
+        // not used for payment_details
+        ti->m_change = 0;
+        ti->m_tx_state = TransactionInfo::TxState_Confirmed;
+        // not used for payment_details
+        ti->m_double_spend_seen = false;
         m_history.push_back(ti);
 
     }
@@ -193,6 +198,11 @@ void TransactionHistoryImpl::refresh()
         ti->m_label = pd.m_subaddr_indices.size() == 1 ? m_wallet->m_wallet->get_subaddress_label({pd.m_subaddr_account, *pd.m_subaddr_indices.begin()}) : "";
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = (wallet_height > pd.m_block_height) ? wallet_height - pd.m_block_height : 0;
+        ti->m_unlock_time = pd.m_unlock_time;
+        ti->m_change = pd.m_change;
+        ti->m_tx_state = TransactionInfo::TxState_Confirmed;
+        // not used for confirmed_transfer_details
+        ti->m_double_spend_seen = false;
 
         // single output transaction might contain multiple transfers
         for (const auto &d: pd.m_dests) {
@@ -229,6 +239,11 @@ void TransactionHistoryImpl::refresh()
         ti->m_label = pd.m_subaddr_indices.size() == 1 ? m_wallet->m_wallet->get_subaddress_label({pd.m_subaddr_account, *pd.m_subaddr_indices.begin()}) : "";
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = 0;
+        ti->m_unlock_time = pd.m_tx.unlock_time;
+        ti->m_change = pd.m_change;
+        ti->m_tx_state = (TransactionInfo::TxState) pd.m_state;
+        // not used for unconfirmed_transfer_details
+        ti->m_double_spend_seen = false;
         for (const auto &d : pd.m_dests)
         {
             ti->m_transfers.push_back({d.amount, d.address(m_wallet->m_wallet->nettype(), pd.m_payment_id)});
@@ -258,6 +273,11 @@ void TransactionHistoryImpl::refresh()
         ti->m_label     = m_wallet->m_wallet->get_subaddress_label(pd.m_subaddr_index);
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = 0;
+        ti->m_unlock_time = pd.m_unlock_time;
+        // not used for pool_payment_details
+        ti->m_change = 0;
+        ti->m_tx_state = TransactionInfo::TxState_PendingInPool;
+        ti->m_double_spend_seen = i->second.m_double_spend_seen;
         m_history.push_back(ti);
         
         LOG_PRINT_L1(__FUNCTION__ << ": Unconfirmed payment found " << pd.m_amount);

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -150,9 +150,10 @@ void TransactionHistoryImpl::refresh()
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = (wallet_height > pd.m_block_height) ? wallet_height - pd.m_block_height : 0;
         ti->m_unlock_time = pd.m_unlock_time;
+        ti->m_is_unlocked = m_wallet->m_wallet->is_transfer_unlocked(pd.m_unlock_time, pd.m_block_height);
         // not used for payment_details
         ti->m_change = 0;
-        ti->m_tx_state = TransactionInfo::TxState_Confirmed;
+        ti->m_tx_state = TransactionInfo::TxState::TxState_Confirmed;
         // not used for payment_details
         ti->m_double_spend_seen = false;
         m_history.push_back(ti);
@@ -199,8 +200,9 @@ void TransactionHistoryImpl::refresh()
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = (wallet_height > pd.m_block_height) ? wallet_height - pd.m_block_height : 0;
         ti->m_unlock_time = pd.m_unlock_time;
+        ti->m_is_unlocked = true;
         ti->m_change = pd.m_change;
-        ti->m_tx_state = TransactionInfo::TxState_Confirmed;
+        ti->m_tx_state = TransactionInfo::TxState::TxState_Confirmed;
         // not used for confirmed_transfer_details
         ti->m_double_spend_seen = false;
 
@@ -240,6 +242,7 @@ void TransactionHistoryImpl::refresh()
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = 0;
         ti->m_unlock_time = pd.m_tx.unlock_time;
+        ti->m_is_unlocked = true;
         ti->m_change = pd.m_change;
         ti->m_tx_state = (TransactionInfo::TxState) pd.m_state;
         // not used for unconfirmed_transfer_details
@@ -251,7 +254,9 @@ void TransactionHistoryImpl::refresh()
         m_history.push_back(ti);
     }
     
-    
+    // simplewallet called m_wallet.update_pool_state() & m_wallet.process_pool_state() before getting unconfirmed incoming transfers from the tx pool
+    // src: https://github.com/monero-project/monero/blob/8d4c625713e3419573dfcc7119c8848f47cabbaa/src/simplewallet/simplewallet.cpp#L10293-L10296
+    m_wallet->refreshPoolOnly();
     // unconfirmed payments (tx pool)
     std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> upayments;
     m_wallet->m_wallet->get_unconfirmed_payments(upayments);
@@ -274,9 +279,10 @@ void TransactionHistoryImpl::refresh()
         ti->m_timestamp = pd.m_timestamp;
         ti->m_confirmations = 0;
         ti->m_unlock_time = pd.m_unlock_time;
+        ti->m_is_unlocked = false;
         // not used for pool_payment_details
         ti->m_change = 0;
-        ti->m_tx_state = TransactionInfo::TxState_PendingInPool;
+        ti->m_tx_state = TransactionInfo::TxState::TxState_PendingInPool;
         ti->m_double_spend_seen = i->second.m_double_spend_seen;
         m_history.push_back(ti);
         

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -86,8 +86,10 @@ TransactionInfo *TransactionHistoryImpl::transaction(const std::string &id) cons
     return itr != m_history.end() ? *itr : nullptr;
 }
 
-std::vector<TransactionInfo *> TransactionHistoryImpl::getAll() const
+std::vector<TransactionInfo *> TransactionHistoryImpl::getAll(bool do_refresh /* = false */)
 {
+    if (do_refresh)
+        refresh();
     boost::shared_lock<boost::shared_mutex> lock(m_historyMutex);
     return m_history;
 }
@@ -268,6 +270,7 @@ void TransactionHistoryImpl::refresh()
         TransactionInfoImpl * ti = new TransactionInfoImpl();
         ti->m_paymentid = payment_id;
         ti->m_amount    = pd.m_amount;
+        ti->m_fee       = pd.m_fee;
         ti->m_direction = TransactionInfo::Direction_In;
         ti->m_hash      = string_tools::pod_to_hex(pd.m_tx_hash);
         ti->m_blockheight = pd.m_block_height;

--- a/src/wallet/api/transaction_history.h
+++ b/src/wallet/api/transaction_history.h
@@ -43,7 +43,7 @@ public:
     virtual int count() const;
     virtual TransactionInfo * transaction(int index)  const;
     virtual TransactionInfo * transaction(const std::string &id) const;
-    virtual std::vector<TransactionInfo*> getAll() const;
+    virtual std::vector<TransactionInfo*> getAll(bool do_refresh = false);
     virtual void refresh();
     virtual void setTxNote(const std::string &txid, const std::string &note);
 

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -149,4 +149,19 @@ uint64_t TransactionInfoImpl::unlockTime() const
     return m_unlock_time;
 }
 
+std::uint64_t TransactionInfoImpl::receivedChangeAmount() const
+{
+    return m_change;
+}
+
+TransactionInfo::TxState TransactionInfoImpl::txState() const
+{
+    return m_tx_state;
+}
+
+bool TransactionInfoImpl::isDoubleSpendSeen() const
+{
+    return m_double_spend_seen;
+}
+
 } // namespace

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -83,6 +83,11 @@ bool TransactionInfoImpl::isCoinbase() const
     return m_coinbase;
 }
 
+bool TransactionInfoImpl::isUnlocked() const
+{
+    return m_is_unlocked;
+}
+
 uint64_t TransactionInfoImpl::amount() const
 {
     return m_amount;

--- a/src/wallet/api/transaction_info.h
+++ b/src/wallet/api/transaction_info.h
@@ -47,6 +47,7 @@ public:
     virtual bool isPending() const override;
     virtual bool isFailed() const override;
     virtual bool isCoinbase() const override;
+    virtual bool isUnlocked() const override;
     virtual uint64_t amount() const override;
     //! always 0 for incoming txes
     virtual uint64_t fee() const override;
@@ -72,6 +73,7 @@ private:
     bool        m_pending;
     bool        m_failed;
     bool        m_coinbase;
+    bool        m_is_unlocked;
     uint64_t    m_amount;
     uint64_t    m_fee;
     uint64_t    m_blockheight;

--- a/src/wallet/api/transaction_info.h
+++ b/src/wallet/api/transaction_info.h
@@ -63,6 +63,10 @@ public:
     virtual uint64_t confirmations() const override;
     virtual uint64_t unlockTime() const override;
 
+    std::uint64_t receivedChangeAmount() const override;
+    TxState txState() const override;
+    bool isDoubleSpendSeen() const override;
+
 private:
     int         m_direction;
     bool        m_pending;
@@ -81,6 +85,12 @@ private:
     std::vector<Transfer> m_transfers;
     uint64_t    m_confirmations;
     uint64_t    m_unlock_time;
+    // received change amount from outgoing transaction
+    std::uint64_t m_change;
+    // tx state : TxState_Pending / TxState_PendingInPool / TxState_Failed / TxState_Confirmed
+    TxState m_tx_state;
+    // is double spend seen
+    bool m_double_spend_seen;
 
     friend class TransactionHistoryImpl;
 

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -68,7 +68,7 @@ string UnsignedTransactionImpl::errorString() const
     return m_errorString;
 }
 
-bool UnsignedTransactionImpl::sign(const std::string &signedFileName)
+bool UnsignedTransactionImpl::sign(const std::string &signedFileName, bool do_export_raw /* = false */, std::vector<std::string> *tx_ids_out /* = nullptr */)
 {
   if(m_wallet.watchOnly())
   {
@@ -79,7 +79,7 @@ bool UnsignedTransactionImpl::sign(const std::string &signedFileName)
   std::vector<tools::wallet2::pending_tx> ptx;
   try
   {
-    bool r = m_wallet.m_wallet->sign_tx(m_unsigned_tx_set, signedFileName, ptx);
+    bool r = m_wallet.m_wallet->sign_tx(m_unsigned_tx_set, signedFileName, ptx, do_export_raw);
     if (!r)
     {
       m_errorString = tr("Failed to sign transaction");
@@ -89,9 +89,17 @@ bool UnsignedTransactionImpl::sign(const std::string &signedFileName)
   }
   catch (const std::exception &e)
   {
-    m_errorString = string(tr("Failed to sign transaction")) + e.what();
+    m_errorString = string(tr("Failed to sign transaction: ")) + e.what();
     m_status = Status_Error;
     return false;
+  }
+  if (tx_ids_out)
+  {
+    std::string tx_id_str;
+    for (const auto &tx : ptx)
+    {
+      (*tx_ids_out).push_back(epee::string_tools::pod_to_hex(get_transaction_hash(tx.tx)));
+    }
   }
   return true;
 }
@@ -122,13 +130,18 @@ bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_nu
         {
           if (!payment_id_string.empty())
             payment_id_string += ", ";
-          if (payment_id8 == crypto::null_hash8)
-          {
+
+          // if none of the addresses are integrated addresses, it's a dummy one
+          bool is_dummy = true;
+          for (const auto &e: cd.dests)
+            if (e.is_integrated)
+              is_dummy = false;
+
+          if (is_dummy)
             payment_id_string += std::string("dummy encrypted payment ID");
-          }
           else
           {
-            payment_id_string += std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
+            payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
             has_encrypted_payment_id = true;
           }
         }
@@ -198,6 +211,10 @@ bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_nu
         dests.erase(cd.change_dts.addr);
     }
   }
+
+  if (payment_id_string.empty())
+    payment_id_string = "no payment ID";
+
   std::string dest_string;
   for (auto i = dests.begin(); i != dests.end(); )
   {
@@ -218,7 +235,7 @@ bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_nu
   else
     change_string += tr("no change");
   uint64_t fee = amount - amount_to_dests;
-  m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % extra_message).str();
+  m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
   return true;
 }
 

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -37,7 +37,6 @@
 
 #include <memory>
 #include <vector>
-#include <sstream>
 #include <boost/format.hpp>
 
 using namespace std;
@@ -95,7 +94,6 @@ bool UnsignedTransactionImpl::sign(const std::string &signedFileName, bool do_ex
   }
   if (tx_ids_out)
   {
-    std::string tx_id_str;
     for (const auto &tx : ptx)
     {
       (*tx_ids_out).push_back(epee::string_tools::pod_to_hex(get_transaction_hash(tx.tx)));
@@ -107,136 +105,149 @@ bool UnsignedTransactionImpl::sign(const std::string &signedFileName, bool do_ex
 //----------------------------------------------------------------------------------------------------
 bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_num_txes, const std::function<const tools::wallet2::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message)
 {
-  // gather info to ask the user
-  uint64_t amount = 0, amount_to_dests = 0, change = 0;
-  size_t min_ring_size = ~0;
-  std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
-  int first_known_non_zero_change_index = -1;
-  std::string payment_id_string = "";
-  for (size_t n = 0; n < get_num_txes(); ++n)
-  {
-    const tools::wallet2::tx_construction_data &cd = get_tx(n);
-
-    std::vector<cryptonote::tx_extra_field> tx_extra_fields;
-    bool has_encrypted_payment_id = false;
-    crypto::hash8 payment_id8 = crypto::null_hash8;
-    if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
+    // gather info to ask the user
+    uint64_t amount = 0, amount_to_dests = 0, change = 0;
+    size_t min_ring_size = ~0;
+    std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> dests;
+    int first_known_non_zero_change_index = -1;
+    std::string payment_id_string = "";
+    for (size_t n = 0; n < get_num_txes(); ++n)
     {
-      cryptonote::tx_extra_nonce extra_nonce;
-      if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
-      {
-        crypto::hash payment_id;
-        if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+        const tools::wallet2::tx_construction_data &cd = get_tx(n);
+
+        std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+        bool has_encrypted_payment_id = false;
+        crypto::hash8 payment_id8 = crypto::null_hash8;
+        if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
         {
-          if (!payment_id_string.empty())
-            payment_id_string += ", ";
+            cryptonote::tx_extra_nonce extra_nonce;
+            if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+            {
+                crypto::hash payment_id;
+                if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+                {
+                    if (!payment_id_string.empty())
+                        payment_id_string += ", ";
 
-          // if none of the addresses are integrated addresses, it's a dummy one
-          bool is_dummy = true;
-          for (const auto &e: cd.dests)
-            if (e.is_integrated)
-              is_dummy = false;
+                    // if none of the addresses are integrated addresses, it's a dummy one
+                    bool is_dummy = true;
+                    for (const auto &e: cd.dests)
+                        if (e.is_integrated)
+                            is_dummy = false;
 
-          if (is_dummy)
-            payment_id_string += std::string("dummy encrypted payment ID");
-          else
-          {
-            payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
-            has_encrypted_payment_id = true;
-          }
+                    if (is_dummy)
+                        payment_id_string += std::string("dummy encrypted payment ID");
+                    else
+                    {
+                        payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
+                        has_encrypted_payment_id = true;
+                    }
+                }
+                else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+                {
+                    if (!payment_id_string.empty())
+                        payment_id_string += ", ";
+                    payment_id_string = std::string("unencrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id);
+                    payment_id_string += " (OBSOLETE)";
+                }
+            }
         }
-        else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+
+        for (size_t s = 0; s < cd.sources.size(); ++s)
         {
-          if (!payment_id_string.empty())
-            payment_id_string += ", ";
-          payment_id_string = std::string("unencrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id);
+            amount += cd.sources[s].amount;
+            size_t ring_size = cd.sources[s].outputs.size();
+            if (ring_size < min_ring_size)
+                min_ring_size = ring_size;
         }
-      }
-    }
-
-    for (size_t s = 0; s < cd.sources.size(); ++s)
-    {
-      amount += cd.sources[s].amount;
-      size_t ring_size = cd.sources[s].outputs.size();
-      if (ring_size < min_ring_size)
-        min_ring_size = ring_size;
-    }
-    for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
-    {
-      const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
-      std::string address, standard_address = get_account_address_as_str(m_wallet.m_wallet->nettype(), entry.is_subaddress, entry.addr);
-      if (has_encrypted_payment_id && !entry.is_subaddress)
-      {
-        address = get_account_integrated_address_as_str(m_wallet.m_wallet->nettype(), entry.addr, payment_id8);
-        address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");
-      }
-      else
-        address = standard_address;
-      auto i = dests.find(entry.addr);
-      if (i == dests.end())
-        dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
-      else
-        i->second.second += entry.amount;
-      amount_to_dests += entry.amount;
-    }
-    if (cd.change_dts.amount > 0)
-    {
-      auto it = dests.find(cd.change_dts.addr);
-      if (it == dests.end())
-      {
-        m_status = Status_Error;
-        m_errorString = tr("Claimed change does not go to a paid address");
-        return false;
-      }
-      if (it->second.second < cd.change_dts.amount)
-      {
-        m_status = Status_Error;
-        m_errorString = tr("Claimed change is larger than payment to the change address");
-        return  false;
-      }
-      if (cd.change_dts.amount > 0)
-      {
-        if (first_known_non_zero_change_index == -1)
-          first_known_non_zero_change_index = n;
-        if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
+        for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
         {
-          m_status = Status_Error;
-          m_errorString = tr("Change goes to more than one address");
-          return false;
+            const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
+            std::string address, standard_address = get_account_address_as_str(m_wallet.m_wallet->nettype(), entry.is_subaddress, entry.addr);
+            if (has_encrypted_payment_id && !entry.is_subaddress)
+            {
+                address = get_account_integrated_address_as_str(m_wallet.m_wallet->nettype(), entry.addr, payment_id8);
+                address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");
+            }
+            else
+                address = standard_address;
+            auto i = dests.find(entry.addr);
+            if (i == dests.end())
+                dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
+            else
+                i->second.second += entry.amount;
+            amount_to_dests += entry.amount;
         }
-      }
-      change += cd.change_dts.amount;
-      it->second.second -= cd.change_dts.amount;
-      if (it->second.second == 0)
-        dests.erase(cd.change_dts.addr);
+        if (cd.change_dts.amount > 0)
+        {
+            auto it = dests.find(cd.change_dts.addr);
+            if (it == dests.end())
+            {
+                m_status = Status_Error;
+                m_errorString = tr("Claimed change does not go to a paid address");
+                return false;
+            }
+            if (it->second.second < cd.change_dts.amount)
+            {
+                m_status = Status_Error;
+                m_errorString = tr("Claimed change is larger than payment to the change address");
+                return  false;
+            }
+            if (cd.change_dts.amount > 0)
+            {
+                if (first_known_non_zero_change_index == -1)
+                    first_known_non_zero_change_index = n;
+                if (memcmp(&cd.change_dts.addr, &get_tx(first_known_non_zero_change_index).change_dts.addr, sizeof(cd.change_dts.addr)))
+                {
+                    m_status = Status_Error;
+                    m_errorString = tr("Change goes to more than one address");
+                    return false;
+                }
+            }
+            change += cd.change_dts.amount;
+            it->second.second -= cd.change_dts.amount;
+            if (it->second.second == 0)
+                dests.erase(cd.change_dts.addr);
+        }
     }
-  }
 
-  if (payment_id_string.empty())
-    payment_id_string = "no payment ID";
+    if (payment_id_string.empty())
+        payment_id_string = "no payment ID";
 
-  std::string dest_string;
-  for (auto i = dests.begin(); i != dests.end(); )
-  {
-    dest_string += (boost::format(tr("sending %s to %s")) % cryptonote::print_money(i->second.second) % i->second.first).str();
-    ++i;
-    if (i != dests.end())
-      dest_string += ", ";
-  }
-  if (dest_string.empty())
-    dest_string = tr("with no destinations");
+    std::string dest_string;
+    size_t n_dummy_outputs = 0;
+    for (auto i = dests.begin(); i != dests.end(); )
+    {
+        if (i->second.second > 0)
+        {
+            if (!dest_string.empty())
+                dest_string += ", ";
+            dest_string += (boost::format(tr("sending %s to %s")) % cryptonote::print_money(i->second.second) % i->second.first).str();
+        }
+        else
+            ++n_dummy_outputs;
+        ++i;
+    }
+    if (n_dummy_outputs > 0)
+    {
+        if (!dest_string.empty())
+            dest_string += ", ";
+        dest_string += std::to_string(n_dummy_outputs) + tr(" dummy output(s)");
+    }
+    if (dest_string.empty())
+        dest_string = tr("with no destinations");
 
-  std::string change_string;
-  if (change > 0)
-  {
-    std::string address = get_account_address_as_str(m_wallet.m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
-    change_string += (boost::format(tr("%s change to %s")) % cryptonote::print_money(change) % address).str();
-  }
-  else
-    change_string += tr("no change");
-  uint64_t fee = amount - amount_to_dests;
-  m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
-  return true;
+    std::string change_string;
+    if (change > 0)
+    {
+        std::string address = get_account_address_as_str(m_wallet.m_wallet->nettype(), get_tx(0).subaddr_account > 0, get_tx(0).change_dts.addr);
+        change_string += (boost::format(tr("%s change to %s")) % cryptonote::print_money(change) % address).str();
+    }
+    else
+        change_string += tr("no change");
+    uint64_t fee = amount - amount_to_dests;
+    m_confirmationMessage = (boost::format(tr("Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %s. Is this okay?")) % (unsigned long)get_num_txes() % cryptonote::print_money(amount) % cryptonote::print_money(fee) % dest_string % change_string % (unsigned long)min_ring_size % payment_id_string % extra_message).str();
+    return true;
 }
 
 std::vector<uint64_t> UnsignedTransactionImpl::amount() const
@@ -361,6 +372,15 @@ std::string UnsignedTransactionImpl::signAsString()
         m_status = Status_Error;
         return "";
     }
+}
+
+std::unique_ptr<TransactionDescription> UnsignedTransactionImpl::getTransactionDescription()
+{
+    std::vector<tools::wallet2::tx_construction_data> tx_construction_data;
+    for (size_t i = 0; i < m_unsigned_tx_set.txes.size(); ++i)
+        tx_construction_data.push_back(m_unsigned_tx_set.txes[i]);
+
+    return m_wallet.getTxDescription(tx_construction_data, m_status, m_errorString);
 }
 
 } // namespace

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -324,4 +324,26 @@ uint64_t UnsignedTransactionImpl::minMixinCount() const
     return min_mixin;
 }
 
+std::string UnsignedTransactionImpl::signAsString()
+{
+    if(m_wallet.watchOnly())
+    {
+        m_errorString = tr("This is a watch only wallet");
+        m_status = Status_Error;
+        return "";
+    }
+    tools::wallet2::signed_tx_set signed_txes;
+    std::vector<tools::wallet2::pending_tx> ptx;
+    try
+    {
+        return m_wallet.m_wallet->sign_tx_dump_to_str(m_unsigned_tx_set, ptx, signed_txes);
+    }
+    catch (const std::exception &e)
+    {
+        m_errorString = string(tr("Failed to sign transaction ")) + e.what();
+        m_status = Status_Error;
+        return "";
+    }
+}
+
 } // namespace

--- a/src/wallet/api/unsigned_transaction.h
+++ b/src/wallet/api/unsigned_transaction.h
@@ -52,7 +52,7 @@ public:
     std::vector<std::string> recipientAddress() const override;
     uint64_t txCount() const override;
     // sign txs and save to file
-    bool sign(const std::string &signedFileName) override;
+    bool sign(const std::string &signedFileName, bool do_export_raw = false, std::vector<std::string> *tx_ids_out = nullptr) override;
     std::string confirmationMessage() const override {return m_confirmationMessage;}
     uint64_t minMixinCount() const override;
     std::string signAsString() override;

--- a/src/wallet/api/unsigned_transaction.h
+++ b/src/wallet/api/unsigned_transaction.h
@@ -55,6 +55,7 @@ public:
     bool sign(const std::string &signedFileName) override;
     std::string confirmationMessage() const override {return m_confirmationMessage;}
     uint64_t minMixinCount() const override;
+    std::string signAsString() override;
 
 private:
     // Callback function to check all loaded tx's and generate confirmationMessage

--- a/src/wallet/api/unsigned_transaction.h
+++ b/src/wallet/api/unsigned_transaction.h
@@ -56,6 +56,7 @@ public:
     std::string confirmationMessage() const override {return m_confirmationMessage;}
     uint64_t minMixinCount() const override;
     std::string signAsString() override;
+    std::unique_ptr<TransactionDescription> getTransactionDescription() override;
 
 private:
     // Callback function to check all loaded tx's and generate confirmationMessage

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -33,6 +33,8 @@
 #include "device/device.hpp"
 #include "crypto/crypto.h"
 #include "enote_details.h"
+#include "device/device.hpp"
+#include "net/net_ssl.h"
 #include "pending_transaction.h"
 #include "string_tools.h"
 #include "unsigned_transaction.h"
@@ -46,6 +48,7 @@
 
 #include "mnemonics/electrum-words.h"
 #include "mnemonics/english.h"
+#include "wallet/fee_priority.h"
 #include <boost/format.hpp>
 #include <sstream>
 #include <unordered_map>
@@ -198,13 +201,11 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
-    virtual void on_money_received(uint64_t height, const crypto::hash &txid,
-        const cryptonote::transaction& tx, uint64_t amount, uint64_t burnt,
-        const cryptonote::subaddress_index& subaddr_index, const crypto::hash &payment_id,
-        bool is_change, uint64_t unlock_time)
+    virtual void on_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, uint64_t burnt, const cryptonote::subaddress_index& subaddr_index, const crypto::hash &payment_id, bool is_change, uint64_t unlock_time, const crypto::public_key& enote_pub_key)
     {
 
         std::string tx_hash =  epee::string_tools::pod_to_hex(txid);
+        std::string enote_pub_key_str = epee::string_tools::pod_to_hex(enote_pub_key);
 
         LOG_PRINT_L3(__FUNCTION__ << ": money received. height:  " << height
                      << ", tx: " << tx_hash
@@ -212,9 +213,9 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
                      << ", burnt: " << print_money(burnt)
                      << ", raw_output_value: " << print_money(amount)
                      << ", idx: " << subaddr_index);
-        // do not signal on received tx if wallet is not synchronized completely
-        if (m_listener && m_wallet->synchronized()) {
-            m_listener->moneyReceived(tx_hash, amount - burnt);
+        // do not signal on received tx if unattended wallet is not synchronized completely
+        if (m_listener && (m_wallet->synchronized() || !m_wallet->m_wallet->is_unattended())) {
+            m_listener->moneyReceived(tx_hash, amount - burnt, burnt, enote_pub_key_str, is_change, cryptonote::is_coinbase(tx));
             m_listener->updated();
         }
     }
@@ -228,25 +229,27 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
                      << ", tx: " << tx_hash
                      << ", amount: " << print_money(amount)
                      << ", idx: " << subaddr_index);
-        // do not signal on received tx if wallet is not synchronized completely
-        if (m_listener && m_wallet->synchronized()) {
+        // do not signal on received tx if unattended wallet is not synchronized completely
+        if (m_listener && (m_wallet->synchronized() || !m_wallet->m_wallet->is_unattended())) {
             m_listener->unconfirmedMoneyReceived(tx_hash, amount);
             m_listener->updated();
         }
     }
 
     virtual void on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx,
-                                uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index)
+                                uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index,
+                                const crypto::public_key& enote_pub_key)
     {
         // TODO;
         std::string tx_hash = epee::string_tools::pod_to_hex(txid);
+        std::string enote_pub_key_str = epee::string_tools::pod_to_hex(enote_pub_key);
         LOG_PRINT_L3(__FUNCTION__ << ": money spent. height:  " << height
                      << ", tx: " << tx_hash
                      << ", amount: " << print_money(amount)
                      << ", idx: " << subaddr_index);
-        // do not signal on sent tx if wallet is not synchronized completely
-        if (m_listener && m_wallet->synchronized()) {
-            m_listener->moneySpent(tx_hash, amount);
+        // do not signal on sent tx if unattended wallet is not synchronized completely
+        if (m_listener && (m_wallet->synchronized() || !m_wallet->m_wallet->is_unattended())) {
+            m_listener->moneySpent(tx_hash, amount, enote_pub_key_str, std::make_pair(subaddr_index.major, subaddr_index.minor));
             m_listener->updated();
         }
     }
@@ -331,6 +334,19 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
     WalletImpl     * m_wallet;
 };
 
+WalletKeysDecryptGuard::~WalletKeysDecryptGuard() {}
+
+struct WalletKeysDecryptGuardImpl: public WalletKeysDecryptGuard
+{
+    WalletKeysDecryptGuardImpl(tools::wallet2 &w, const epee::wipeable_string &password):
+        u(w, &password)
+    {}
+
+    ~WalletKeysDecryptGuardImpl() override = default;
+
+    tools::wallet_keys_unlocker u;
+};
+
 Wallet::~Wallet() {}
 
 WalletListener::~WalletListener() {}
@@ -371,6 +387,20 @@ bool Wallet::paymentIdValid(const string &paiment_id)
     if (tools::wallet2::parse_long_payment_id(paiment_id, pid))
         return true;
     return false;
+}
+
+bool Wallet::isSubaddress(const std::string &address, NetworkType nettype)
+{
+  cryptonote::address_parse_info info;
+  return get_account_address_from_str(info, static_cast<cryptonote::network_type>(nettype), address) ? info.is_subaddress : false;
+}
+
+std::string Wallet::getAddressFromIntegrated(const std::string &address, NetworkType nettype)
+{
+  cryptonote::address_parse_info info;
+  if (!get_account_address_from_str(info, static_cast<cryptonote::network_type>(nettype), address))
+    return "";
+  return get_account_address_as_str(static_cast<cryptonote::network_type>(nettype), info.is_subaddress, info.address);
 }
 
 bool Wallet::addressValid(const std::string &str, NetworkType nettype)
@@ -463,7 +493,7 @@ void Wallet::error(const std::string &category, const std::string &str) {
 }
 
 ///////////////////////// WalletImpl implementation ////////////////////////
-WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds)
+WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds, const bool unattended /* = true */)
     :m_wallet(nullptr)
     , m_status(Wallet::Status_Ok)
     , m_wallet2Callback(nullptr)
@@ -473,8 +503,9 @@ WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds)
     , m_rebuildWalletCache(false)
     , m_is_connected(false)
     , m_refreshShouldRescan(false)
+    , m_kdf_rounds(kdf_rounds)
 {
-    m_wallet.reset(new tools::wallet2(static_cast<cryptonote::network_type>(nettype), kdf_rounds, true));
+    m_wallet.reset(new tools::wallet2(static_cast<cryptonote::network_type>(nettype), kdf_rounds, unattended));
     m_history.reset(new TransactionHistoryImpl(this));
     m_wallet2Callback.reset(new Wallet2CallbackImpl(this));
     m_wallet->callback(m_wallet2Callback.get());
@@ -512,7 +543,7 @@ WalletImpl::~WalletImpl()
     LOG_PRINT_L1(__FUNCTION__ << " finished");
 }
 
-bool WalletImpl::create(const std::string &path, const std::string &password, const std::string &language)
+bool WalletImpl::create(const std::string &path, const std::string &password, const std::string &language, bool create_address_file /* = false */, bool non_deterministic /* = false */)
 {
 
     clearStatus();
@@ -533,13 +564,13 @@ bool WalletImpl::create(const std::string &path, const std::string &password, co
         setStatusCritical(error);
         return false;
     }
-    setSeedLanguage(language);
+    if (!non_deterministic)
+        setSeedLanguage(language);
     if (!statusOk())
         return false;
     crypto::secret_key recovery_val, secret_key;
     try {
-        recovery_val = m_wallet->generate(path, password, secret_key, false, false);
-        m_password = password;
+        recovery_val = m_wallet->generate(path, password, secret_key, /* recover */ false, non_deterministic, create_address_file);
         clearStatus();
     } catch (const std::exception &e) {
         LOG_ERROR("Error creating wallet: " << e.what());
@@ -708,7 +739,7 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
             LOG_PRINT_L1("Generated new view only wallet from keys");
         }
         if(has_spendkey && !has_viewkey) {
-           m_wallet->generate(path, password, spendkey, true, false);
+           m_wallet->generate(path, password, spendkey, /* recover */ true, /* non-deterministic */ false);
            setSeedLanguage(language);
            if (!statusOk())
                return false;
@@ -721,6 +752,70 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
         return false;
     }
     m_password = password;
+    m_wallet->set_ring_database(get_default_ringdb_path(m_wallet->nettype()));
+    return true;
+}
+
+bool WalletImpl::createFromJson(const std::string &json_file_path, std::string &pw_out)
+{
+    try
+    {
+        boost::program_options::variables_map vm;
+        boost::program_options::store(
+            boost::program_options::command_line_parser({
+                nettype() == TESTNET ? "--testnet" : nettype() == STAGENET ? "--stagenet" : "",
+            }).options([]{
+                boost::program_options::options_description options_description{};
+                tools::wallet2::init_options(options_description);
+                return options_description;
+            }()
+            ).run(),
+            vm
+        );
+        auto r = m_wallet->make_from_json(vm, m_wallet->is_unattended(), json_file_path, /* password_promper */ {});
+        if (!r.first) {
+            setStatusError(tr("failed to generate new wallet from json"));
+            return false;
+        }
+        m_wallet = std::move(r.first);
+        pw_out = std::string(r.second.password().data(), r.second.password().size());
+        LOG_PRINT_L1("Generated new wallet from json");
+    }
+    catch (const std::exception& e) {
+        setStatusError(string(tr("failed to generate new wallet from json: ")) + e.what());
+        return false;
+    }
+    m_wallet->set_ring_database(get_default_ringdb_path(m_wallet->nettype()));
+    return true;
+}
+
+bool WalletImpl::recoverFromMultisigSeed(const std::string &path,
+                                         const std::string &password,
+                                         const std::string &language,
+                                         const std::string &multisig_seed,
+                                         const std::string seed_pass /* = "" */,
+                                         const bool do_create_address_file /* = false */)
+{
+    try
+    {
+        if (seed_pass.empty())
+            m_wallet->generate(path, password, multisig_seed, do_create_address_file);
+        else
+        {
+            crypto::secret_key key;
+            crypto::cn_slow_hash(seed_pass.data(), seed_pass.size(), (crypto::hash&)key);
+            sc_reduce32((unsigned char*)key.data);
+            const epee::wipeable_string &msig_keys = m_wallet->decrypt<epee::wipeable_string>(std::string(multisig_seed.data(), multisig_seed.size()), key, true);
+            m_wallet->generate(path, password, msig_keys, do_create_address_file);
+        }
+        setSeedLanguage(language);
+        LOG_PRINT_L1("Generated new multisig wallet from multisig seed");
+    }
+    catch (const std::exception& e) {
+        setStatusError(string(tr("failed to generate new multisig wallet: ")) + e.what());
+        return false;
+    }
+    m_wallet->set_ring_database(get_default_ringdb_path(m_wallet->nettype()));
     return true;
 }
 
@@ -853,22 +948,6 @@ std::string WalletImpl::seed(const std::string& seed_offset) const
     if (m_wallet)
         m_wallet->get_seed(seed, seed_offset);
     return std::string(seed.data(), seed.size()); // TODO
-}
-
-std::string WalletImpl::getSeedLanguage() const
-{
-    return m_wallet->get_seed_language();
-}
-
-void WalletImpl::setSeedLanguage(const std::string &arg)
-{
-    if (checkBackgroundSync("cannot set seed language"))
-        return;
-
-    if (crypto::ElectrumWords::is_valid_language(arg))
-        m_wallet->set_seed_language(arg);
-    else
-        setStatusError(string(tr("Failed to set seed language. Language not valid: ")) + arg);
 }
 
 int WalletImpl::status() const
@@ -1020,21 +1099,9 @@ bool WalletImpl::init(const std::string &daemon_address, uint64_t upper_transact
     return doInit(daemon_address, proxy_address, upper_transaction_size_limit, use_ssl);
 }
 
-void WalletImpl::allowMismatchedDaemonVersion(bool allow_mismatch)
-{
-    m_wallet->allow_mismatched_daemon_version(allow_mismatch);
-}
-
 void WalletImpl::setRingDatabase(const std::string &path)
 {
     m_wallet->set_ring_database(path);
-}
-
-void WalletImpl::setRefreshFromBlockHeight(uint64_t refresh_from_block_height)
-{
-    if (checkBackgroundSync("cannot change refresh height"))
-        return;
-    m_wallet->set_refresh_from_block_height(refresh_from_block_height);
 }
 
 void WalletImpl::setRecoveringFromSeed(bool recoveringFromSeed)
@@ -1047,19 +1114,26 @@ void WalletImpl::setRecoveringFromDevice(bool recoveringFromDevice)
     m_recoveringFromDevice = recoveringFromDevice;
 }
 
-void WalletImpl::setSubaddressLookahead(uint32_t major, uint32_t minor)
-{
-    m_wallet->set_subaddress_lookahead(major, minor);
-}
-
 uint64_t WalletImpl::balance(uint32_t accountIndex) const
 {
     return m_wallet->balance(accountIndex, false);
 }
 
-uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex) const
+std::map<uint32_t, uint64_t> WalletImpl::balancePerSubaddress(uint32_t accountIndex /* = 0 */) const
 {
-    return m_wallet->unlocked_balance(accountIndex, false);
+    return m_wallet->balance_per_subaddress(accountIndex, false);
+}
+
+uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex /* = 0 */,
+                                     uint64_t *blocks_to_unlock /* = NULL */,
+                                     uint64_t *time_to_unlock /* = NULL */) const
+{
+    return m_wallet->unlocked_balance(accountIndex, false, blocks_to_unlock, time_to_unlock);
+}
+
+std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> WalletImpl::unlockedBalancePerSubaddress(uint32_t accountIndex /* = 0 */) const
+{
+    return m_wallet->unlocked_balance_per_subaddress(accountIndex, false);
 }
 
 uint64_t WalletImpl::blockChainHeight() const
@@ -1124,13 +1198,17 @@ bool WalletImpl::synchronized() const
     return m_synchronized;
 }
 
-bool WalletImpl::refresh()
+bool WalletImpl::refresh(std::uint64_t start_height /* = 0 */,
+                         bool check_pool /* = true */,
+                         bool try_incremental /* = false */,
+                         std::uint64_t max_blocks /* = std::numeric_limits<uint64_t>::max() */,
+                         std::uint64_t *blocks_fetched_out /* = nullptr */,
+                         bool *received_money_out /* = nullptr */)
 {
     clearStatus();
-    //TODO: make doRefresh return bool to know whether the error occurred during refresh or not
-    //otherwise one may try, say, to send transaction, transfer fails and this method returns false
-    doRefresh();
-    return statusOk();
+    bool did_error_occur;
+    doRefresh(start_height, check_pool, try_incremental, max_blocks, &did_error_occur, blocks_fetched_out, received_money_out);
+    return !did_error_occur;
 }
 
 void WalletImpl::refreshAsync()
@@ -1140,21 +1218,26 @@ void WalletImpl::refreshAsync()
     m_refreshCV.notify_one();
 }
 
-bool WalletImpl::rescanBlockchain()
+bool WalletImpl::rescanBlockchain(bool do_hard_rescan /* = false */, bool do_keep_key_images /* = false */, bool do_skip_refresh /* = false */)
 {
     if (checkBackgroundSync("cannot rescan blockchain"))
         return false;
     clearStatus();
     m_refreshShouldRescan = true;
-    doRefresh();
+    m_do_hard_rescan = do_hard_rescan;
+    m_do_keep_key_images_on_rescan = do_keep_key_images;
+    if (!do_skip_refresh)
+        doRefresh();
     return statusOk();
 }
 
-void WalletImpl::rescanBlockchainAsync()
+void WalletImpl::rescanBlockchainAsync(bool do_hard_rescan /* = false */, bool do_keep_key_images /* = false */)
 {
     if (checkBackgroundSync("cannot rescan blockchain"))
         return;
     m_refreshShouldRescan = true;
+    m_do_hard_rescan = do_hard_rescan;
+    m_do_keep_key_images_on_rescan = do_keep_key_images;
     refreshAsync();
 }
 
@@ -1229,7 +1312,7 @@ bool WalletImpl::submitTransaction(const string &fileName) {
     setStatusError(tr("Failed to load transaction from file"));
     return false;
   }
-  
+
   if(!transaction->commit()) {
     setStatusError(transaction->m_errorString);
     return false;
@@ -1289,7 +1372,7 @@ std::string WalletImpl::exportKeyImagesAsString(bool all /* = false */)
     return "";
 }
 
-bool WalletImpl::importKeyImages(const string &filename)
+bool WalletImpl::importKeyImages(const std::string &filename, std::uint64_t *spent_out /* = nullptr */, std::uint64_t *unspent_out /* = nullptr */, std::uint64_t *import_height /* = nullptr */)
 {
   if (checkBackgroundSync("cannot import key images"))
     return false;
@@ -1299,10 +1382,16 @@ bool WalletImpl::importKeyImages(const string &filename)
   }
   try
   {
-    uint64_t spent = 0, unspent = 0;
-    uint64_t height = m_wallet->import_key_images(filename, spent, unspent);
-    LOG_PRINT_L2("Signed key images imported to height " << height << ", "
-        << print_money(spent) << " spent, " << print_money(unspent) << " unspent");
+    uint64_t spent = 0, unspent = 0, height;
+    if (!spent_out)
+        spent_out = &spent;
+    if (!unspent_out)
+        unspent_out = &unspent;
+    if (!import_height)
+        import_height = &height;
+    *import_height = m_wallet->import_key_images(filename, *spent_out, *unspent_out);
+    LOG_PRINT_L2("Signed key images imported to height " << *import_height << ", "
+        << print_money(*spent_out) << " spent, " << print_money(*unspent_out) << " unspent");
   }
   catch (const std::exception &e)
   {
@@ -1352,8 +1441,8 @@ bool WalletImpl::exportOutputs(const string &filename, bool all)
 
     try
     {
-        std::string data = exportEnotesToStr(all);
-        bool r = saveToFile(filename, data);
+        std::string data = m_wallet->export_outputs_to_str(all);
+        bool r = m_wallet->save_to_file(filename, data);
         if (!r)
         {
             LOG_ERROR("Failed to save file " << filename);
@@ -1383,7 +1472,7 @@ bool WalletImpl::importOutputs(const string &filename)
     }
 
     std::string data;
-    bool r = loadFromFile(filename, data);
+    bool r = m_wallet->load_from_file(filename, data);
     if (!r)
     {
         LOG_ERROR("Failed to read file: " << filename);
@@ -1393,7 +1482,7 @@ bool WalletImpl::importOutputs(const string &filename)
 
     try
     {
-        size_t n_outputs = importEnotesFromStr(data);
+        size_t n_outputs = m_wallet->import_outputs_from_str(data);
         if (!statusOk())
             throw runtime_error(errorString());
         LOG_PRINT_L2(std::to_string(n_outputs) << " outputs imported");
@@ -1408,7 +1497,7 @@ bool WalletImpl::importOutputs(const string &filename)
     return true;
 }
 
-bool WalletImpl::scanTransactions(const std::vector<std::string> &txids)
+bool WalletImpl::scanTransactions(const std::vector<std::string> &txids, bool *wont_reprocess_recent_txs_via_untrusted_daemon /* = nullptr */ )
 {
     if (checkBackgroundSync("cannot scan transactions"))
         return false;
@@ -1437,6 +1526,8 @@ bool WalletImpl::scanTransactions(const std::vector<std::string> &txids)
     }
     catch (const tools::error::wont_reprocess_recent_txs_via_untrusted_daemon &e)
     {
+        if (wont_reprocess_recent_txs_via_untrusted_daemon)
+            *wont_reprocess_recent_txs_via_untrusted_daemon = true;
         setStatusError(e.what());
         return false;
     }
@@ -1712,7 +1803,7 @@ bool WalletImpl::hasMultisigPartialKeyImages() const {
     return false;
 }
 
-PendingTransaction* WalletImpl::restoreMultisigTransaction(const string& signData) {
+PendingTransaction* WalletImpl::restoreMultisigTransaction(const string& signData, bool ask_for_confirmation /* = false */) {
     try {
         clearStatus();
         checkMultisigWalletReady(m_wallet);
@@ -1723,13 +1814,20 @@ PendingTransaction* WalletImpl::restoreMultisigTransaction(const string& signDat
         }
 
         tools::wallet2::multisig_tx_set txSet;
-        if (!m_wallet->load_multisig_tx(binary, txSet, {})) {
+        if (!m_wallet->load_multisig_tx(binary, txSet, {}, ask_for_confirmation)) {
           throw runtime_error("couldn't parse multisig transaction data");
         }
 
         auto ptx = new PendingTransactionImpl(*this);
         ptx->m_pending_tx = txSet.m_ptx;
         ptx->m_signers = txSet.m_signers;
+
+        // Check tx data and construct confirmation message
+        if (ask_for_confirmation) {
+            std::string extra_message;
+            ptx->checkLoadedTx([&ptx](){return ptx->txCount();}, [&ptx](size_t n)->const tools::wallet2::tx_construction_data&{return ptx->m_pending_tx[n].construction_data;}, extra_message);
+            setStatus(ptx->status(), ptx->errorString());
+        }
 
         return ptx;
     } catch (exception& e) {
@@ -1750,7 +1848,7 @@ PendingTransaction* WalletImpl::restoreMultisigTransaction(const string& signDat
 //    - unconfirmed_transfer_details;
 //    - confirmed_transfer_details)
 
-PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<string> &dst_addr, const string &payment_id, optional<std::vector<uint64_t>> amount, uint32_t mixin_count, PendingTransaction::Priority priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<string> &dst_addr, const string &payment_id, optional<std::vector<uint64_t>> amount, uint32_t mixin_count, PendingTransaction::Priority priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices /* = {} */, std::set<uint32_t> subtract_fee_from_outputs /* = {} */, const std::string key_image /* = "" */, const size_t outputs /* = 1 */, const std::uint64_t below /* = 0 */)
 
 {
     clearStatus();
@@ -1763,7 +1861,6 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
 
     PendingTransactionImpl * transaction = new PendingTransactionImpl(*this);
 
-    uint32_t adjusted_priority = adjustPriority(static_cast<uint32_t>(priority));
     if (!statusOk())
         return transaction;
 
@@ -1832,14 +1929,29 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
         }
         try {
             size_t fake_outs_count = mixin_count > 0 ? mixin_count : defaultMixin();
-            fake_outs_count = m_wallet->adjust_mixin(mixin_count);
+            fake_outs_count = m_wallet->adjust_mixin(fake_outs_count);
 
             if (amount) {
                 transaction->m_pending_tx = m_wallet->create_transactions_2(dsts, fake_outs_count,
                                                                             adjusted_priority,
-                                                                            extra, subaddr_account, subaddr_indices);
-            } else {
-                transaction->m_pending_tx = m_wallet->create_transactions_all(0, info.address, info.is_subaddress, 1, fake_outs_count,
+                                                                            extra, subaddr_account, subaddr_indices, subtract_fee_from_outputs);
+            }
+            else if (!key_image.empty()) { // sweep_single
+                crypto::key_image ki;
+                if (!epee::string_tools::hex_to_pod(key_image, ki))
+                {
+                    setStatusError(tr("Failed to parse key image"));
+                    break;
+                }
+                transaction->m_pending_tx = m_wallet->create_transactions_single(ki,
+                                                                                 info.address,
+                                                                                 info.is_subaddress,
+                                                                                 outputs,
+                                                                                 fake_outs_count,
+                                                                                 tools::fee_priority_utilities::from_integral(priority),
+                                                                                 extra);
+            } else { // sweep_account, sweep_all, sweep_below
+                transaction->m_pending_tx = m_wallet->create_transactions_all(below, info.address, info.is_subaddress, outputs, fake_outs_count,
                                                                               adjusted_priority,
                                                                               extra, subaddr_account, subaddr_indices);
             }
@@ -1915,8 +2027,11 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
     } while (false);
 
     statusWithErrorString(transaction->m_status, transaction->m_errorString);
-    // Resume refresh thread
-    startRefresh();
+    // Resume refresh thread for unattended wallet (like GUI).
+    // A non-unattended wallet (like CLI) could be waiting for confirmation prompt
+    // and a refresh could mess up the output
+    if (m_wallet->is_unattended())
+        startRefresh();
     return transaction;
 }
 
@@ -1955,7 +2070,7 @@ PendingTransaction *WalletImpl::createSweepUnmixableTransaction()
             setStatusError("");
             std::ostringstream writer;
 
-            writer << boost::format(tr("not enough money to transfer, available only %s, sent amount %s")) %
+            writer << boost::format(tr("not enough unlocked money to transfer, available only %s, sent amount %s")) %
                       print_money(e.available()) %
                       print_money(e.tx_amount());
             setStatusError(writer.str());
@@ -2097,7 +2212,10 @@ bool WalletImpl::setUserNote(const std::string &txid, const std::string &note)
         return false;
     cryptonote::blobdata txid_data;
     if(!epee::string_tools::parse_hexstr_to_binbuff(txid, txid_data) || txid_data.size() != sizeof(crypto::hash))
+    {
+      setStatusError(tr("failed to parse tx_id"));
       return false;
+    }
     const crypto::hash htxid = *reinterpret_cast<const crypto::hash*>(txid_data.data());
 
     m_wallet->set_tx_note(htxid, note);
@@ -2110,7 +2228,10 @@ std::string WalletImpl::getUserNote(const std::string &txid) const
         return "";
     cryptonote::blobdata txid_data;
     if(!epee::string_tools::parse_hexstr_to_binbuff(txid, txid_data) || txid_data.size() != sizeof(crypto::hash))
+    {
+      setStatusError(tr("failed to parse tx_id"));
       return "";
+    }
     const crypto::hash htxid = *reinterpret_cast<const crypto::hash*>(txid_data.data());
 
     return m_wallet->get_tx_note(htxid);
@@ -2381,14 +2502,24 @@ std::string WalletImpl::signMessage(const std::string &message, const std::strin
     return m_wallet->sign(message, sig_type, *index);
 }
 
-bool WalletImpl::verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const
+bool WalletImpl::verifySignedMessage(const std::string &message,
+                                     const std::string &address,
+                                     const std::string &signature,
+                                     bool *is_old_out /* = nullptr */,
+                                     std::string *signature_type_out /* = nullptr */) const
 {
   cryptonote::address_parse_info info;
 
   if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), address))
     return false;
-
-  return m_wallet->verify(message, info.address, signature).valid;
+  tools::wallet2::message_signature_result_t result = m_wallet->verify(message, info.address, signature);
+  if (is_old_out)
+      *is_old_out = result.old;
+  if (signature_type_out)
+      *signature_type_out = (result.type == tools::wallet2::sign_with_spend_key
+                        ? "spend key" : result.type == tools::wallet2::sign_with_view_key
+                        ? "view key" : "unknown key combination (suspicious)");
+  return result.valid;
 }
 
 std::string WalletImpl::signMultisigParticipant(const std::string &message) const
@@ -2435,9 +2566,13 @@ bool WalletImpl::verifyMessageWithPublicKey(const std::string &message, const st
     return false;
 }
 
-bool WalletImpl::connectToDaemon()
+bool WalletImpl::connectToDaemon(uint32_t *version /* = NULL*/,
+                                 bool *ssl /* = NULL */,
+                                 uint32_t timeout /* = 20000 */, // TODO : can we put DEFAULT_CONNECTION_TIMEOUT_MILLIS into wallet2_api.h and have it as default param?
+                                 bool *wallet_is_outdated /* = NULL */,
+                                 bool *daemon_is_outdated /* = NULL */)
 {
-    bool result = m_wallet->check_connection(NULL, NULL, DEFAULT_CONNECTION_TIMEOUT_MILLIS);
+    bool result = m_wallet->check_connection(version, ssl, timeout, wallet_is_outdated, daemon_is_outdated);
     if (!result) {
         setStatusError("Error connecting to daemon at " + m_wallet->get_daemon_address());
     } else {
@@ -2554,8 +2689,16 @@ void WalletImpl::refreshThreadFunc()
     LOG_PRINT_L3(__FUNCTION__ << ": refresh thread stopped");
 }
 
-void WalletImpl::doRefresh()
+void WalletImpl::doRefresh(std::uint64_t start_height /* = 0 */,
+                           bool check_pool /* = true */,
+                           bool try_incremental /* = false */,
+                           std::uint64_t max_blocks /* = std::numeric_limits<uint64_t>::max() */,
+                           bool *error_out /* = nullptr */,
+                           std::uint64_t *blocks_fetched_out /* = nullptr */,
+                           bool *received_money_out /* = nullptr */)
 {
+    if (error_out)
+        *error_out = false;
     bool rescan = m_refreshShouldRescan.exchange(false);
     // synchronizing async and sync refresh calls
     boost::lock_guard<boost::mutex> guarg(m_refreshMutex2);
@@ -2565,8 +2708,16 @@ void WalletImpl::doRefresh()
         // Disable refresh if wallet is disconnected or daemon isn't synced.
         if (daemonSynced()) {
             if(rescan)
-                m_wallet->rescan_blockchain(false);
-            m_wallet->refresh(trustedDaemon());
+                m_wallet->rescan_blockchain(m_do_hard_rescan, /* refresh */ false, m_do_keep_key_images_on_rescan);
+            std::uint64_t blocks_fetched_ignored;
+            bool received_money_ignored;
+            m_wallet->refresh(trustedDaemon(),
+                              start_height,
+                              (blocks_fetched_out ? *blocks_fetched_out : blocks_fetched_ignored),
+                              (received_money_out ? *received_money_out : received_money_ignored),
+                              check_pool,
+                              try_incremental,
+                              max_blocks);
             m_synchronized = m_wallet->is_synced();
             // assuming if we have empty history, it wasn't initialized yet
             // for further history changes client need to update history in
@@ -2577,10 +2728,39 @@ void WalletImpl::doRefresh()
         } else {
            LOG_PRINT_L3(__FUNCTION__ << ": skipping refresh - daemon is not synced");
         }
-    } catch (const std::exception &e) {
-        setStatusError(e.what());
+    } catch (const tools::error::daemon_busy&) {
+        setStatusError(tr("daemon is busy. Please try again later."));
+        break;
+    } catch (const tools::error::no_connection_to_daemon&) {
+        setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        break;
+    } catch (const tools::error::deprecated_rpc_access&) {
+        setStatusError(tr("Daemon requires deprecated RPC payment. See https://github.com/monero-project/monero/issues/8722"));
+        break;
+    } catch (const tools::error::wallet_rpc_error& e) {
+        LOG_ERROR("RPC error: " << e.to_string());
+        setStatusError(std::string(tr("RPC error: ")) + e.what());
+        break;
+    } catch (const tools::error::refresh_error& e) {
+        LOG_ERROR("refresh error: " << e.to_string());
+        setStatusError(std::string(tr("refresh error: ")) + e.what());
+        break;
+    } catch (const tools::error::wallet_internal_error& e) {
+        LOG_ERROR("internal error: " << e.to_string());
+        setStatusError(std::string(tr("internal error: ")) + e.what());
+        break;
+    } catch (const std::exception& e) {
+        LOG_ERROR("unexpected error: " << e.what());
+        setStatusError(std::string(tr("unexpected error: ")) + e.what());
+        break;
+    } catch (...) {
+        LOG_ERROR("unknown error");
+        setStatusError(tr("unknown error"));
         break;
     }while(!rescan && (rescan=m_refreshShouldRescan.exchange(false))); // repeat if not rescanned and rescan was requested
+
+   if (error_out)
+       *error_out = !statusOk();
 
     if (m_wallet2Callback->getListener()) {
         m_wallet2Callback->getListener()->refreshed();
@@ -2642,6 +2822,11 @@ void WalletImpl::pendingTxPostProcess(PendingTransactionImpl * pending)
   m_wallet->cold_sign_tx(pending->m_pending_tx, exported_txs, dsts_info, pending->m_tx_device_aux);
   pending->m_key_images = exported_txs.key_images;
   pending->m_pending_tx = exported_txs.ptx;
+
+  std::string extra_message;
+  if (!exported_txs.key_images.empty())
+    extra_message = (boost::format("%u key images to import. ") % (unsigned)exported_txs.key_images.size()).str();
+  pending->checkLoadedTx([&pending](){return pending->txCount();}, [&pending](size_t n)->const tools::wallet2::tx_construction_data&{return pending->m_pending_tx[n].construction_data;}, extra_message);
 }
 
 bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_address, uint64_t upper_transaction_size_limit, bool ssl)
@@ -2704,21 +2889,61 @@ std::string WalletImpl::getDefaultDataDir() const
 
 bool WalletImpl::rescanSpent()
 {
-  clearStatus();
-  if (checkBackgroundSync("cannot rescan spent"))
-    return false;
-  if (!trustedDaemon()) {
-    setStatusError(tr("Rescan spent can only be used with a trusted daemon"));
-    return false;
-  }
-  try {
-      m_wallet->rescan_spent();
-  } catch (const std::exception &e) {
-      LOG_ERROR(__FUNCTION__ << " error: " << e.what());
-      setStatusError(e.what());
-      return false;
-  }
-  return true;
+    clearStatus();
+    if (checkBackgroundSync("cannot rescan spent"))
+        return false;
+    if (!trustedDaemon()) {
+        setStatusError(tr("Rescan spent can only be used with a trusted daemon"));
+        return false;
+    }
+    try {
+        m_wallet->rescan_spent();
+    }
+    catch (const tools::error::daemon_busy&)
+    {
+        setStatusError(tr("daemon is busy. Please try again later."));
+        return false;
+    }
+    catch (const tools::error::no_connection_to_daemon&)
+    {
+        setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        return false;
+    }
+    catch (const tools::error::deprecated_rpc_access&)
+    {
+        setStatusError(tr("Daemon requires deprecated RPC payment. See https://github.com/monero-project/monero/issues/8722"));
+        return false;
+    }
+    catch (const tools::error::is_key_image_spent_error&)
+    {
+        setStatusError(tr("failed to get spent status"));
+        return false;
+    }
+    catch (const tools::error::wallet_rpc_error& e)
+    {
+        LOG_ERROR("RPC error: " << e.to_string());
+        setStatusError(std::string(tr("RPC error: ")) + e.to_string());
+        return false;
+    }
+    catch (const std::exception& e)
+    {
+        LOG_ERROR(__FUNCTION__ << "unexpected error: " << e.what());
+        setStatusError(std::string(tr("unexpected error: ")) + e.what());
+        return false;
+    }
+    catch (...)
+    {
+        LOG_ERROR(__FUNCTION__ << "unknown error");
+        setStatusError(tr("unknonw error: "));
+        return false;
+    }
+
+    return true;
+}
+
+NetworkType WalletImpl::nettype() const
+{
+    return static_cast<NetworkType>(m_wallet->nettype());
 }
 
 void WalletImpl::setOffline(bool offline)
@@ -2838,6 +3063,11 @@ bool WalletImpl::isKeysFileLocked()
     return m_wallet->is_keys_file_locked();
 }
 
+std::unique_ptr<WalletKeysDecryptGuard> WalletImpl::createKeysDecryptGuard(const std::string_view &password)
+{
+    return std::unique_ptr<WalletKeysDecryptGuard>(new WalletKeysDecryptGuardImpl(*m_wallet, epee::wipeable_string(password.data(), password.size())));
+}
+
 uint64_t WalletImpl::coldKeyImageSync(uint64_t &spent, uint64_t &unspent)
 {
     return m_wallet->cold_key_image_sync(spent, unspent);
@@ -2845,6 +3075,7 @@ uint64_t WalletImpl::coldKeyImageSync(uint64_t &spent, uint64_t &unspent)
 
 void WalletImpl::deviceShowAddress(uint32_t accountIndex, uint32_t addressIndex, const std::string &paymentId)
 {
+    clearStatus();
     boost::optional<crypto::hash8> payment_id_param = boost::none;
     if (!paymentId.empty())
     {
@@ -2852,7 +3083,8 @@ void WalletImpl::deviceShowAddress(uint32_t accountIndex, uint32_t addressIndex,
         bool res = tools::wallet2::parse_short_payment_id(paymentId, payment_id);
         if (!res)
         {
-            throw runtime_error("Invalid payment ID");
+            setStatusError(tr("Invalid payment ID"));
+            return;
         }
         payment_id_param = payment_id;
     }
@@ -2954,14 +3186,14 @@ void WalletImpl::freeze(const std::string &key_image)
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::freezeByPubKey(const std::string &public_key)
+void WalletImpl::freezeByPubKey(const std::string &enote_pub_key)
 {
     clearStatus();
 
     crypto::public_key pk;
-    if (!epee::string_tools::hex_to_pod(public_key, pk))
+    if (!epee::string_tools::hex_to_pod(enote_pub_key, pk))
     {
-        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % enote_pub_key).str());
         return;
     }
 
@@ -2972,7 +3204,7 @@ void WalletImpl::freezeByPubKey(const std::string &public_key)
     catch (const std::exception &e)
     {
         LOG_ERROR(__FUNCTION__ << " error: " << e.what());
-        setStatusError((boost::format(tr("Failed to freeze enote with public key `%s`: %s")) % public_key % e.what()).str());
+        setStatusError((boost::format(tr("Failed to freeze enote with public key `%s`: %s")) % enote_pub_key % e.what()).str());
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
@@ -2998,14 +3230,14 @@ void WalletImpl::thaw(const std::string &key_image)
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::thawByPubKey(const std::string &public_key)
+void WalletImpl::thawByPubKey(const std::string &enote_pub_key)
 {
     clearStatus();
 
     crypto::public_key pk;
-    if (!epee::string_tools::hex_to_pod(public_key, pk))
+    if (!epee::string_tools::hex_to_pod(enote_pub_key, pk))
     {
-        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % enote_pub_key).str());
         return;
     }
 
@@ -3016,7 +3248,7 @@ void WalletImpl::thawByPubKey(const std::string &public_key)
     catch (const std::exception &e)
     {
         LOG_ERROR(__FUNCTION__ << " error: " << e.what());
-        setStatusError((boost::format(tr("Failed to thaw enote with public key `%s`: %s")) % public_key % e.what()).str());
+        setStatusError((boost::format(tr("Failed to thaw enote with public key `%s`: %s")) % enote_pub_key % e.what()).str());
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
@@ -3044,29 +3276,6 @@ bool WalletImpl::isFrozen(const std::string &key_image) const
     return false;
 }
 //-------------------------------------------------------------------------------------------------------------------
-bool WalletImpl::isFrozenByPubKey(const std::string &public_key)
-{
-    clearStatus();
-
-    crypto::public_key pk;
-    if (!epee::string_tools::hex_to_pod(public_key, pk))
-    {
-        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
-        return false;
-    }
-
-    try
-    {
-        return m_wallet->frozen(m_wallet->get_output_index(pk));
-    }
-    catch (const std::exception &e)
-    {
-        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
-        setStatusError((boost::format(tr("Failed to determine if enote with public key `%s` is frozen: %s")) % public_key % e.what()).str());
-    }
-    return false;
-}
-//-------------------------------------------------------------------------------------------------------------------
 void WalletImpl::createOneOffSubaddress(std::uint32_t account_index, std::uint32_t address_index)
 {
     m_wallet->create_one_off_subaddress({account_index, address_index});
@@ -3076,14 +3285,33 @@ Wallet::WalletState WalletImpl::getWalletState() const
 {
     WalletState wallet_state{};
 
-    wallet_state.is_deprecated = m_wallet->is_deprecated();
-    wallet_state.ring_size = 16;
+    wallet_state.is_deprecated  = m_wallet->is_deprecated();
+    wallet_state.is_unattended  = m_wallet->is_unattended();
     wallet_state.daemon_address = m_wallet->get_daemon_address();
+    wallet_state.ring_database  = m_wallet->get_ring_database();
+    wallet_state.n_enotes       = m_wallet->get_num_transfer_details();
 
     return wallet_state;
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::rewriteWalletFile(const std::string &wallet_name, const std::string &password)
+Wallet::DeviceState WalletImpl::getDeviceState() const
+{
+    DeviceState device_state{};
+    auto &device = m_wallet->get_account().get_device();
+
+    device_state.key_on_device       = m_wallet->key_on_device();
+    device_state.device_name         = device.get_name();
+    device_state.has_tx_cold_sign    = device.has_tx_cold_sign();
+    device_state.has_ki_live_refresh = device.has_ki_live_refresh();
+    device_state.has_ki_cold_sync    = device.has_ki_cold_sync();
+    device_state.last_ki_sync        = m_wallet->get_device_last_key_image_sync();
+    device_state.protocol            = static_cast<DeviceState::DeviceProtocol>(device.device_protocol());
+    device_state.device_type         = static_cast<DeviceState::DeviceType>(device.get_type());
+
+    return device_state;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::rewriteWalletFile(const std::string &wallet_name, const std::string_view &password)
 {
     clearStatus();
 
@@ -3098,7 +3326,7 @@ void WalletImpl::rewriteWalletFile(const std::string &wallet_name, const std::st
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name)
+void WalletImpl::writeWatchOnlyWallet(const std::string_view &password, std::string &new_keys_file_name)
 {
     clearStatus();
 
@@ -3145,46 +3373,86 @@ void WalletImpl::refreshPoolOnly(bool refreshed /*false*/, bool try_incremental 
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const
+std::vector<std::unique_ptr<EnoteDetails>> WalletImpl::getEnoteDetails() const
 {
-    tools::wallet2::transfer_container tc;
-    m_wallet->get_transfers(tc);
-    enote_details.reserve(tc.size());
+    std::vector<std::unique_ptr<EnoteDetails>> enotes_details{};
+    std::size_t n_transfers = m_wallet->get_num_transfer_details();
+    enotes_details.reserve(n_transfers);
 
-    for (const auto &td : tc)
+    for (std::size_t i = 0; i < n_transfers; ++i)
     {
-        auto ed = std::make_unique<EnoteDetailsImpl>();
-
-        cryptonote::txout_target_v txout_v = td.m_tx.vout[td.m_internal_output_index].target;
-        if (txout_v.type() == typeid(cryptonote::txout_to_key))
-            ed->m_onetime_address = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_key>(txout_v).key);
-        else if (txout_v.type() == typeid(cryptonote::txout_to_tagged_key))
-        {
-            ed->m_onetime_address = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_tagged_key>(txout_v).key);
-            ed->m_view_tag = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_tagged_key>(txout_v).view_tag);
-        }
-
-        ed->m_block_height = td.m_block_height;
-        ed->m_tx_id = epee::string_tools::pod_to_hex(td.m_txid);
-        ed->m_internal_enote_index = td.m_internal_output_index;
-        ed->m_global_enote_index = td.m_global_output_index;
-        ed->m_spent = td.m_spent;
-        ed->m_frozen = td.m_frozen;
-        ed->m_spent_height = td.m_spent_height;
-        ed->m_key_image = epee::string_tools::pod_to_hex(td.m_key_image);
-        ed->m_mask = epee::string_tools::pod_to_hex(td.m_mask);
-        ed->m_amount = td.m_amount;
-        ed->m_protocol_version = td.m_rct ? EnoteDetails::TxProtocol_RingCT : EnoteDetails::TxProtocol_CryptoNote;
-        ed->m_key_image_known = td.m_key_image_known;
-        ed->m_key_image_request = td.m_key_image_request;
-        ed->m_pk_index = td.m_pk_index;
-        ed->m_uses.reserve(td.m_uses.size());
-        for (auto &u : td.m_uses)
-            ed->m_uses.push_back(std::make_pair(u.first, epee::string_tools::pod_to_hex(u.second)));
-        ed->m_key_image_partial = td.m_key_image_partial;
-
-        enote_details.push_back(std::move(ed));
+        enotes_details.push_back(getEnoteDetails(i));
     }
+    return enotes_details;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::unique_ptr<EnoteDetails> WalletImpl::getEnoteDetails(const std::string &enote_pub_key) const
+{
+    clearStatus();
+
+    crypto::public_key pk{};
+    if (!epee::string_tools::hex_to_pod(enote_pub_key, pk))
+    {
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % enote_pub_key).str());
+        return nullptr;
+    }
+
+    std::size_t enote_index{};
+    try { enote_index = m_wallet->get_output_index(pk); }
+    catch (const exception &e)
+    {
+        setStatusError(std::string(tr("Could not find index of enote: ")) + e.what());
+        return nullptr;
+    }
+    return getEnoteDetails(enote_index);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::unique_ptr<EnoteDetails> WalletImpl::getEnoteDetails(const std::size_t enote_index) const
+{
+    clearStatus();
+
+    std::unique_ptr<EnoteDetails> enote_details = nullptr;
+    tools::wallet2::transfer_details td{};
+    try { td = m_wallet->get_transfer_details(enote_index); }
+    catch (const exception &e)
+    {
+        setStatusError(std::string(tr("Could not find enote details for index: ")) + std::to_string(enote_index));
+        return nullptr;
+    }
+
+    std::unique_ptr<EnoteDetailsImpl> ed(new EnoteDetailsImpl);
+    crypto::public_key enote_pub_key{};
+    cryptonote::get_output_public_key(td.m_tx.vout[td.m_internal_output_index], enote_pub_key);
+    auto view_tag = cryptonote::get_output_view_tag(td.m_tx.vout[td.m_internal_output_index]);
+
+    ed->m_onetime_address = epee::string_tools::pod_to_hex(enote_pub_key);
+    ed->m_view_tag = view_tag ? epee::string_tools::pod_to_hex(*view_tag) : "";
+    ed->m_payment_id = getPaymentIdFromExtra(td.m_tx.extra);
+    ed->m_block_height = td.m_block_height;
+    ed->m_unlock_time = td.m_tx.unlock_time;
+    ed->m_is_unlocked = m_wallet->is_transfer_unlocked(td);
+    ed->m_tx_id = epee::string_tools::pod_to_hex(td.m_txid);
+    ed->m_internal_enote_index = td.m_internal_output_index;
+    ed->m_global_enote_index = td.m_global_output_index;
+    ed->m_spent = td.m_spent;
+    ed->m_frozen = td.m_frozen;
+    ed->m_spent_height = td.m_spent_height;
+    ed->m_key_image = epee::string_tools::pod_to_hex(td.m_key_image);
+    ed->m_mask = epee::string_tools::pod_to_hex(td.m_mask);
+    ed->m_amount = td.m_amount;
+    ed->m_protocol_version = td.m_rct ? EnoteDetails::TxProtocol::TxProtocol_RingCT : EnoteDetails::TxProtocol::TxProtocol_CryptoNote;
+    ed->m_key_image_known = td.m_key_image_known;
+    ed->m_key_image_request = td.m_key_image_request;
+    ed->m_pk_index = td.m_pk_index;
+    ed->m_uses.reserve(td.m_uses.size());
+    ed->m_subaddress_index_major = td.m_subaddr_index.major;
+    ed->m_subaddress_index_minor = td.m_subaddr_index.minor;
+    for (auto &u : td.m_uses)
+        ed->m_uses.push_back(std::make_pair(u.first, epee::string_tools::pod_to_hex(u.second)));
+    ed->m_key_image_partial = td.m_key_image_partial;
+
+    enote_details = std::move(ed);
+    return enote_details;
 }
 //-------------------------------------------------------------------------------------------------------------------
 std::string WalletImpl::convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const
@@ -3241,46 +3509,58 @@ bool WalletImpl::saveMultisigTx(const PendingTransaction &multisig_ptx, const st
     return false;
 }
 //-------------------------------------------------------------------------------------------------------------------
-bool WalletImpl::parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const
+PendingTransaction* WalletImpl::parseTxFromStr(const std::string &signed_tx_str)
 {
-    PendingTransactionImpl *ptx_impl = dynamic_cast<PendingTransactionImpl*>(&ptx);
+    clearStatus();
+    std::unique_ptr<PendingTransactionImpl> ptx(new PendingTransactionImpl(*this));
     std::shared_ptr<tools::wallet2::signed_tx_set> signed_tx_set_out = std::make_shared<tools::wallet2::signed_tx_set>();
-    bool r = m_wallet->parse_tx_from_str(signed_tx_str, ptx_impl->m_pending_tx, /* accept_func = */ NULL, signed_tx_set_out.get(), /* do_handle_key_images = */ false);
-    if (r)
-        ptx_impl->m_tx_key_images = signed_tx_set_out->tx_key_images;
-    return r;
+    bool r = m_wallet->parse_tx_from_str(signed_tx_str,
+                                         ptx->m_pending_tx,
+                                         /* accept_func = */ NULL,
+                                         signed_tx_set_out.get(),
+                                         /* do_handle_key_images = */ false);
+    if (!r)
+    {
+        setStatusError(tr("Failed to parse signed tx from str"));
+        ptx->m_status = PendingTransaction::Status::Status_Error;
+        ptx->m_errorString = errorString();
+        return ptx.release();
+    }
+
+    ptx->m_tx_key_images = signed_tx_set_out->tx_key_images;
+
+    // Check tx data and construct confirmation message
+    std::string extra_message;
+    ptx->checkLoadedTx([&ptx](){return ptx->txCount();}, [&ptx](size_t n)->const tools::wallet2::tx_construction_data & {return ptx->m_pending_tx[n].construction_data;}, extra_message);
+    setStatus(ptx->status(), ptx->errorString());
+
+    return ptx.release();
 }
 //-------------------------------------------------------------------------------------------------------------------
-void WalletImpl::insertColdKeyImages(PendingTransaction &ptx)
-{
-    m_wallet->insert_cold_key_images(dynamic_cast<PendingTransactionImpl*>(&ptx)->m_tx_key_images);
-}
-//-------------------------------------------------------------------------------------------------------------------
-bool WalletImpl::parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const
+PendingTransaction* WalletImpl::parseMultisigTxFromStr(const std::string &multisig_tx_str)
 {
     clearStatus();
 
+    std::unique_ptr<PendingTransactionImpl> ptx(new PendingTransactionImpl(*this));
     try
     {
         checkMultisigWalletReady(m_wallet);
 
-        PendingTransactionImpl *ptx_impl = dynamic_cast<PendingTransactionImpl*>(&exported_txs);
         tools::wallet2::multisig_tx_set multisig_tx;
 
         if (!m_wallet->parse_multisig_tx_from_str(multisig_tx_str, multisig_tx))
             throw runtime_error(tr("Failed to parse multisig transaction from string."));
 
-        ptx_impl->m_pending_tx = multisig_tx.m_ptx;
-        ptx_impl->m_signers = multisig_tx.m_signers;
-
-        return true;
+        ptx->m_pending_tx = multisig_tx.m_ptx;
+        ptx->m_signers = multisig_tx.m_signers;
     }
     catch (const exception &e)
     {
         setStatusError(e.what());
+        return nullptr;
     }
 
-    return false;
+    return ptx.release();
 }
 //-------------------------------------------------------------------------------------------------------------------
 std::uint64_t WalletImpl::getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const
@@ -3289,7 +3569,8 @@ std::uint64_t WalletImpl::getFeeMultiplier(std::uint32_t priority, int fee_algor
 
     try
     {
-        return m_wallet->get_fee_multiplier(priority, fee_algorithm);
+        return m_wallet->get_fee_multiplier(tools::fee_priority_utilities::from_integral(priority),
+                                            static_cast<tools::fee_algorithm>(fee_algorithm));
     }
     catch (const exception &e)
     {
@@ -3305,7 +3586,7 @@ std::uint64_t WalletImpl::getBaseFee() const
 //-------------------------------------------------------------------------------------------------------------------
 std::uint32_t WalletImpl::adjustPriority(std::uint32_t priority)
 {
-    return m_wallet->adjust_priority(priority);
+    return tools::fee_priority_utilities::as_integral(m_wallet->adjust_priority(priority));
 }
 //-------------------------------------------------------------------------------------------------------------------
 void WalletImpl::coldTxAuxImport(const PendingTransaction &ptx, const std::vector<std::string> &tx_device_aux) const
@@ -3520,16 +3801,6 @@ std::vector<std::pair<std::uint64_t, std::uint64_t>> WalletImpl::estimateBacklog
     return { std::make_pair(0, 0) };
 }
 //-------------------------------------------------------------------------------------------------------------------
-bool WalletImpl::saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable /* = false */) const
-{
-    return m_wallet->save_to_file(path_to_file, binary, is_printable);
-}
-//-------------------------------------------------------------------------------------------------------------------
-bool WalletImpl::loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size /* = 1000000000 */) const
-{
-    return m_wallet->load_from_file(path_to_file, target_str, max_size);
-}
-//-------------------------------------------------------------------------------------------------------------------
 std::uint64_t WalletImpl::hashEnotes(std::uint64_t enote_idx, std::string &hash) const
 {
     clearStatus();
@@ -3685,11 +3956,21 @@ void WalletImpl::setAllowMismatchedDaemonVersion(bool allow_mismatch)
     m_wallet->allow_mismatched_daemon_version(allow_mismatch);
 }
 //-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::getDeviceDerivationPath() const
+{
+    return m_wallet->device_derivation_path();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setDeviceDerivationPath(std::string device_derivation_path)
+{
+    m_wallet->device_derivation_path(device_derivation_path);
+}
+//-------------------------------------------------------------------------------------------------------------------
 bool WalletImpl::setDaemon(const std::string &daemon_address,
         const std::string &daemon_username /* = "" */,
         const std::string &daemon_password /* = "" */,
         bool trusted_daemon /* = false */,
-        const std::string &ssl_support /* = "autodetect" */,
+        Wallet::SSLSupport ssl_support /* = Wallet::SSLSupport::SSLSupport_Autodetect */,
         const std::string &ssl_private_key_path /* = "" */,
         const std::string &ssl_certificate_path /* = "" */,
         const std::string &ssl_ca_file_path /* = "" */,
@@ -3715,13 +3996,9 @@ bool WalletImpl::setDaemon(const std::string &daemon_address,
     if (ssl_allow_any_cert)
         ssl_options.verification = epee::net_utils::ssl_verification_t::none;
     else if (!ssl_allowed_fingerprints.empty() || !ssl_ca_file_path.empty())
-        ssl_options = epee::net_utils::ssl_options_t{std::move(ssl_allowed_fingerprints), std::move(ssl_ca_file_path)};
+        ssl_options = epee::net_utils::ssl_options_t{std::move(ssl_allowed_fingerprints), ssl_ca_file_path};
 
-    if (!epee::net_utils::ssl_support_from_string(ssl_options.support, ssl_support))
-    {
-        setStatusError(string(tr("Invalid ssl support option (allowed options:`disabled` | `enabled` | `autodetect`), actual value: ")) + ssl_support);
-        return false;
-    }
+    ssl_options.support = static_cast<epee::net_utils::ssl_support_t>(ssl_support);
 
     ssl_options.auth = epee::net_utils::ssl_authentication_t{
         std::move(ssl_private_key_path), std::move(ssl_certificate_path)
@@ -3753,14 +4030,420 @@ bool WalletImpl::setDaemon(const std::string &daemon_address,
     return false;
 }
 //-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::verifyPassword(const std::string_view &password)
+{
+    clearStatus();
+
+    bool r = false;
+    bool was_locked = false;
+
+    if (isKeysFileLocked())
+    {
+        was_locked = true;
+        unlockKeysFile();
+    }
+
+    try
+    {
+        bool no_spend_key = getDeviceState().protocol == DeviceState::DeviceProtocol::DeviceProtocol_Cold || watchOnly() || multisig().isMultisig || isBackgroundWallet();
+        r = tools::wallet2::verify_password(keysFilename(),
+                                            epee::wipeable_string(password.data(), password.size()),
+                                            no_spend_key,
+                                            hw::get_device("default"),
+                                            m_kdf_rounds);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to verify password: ")) + e.what());
+    }
+
+    if (was_locked)
+        lockKeysFile();
+
+    return r;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::encryptKeys(const std::string_view &password)
+{
+    m_wallet->encrypt_keys(epee::wipeable_string(password.data(), password.size()));
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::decryptKeys(const std::string_view &password)
+{
+    m_wallet->decrypt_keys(epee::wipeable_string(password.data(), password.size()));
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getMinRingSize() const
+{
+    try { return m_wallet->get_min_ring_size(); }
+    catch (const std::exception &e)
+    { setStatusError(std::string(tr("failed to get min ring size")) + e.what()); }
+    return 0;
+}
+std::uint64_t WalletImpl::getMaxRingSize() const
+{
+    try { return m_wallet->get_max_ring_size(); }
+    catch (const std::exception &e)
+    { setStatusError(std::string(tr("failed to get max ring size")) + e.what()); }
+    return 0;
+}
+std::uint64_t WalletImpl::adjustMixin(const std::uint64_t fake_outs_count) const
+{
+    return m_wallet->adjust_mixin(fake_outs_count);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getDaemonAdjustedTime() const
+{
+    return m_wallet->get_daemon_adjusted_time();
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getLastBlockReward() const
+{
+    return m_wallet->get_last_block_reward();
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::hasUnknownKeyImages() const
+{
+    return m_wallet->has_unknown_key_images();
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getExplicitRefreshFromBlockHeight() const
+{
+    return m_wallet->explicit_refresh_from_block_height();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setExplicitRefreshFromBlockHeight(bool do_explicit_refresh)
+{
+    m_wallet->explicit_refresh_from_block_height(do_explicit_refresh);
+}
+//-------------------------------------------------------------------------------------------------------------------
+// Wallet Settings getter/setter
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::getSeedLanguage() const
+{
+    return m_wallet->get_seed_language();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setSeedLanguage(const std::string &arg)
+{
+    if (checkBackgroundSync("cannot set seed language"))
+        return;
+
+    if (crypto::ElectrumWords::is_valid_language(arg))
+        m_wallet->set_seed_language(arg);
+    else
+        setStatusError(string(tr("Failed to set seed language. Language not valid: ")) + arg);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getAlwaysConfirmTransfers() const
+{
+    return m_wallet->always_confirm_transfers();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAlwaysConfirmTransfers(bool do_always_confirm)
+{
+    m_wallet->always_confirm_transfers(do_always_confirm);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getPrintRingMembers() const
+{
+    return m_wallet->print_ring_members();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setPrintRingMembers(bool do_print_ring_members)
+{
+    m_wallet->print_ring_members(do_print_ring_members);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getStoreTxInfo() const
+{
+    return m_wallet->store_tx_info();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setStoreTxInfo(bool do_store_tx_info)
+{
+    m_wallet->store_tx_info(do_store_tx_info);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getAutoRefresh() const
+{
+    return m_wallet->auto_refresh();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAutoRefresh(bool do_auto_refresh)
+{
+    m_wallet->auto_refresh(do_auto_refresh);
+}
+//-------------------------------------------------------------------------------------------------------------------
+Wallet::RefreshType WalletImpl::getRefreshType() const
+{
+    return static_cast<Wallet::RefreshType>(m_wallet->get_refresh_type());
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setRefreshType(Wallet::RefreshType refresh_type)
+{
+    m_wallet->set_refresh_type(static_cast<tools::wallet2::RefreshType>(refresh_type));
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint32_t WalletImpl::getDefaultPriority() const
+{
+    return tools::fee_priority_utilities::as_integral(m_wallet->get_default_priority());
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setDefaultPriority(std::uint32_t default_priority)
+{
+    m_wallet->set_default_priority(tools::fee_priority_utilities::from_integral(default_priority));
+}
+//-------------------------------------------------------------------------------------------------------------------
+Wallet::AskPasswordType WalletImpl::getAskPasswordType() const
+{
+    return static_cast<AskPasswordType>(m_wallet->ask_password());
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAskPasswordType(AskPasswordType ask_password_type)
+{
+    m_wallet->ask_password(static_cast<tools::wallet2::AskPasswordType>(ask_password_type));
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getMaxReorgDepth() const
+{
+    return m_wallet->max_reorg_depth();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setMaxReorgDepth(std::uint64_t max_reorg_depth)
+{
+    m_wallet->max_reorg_depth(max_reorg_depth);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint32_t WalletImpl::getMinOutputCount() const
+{
+    return m_wallet->get_min_output_count();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setMinOutputCount(std::uint32_t min_output_count)
+{
+    m_wallet->set_min_output_count(min_output_count);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getMinOutputValue() const
+{
+    return m_wallet->get_min_output_value();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setMinOutputValue(std::uint64_t min_output_value)
+{
+    m_wallet->set_min_output_value(min_output_value);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getMergeDestinations() const
+{
+    return m_wallet->merge_destinations();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setMergeDestinations(bool do_merge_destinations)
+{
+    m_wallet->merge_destinations(do_merge_destinations);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getConfirmBacklog() const
+{
+    return m_wallet->confirm_backlog();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setConfirmBacklog(bool do_confirm_backlog)
+{
+    m_wallet->confirm_backlog(do_confirm_backlog);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint32_t WalletImpl::getConfirmBacklogThreshold() const
+{
+    return m_wallet->get_confirm_backlog_threshold();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setConfirmBacklogThreshold(std::uint32_t confirm_backlog_threshold)
+{
+    m_wallet->set_confirm_backlog_threshold(confirm_backlog_threshold);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getConfirmExportOverwrite() const
+{
+    return m_wallet->confirm_export_overwrite();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setConfirmExportOverwrite(bool do_confirm_export_overwrite)
+{
+    m_wallet->confirm_export_overwrite(do_confirm_export_overwrite);
+}
+//-------------------------------------------------------------------------------------------------------------------
+uint64_t WalletImpl::getRefreshFromBlockHeight() const
+{
+    return m_wallet->get_refresh_from_block_height();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setRefreshFromBlockHeight(uint64_t refresh_from_block_height)
+{
+    if (checkBackgroundSync("cannot change refresh height"))
+        return;
+    m_wallet->set_refresh_from_block_height(refresh_from_block_height);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getAutoLowPriority() const
+{
+    return m_wallet->auto_low_priority();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAutoLowPriority(bool use_auto_low_priority)
+{
+    m_wallet->auto_low_priority(use_auto_low_priority);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getSegregatePreForkOutputs() const
+{
+    return m_wallet->segregate_pre_fork_outputs();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setSegregatePreForkOutputs(bool do_segregate)
+{
+    m_wallet->segregate_pre_fork_outputs(do_segregate);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getKeyReuseMitigation2() const
+{
+    return m_wallet->key_reuse_mitigation2();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setKeyReuseMitigation2(bool mitigation)
+{
+    m_wallet->key_reuse_mitigation2(mitigation);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::pair<std::uint32_t, std::uint32_t> WalletImpl::getSubaddressLookahead() const
+{
+    return m_wallet->get_subaddress_lookahead();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setSubaddressLookahead(uint32_t major, uint32_t minor)
+{
+    m_wallet->set_subaddress_lookahead(major, minor);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getSegregationHeight() const
+{
+    return m_wallet->segregation_height();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setSegregationHeight(std::uint64_t height)
+{
+    m_wallet->segregation_height(height);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getIgnoreFractionalOutputs() const
+{
+    return m_wallet->ignore_fractional_outputs();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setIgnoreFractionalOutputs(bool do_ignore_fractional_outputs)
+{
+    m_wallet->ignore_fractional_outputs(do_ignore_fractional_outputs);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getIgnoreOutputsAbove() const
+{
+    return m_wallet->ignore_outputs_above();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setIgnoreOutputsAbove(std::uint64_t ignore_outputs_above)
+{
+    m_wallet->ignore_outputs_above(ignore_outputs_above);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getIgnoreOutputsBelow() const
+{
+    return m_wallet->ignore_outputs_below();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setIgnoreOutputsBelow(std::uint64_t ignore_outputs_below)
+{
+    m_wallet->ignore_outputs_below(ignore_outputs_below);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getTrackUses() const
+{
+    return m_wallet->track_uses();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setTrackUses(bool do_track_uses)
+{
+    m_wallet->track_uses(do_track_uses);
+}
+//-------------------------------------------------------------------------------------------------------------------
+Wallet::BackgroundMiningSetupType WalletImpl::getSetupBackgroundMining() const
+{
+    return static_cast<Wallet::BackgroundMiningSetupType>(m_wallet->setup_background_mining());
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setSetupBackgroundMining(Wallet::BackgroundMiningSetupType background_mining_setup)
+{
+    m_wallet->setup_background_mining(static_cast<tools::wallet2::BackgroundMiningSetupType>(background_mining_setup));
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::getDeviceName() const
+{
+    return m_wallet->device_name();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setDeviceName(const std::string &device_name)
+{
+    m_wallet->device_name(device_name);
+}
+//-------------------------------------------------------------------------------------------------------------------
+Wallet::ExportFormat WalletImpl::getExportFormat() const
+{
+    return static_cast<Wallet::ExportFormat>(m_wallet->export_format());
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setExportFormat(Wallet::ExportFormat export_format)
+{
+    return m_wallet->set_export_format(static_cast<tools::wallet2::ExportFormat>(export_format));
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getShowWalletNameWhenLocked() const
+{
+    return m_wallet->show_wallet_name_when_locked();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setShowWalletNameWhenLocked(bool do_show_wallet_name)
+{
+    m_wallet->show_wallet_name_when_locked(do_show_wallet_name);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint32_t WalletImpl::getInactivityLockTimeout() const
+{
+    return m_wallet->inactivity_lock_timeout();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setInactivityLockTimeout(std::uint32_t seconds)
+{
+    m_wallet->inactivity_lock_timeout(seconds);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getEnableMultisig() const
+{
+    return m_wallet->is_multisig_enabled();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setEnableMultisig(bool do_enable_multisig)
+{
+    m_wallet->enable_multisig(do_enable_multisig);
+}
+//-------------------------------------------------------------------------------------------------------------------
 
 //-------------------------------------------------------------------------------------------------------------------
 // PRIVATE
 //-------------------------------------------------------------------------------------------------------------------
 std::size_t WalletImpl::getEnoteIndex(const std::string &key_image) const
 {
-    std::vector<std::unique_ptr<EnoteDetails>> enote_details;
-    getEnoteDetails(enote_details);
+    std::vector<std::unique_ptr<EnoteDetails>> enote_details = getEnoteDetails();
     for (size_t idx = 0; idx < enote_details.size(); ++idx)
     {
         const auto &ed = dynamic_cast<EnoteDetailsImpl &>(*enote_details[idx].get());
@@ -3778,6 +4461,33 @@ std::size_t WalletImpl::getEnoteIndex(const std::string &key_image) const
 
     setStatusError("Failed to get enote index by key image: Key image not found");
     return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::getPaymentIdFromExtra(const std::vector<std::uint8_t> &tx_extra) const
+{
+    std::vector<tx_extra_field> tx_extra_fields;
+    parse_tx_extra(tx_extra, tx_extra_fields); // failure ok
+    tx_extra_nonce extra_nonce;
+    tx_extra_pub_key extra_pub_key;
+    crypto::hash8 payment_id8 = crypto::null_hash8;
+    crypto::hash payment_id = crypto::null_hash;
+    if (find_tx_extra_field_by_type(tx_extra_fields, extra_pub_key))
+    {
+        const crypto::public_key &tx_pub_key = extra_pub_key.pub_key;
+        if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+        {
+            if (get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+            {
+                m_wallet->get_account().get_device().decrypt_payment_id(payment_id8, tx_pub_key, m_wallet->get_account().get_keys().m_view_secret_key);
+                return epee::string_tools::pod_to_hex(payment_id8);
+            }
+            else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+            {
+                return epee::string_tools::pod_to_hex(payment_id);
+            }
+        }
+    }
+    return std::string();
 }
 //-------------------------------------------------------------------------------------------------------------------
 bool WalletImpl::statusOk() const

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -30,7 +30,11 @@
 
 
 #include "wallet.h"
+#include "device/device.hpp"
+#include "crypto/crypto.h"
+#include "enote_details.h"
 #include "pending_transaction.h"
+#include "string_tools.h"
 #include "unsigned_transaction.h"
 #include "transaction_history.h"
 #include "address_book.h"
@@ -61,7 +65,7 @@ using namespace cryptonote;
 #define LOCK_REFRESH() \
     bool refresh_enabled = m_refreshEnabled; \
     m_refreshEnabled = false; \
-    m_wallet->stop(); \
+    stop(); \
     m_refreshCV.notify_one(); \
     boost::mutex::scoped_lock lock(m_refreshMutex); \
     boost::mutex::scoped_lock lock2(m_refreshMutex2); \
@@ -80,7 +84,7 @@ using namespace cryptonote;
         setStatusError(tr("HW wallet cannot use background sync")); \
         return false; \
     } \
-    if (m_wallet->watch_only()) \
+    if (watchOnly()) \
     { \
         setStatusError(tr("View only wallet cannot use background sync")); \
         return false; \
@@ -297,6 +301,32 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
+    virtual void on_reorg(std::uint64_t height, std::uint64_t blocks_detached, std::size_t transfers_detached)
+    {
+        if (m_listener) {
+            m_listener->onReorg(height, blocks_detached, transfers_detached);
+        }
+    }
+
+    virtual boost::optional<epee::wipeable_string> on_get_password(const char *reason)
+    {
+        if (m_listener) {
+            auto password = m_listener->onGetPassword(reason);
+            if (password) {
+                return boost::optional<epee::wipeable_string>(*password);
+            }
+        }
+        return boost::none;
+    }
+
+    virtual void on_pool_tx_removed(const crypto::hash &txid)
+    {
+        std::string txid_hex = epee::string_tools::pod_to_hex(txid);
+        if (m_listener) {
+            m_listener->onPoolTxRemoved(txid_hex);
+        }
+    }
+
     WalletListener * m_listener;
     WalletImpl     * m_wallet;
 };
@@ -400,6 +430,12 @@ uint64_t Wallet::maximumAllowedAmount()
     return std::numeric_limits<uint64_t>::max();
 }
 
+bool Wallet::walletExists(const std::string &path, bool &key_file_exists, bool &wallet_file_exists)
+{
+    tools::wallet2::wallet_exists(path, key_file_exists, wallet_file_exists);
+    return (key_file_exists || wallet_file_exists);
+}
+
 void Wallet::init(const char *argv0, const char *default_log_base_name, const std::string &log_path, bool console) {
 #ifdef WIN32
     // Activate UTF-8 support for Boost filesystem classes on Windows
@@ -484,7 +520,7 @@ bool WalletImpl::create(const std::string &path, const std::string &password, co
     m_recoveringFromDevice = false;
     bool keys_file_exists;
     bool wallet_file_exists;
-    tools::wallet2::wallet_exists(path, keys_file_exists, wallet_file_exists);
+    Wallet::walletExists(path, keys_file_exists, wallet_file_exists);
     LOG_PRINT_L3("wallet_path: " << path << "");
     LOG_PRINT_L3("keys_file_exists: " << std::boolalpha << keys_file_exists << std::noboolalpha
                  << "  wallet_file_exists: " << std::boolalpha << wallet_file_exists << std::noboolalpha);
@@ -497,8 +533,9 @@ bool WalletImpl::create(const std::string &path, const std::string &password, co
         setStatusCritical(error);
         return false;
     }
-    // TODO: validate language
-    m_wallet->set_seed_language(language);
+    setSeedLanguage(language);
+    if (!statusOk())
+        return false;
     crypto::secret_key recovery_val, secret_key;
     try {
         recovery_val = m_wallet->generate(path, password, secret_key, false, false);
@@ -523,7 +560,7 @@ bool WalletImpl::createWatchOnly(const std::string &path, const std::string &pas
 
     bool keys_file_exists;
     bool wallet_file_exists;
-    tools::wallet2::wallet_exists(path, keys_file_exists, wallet_file_exists);
+    Wallet::walletExists(path, keys_file_exists, wallet_file_exists);
     LOG_PRINT_L3("wallet_path: " << path << "");
     LOG_PRINT_L3("keys_file_exists: " << std::boolalpha << keys_file_exists << std::noboolalpha
                  << "  wallet_file_exists: " << std::boolalpha << wallet_file_exists << std::noboolalpha);
@@ -673,6 +710,8 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
         if(has_spendkey && !has_viewkey) {
            m_wallet->generate(path, password, spendkey, true, false);
            setSeedLanguage(language);
+           if (!statusOk())
+               return false;
            LOG_PRINT_L1("Generated deterministic wallet from spend key with seed language: " + language);
         }
         
@@ -718,7 +757,7 @@ bool WalletImpl::open(const std::string &path, const std::string &password)
         // Check if wallet cache exists
         bool keys_file_exists;
         bool wallet_file_exists;
-        tools::wallet2::wallet_exists(path, keys_file_exists, wallet_file_exists);
+        Wallet::walletExists(path, keys_file_exists, wallet_file_exists);
         if(!wallet_file_exists){
             // Rebuilding wallet cache, using refresh height from .keys file
             m_rebuildWalletCache = true;
@@ -731,7 +770,7 @@ bool WalletImpl::open(const std::string &path, const std::string &password)
         LOG_ERROR("Error opening wallet: " << e.what());
         setStatusCritical(e.what());
     }
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 bool WalletImpl::recover(const std::string &path, const std::string &seed)
@@ -766,33 +805,35 @@ bool WalletImpl::recover(const std::string &path, const std::string &password, c
         old_language = Language::English().get_language_name();
 
     try {
-        m_wallet->set_seed_language(old_language);
+        setSeedLanguage(old_language);
+        if (!statusOk())
+            return false;
         m_wallet->generate(path, password, recovery_key, true, false);
         m_password = password;
 
     } catch (const std::exception &e) {
         setStatusCritical(e.what());
     }
-    return status() == Status_Ok;
+    return statusOk();
 }
 
-bool WalletImpl::close(bool store)
+bool WalletImpl::close(bool do_store)
 {
 
     bool result = false;
     LOG_PRINT_L1("closing wallet...");
     try {
-        if (store) {
+        if (do_store) {
             // Do not store wallet with invalid status
             // Status Critical refers to errors on opening or creating wallets.
             if (status() != Status_Critical)
-                m_wallet->store();
+                store("");
             else
                 LOG_ERROR("Status_Critical - not saving wallet");
             LOG_PRINT_L1("wallet::store done");
         }
         LOG_PRINT_L1("Calling wallet::stop...");
-        m_wallet->stop();
+        stop();
         LOG_PRINT_L1("wallet::stop done");
         m_wallet->deinit();
         result = true;
@@ -823,7 +864,11 @@ void WalletImpl::setSeedLanguage(const std::string &arg)
 {
     if (checkBackgroundSync("cannot set seed language"))
         return;
-    m_wallet->set_seed_language(arg);
+
+    if (crypto::ElectrumWords::is_valid_language(arg))
+        m_wallet->set_seed_language(arg);
+    else
+        setStatusError(string(tr("Failed to set seed language. Language not valid: ")) + arg);
 }
 
 int WalletImpl::status() const
@@ -855,7 +900,7 @@ bool WalletImpl::setPassword(const std::string &password)
     } catch (const std::exception &e) {
         setStatusError(e.what());
     }
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 const std::string& WalletImpl::getPassword() const
@@ -871,7 +916,7 @@ bool WalletImpl::setDevicePin(const std::string &pin)
     } catch (const std::exception &e) {
         setStatusError(e.what());
     }
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 bool WalletImpl::setDevicePassphrase(const std::string &passphrase)
@@ -882,7 +927,7 @@ bool WalletImpl::setDevicePassphrase(const std::string &passphrase)
     } catch (const std::exception &e) {
         setStatusError(e.what());
     }
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 std::string WalletImpl::address(uint32_t accountIndex, uint32_t addressIndex) const
@@ -1085,7 +1130,7 @@ bool WalletImpl::refresh()
     //TODO: make doRefresh return bool to know whether the error occurred during refresh or not
     //otherwise one may try, say, to send transaction, transfer fails and this method returns false
     doRefresh();
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 void WalletImpl::refreshAsync()
@@ -1102,7 +1147,7 @@ bool WalletImpl::rescanBlockchain()
     clearStatus();
     m_refreshShouldRescan = true;
     doRefresh();
-    return status() == Status_Ok;
+    return statusOk();
 }
 
 void WalletImpl::rescanBlockchainAsync()
@@ -1150,6 +1195,29 @@ UnsignedTransaction *WalletImpl::loadUnsignedTx(const std::string &unsigned_file
   return transaction;
 }
 
+UnsignedTransaction *WalletImpl::loadUnsignedTxFromStr(const std::string &unsigned_tx_str)
+{
+    clearStatus();
+    std::unique_ptr<UnsignedTransactionImpl> transaction(new UnsignedTransactionImpl(*this));
+    if (checkBackgroundSync("cannot load tx") || !m_wallet->parse_unsigned_tx_from_str(unsigned_tx_str, transaction->m_unsigned_tx_set))
+    {
+        setStatusError(tr("Failed to load unsigned transaction"));
+        transaction->m_status = UnsignedTransaction::Status::Status_Error;
+        transaction->m_errorString = errorString();
+
+        return transaction.release();
+    }
+
+    // Check tx data and construct confirmation message
+    std::string extra_message;
+    if (!std::get<2>(transaction->m_unsigned_tx_set.transfers).empty())
+        extra_message = (boost::format("%u outputs to import. ") % (unsigned)std::get<2>(transaction->m_unsigned_tx_set.transfers).size()).str();
+    transaction->checkLoadedTx([&transaction](){return transaction->m_unsigned_tx_set.txes.size();}, [&transaction](size_t n)->const tools::wallet2::tx_construction_data&{return transaction->m_unsigned_tx_set.txes[n];}, extra_message);
+    setStatus(transaction->status(), transaction->errorString());
+
+    return transaction.release();
+}
+
 bool WalletImpl::submitTransaction(const string &fileName) {
   clearStatus();
   if (checkBackgroundSync("cannot submit tx"))
@@ -1158,7 +1226,7 @@ bool WalletImpl::submitTransaction(const string &fileName) {
 
   bool r = m_wallet->load_tx(fileName, transaction->m_pending_tx);
   if (!r) {
-    setStatus(Status_Ok, tr("Failed to load transaction from file"));
+    setStatusError(tr("Failed to load transaction from file"));
     return false;
   }
   
@@ -1172,7 +1240,7 @@ bool WalletImpl::submitTransaction(const string &fileName) {
 
 bool WalletImpl::exportKeyImages(const string &filename, bool all) 
 {
-  if (m_wallet->watch_only())
+  if (watchOnly())
   {
     setStatusError(tr("Wallet is view only"));
     return false;
@@ -1195,6 +1263,30 @@ bool WalletImpl::exportKeyImages(const string &filename, bool all)
     return false;
   }
   return true;
+}
+
+std::string WalletImpl::exportKeyImagesAsString(bool all /* = false */)
+{
+    clearStatus();
+    if (watchOnly())
+    {
+        setStatusError(tr("Wallet is view only"));
+        return "";
+    }
+    if (checkBackgroundSync("cannot export key images"))
+        return "";
+
+    try
+    {
+        return m_wallet->export_key_images_to_str(all);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR("Error exporting key images: " << e.what());
+        setStatusError(e.what());
+        return "";
+    }
+    return "";
 }
 
 bool WalletImpl::importKeyImages(const string &filename)
@@ -1222,6 +1314,32 @@ bool WalletImpl::importKeyImages(const string &filename)
   return true;
 }
 
+bool WalletImpl::importKeyImagesFromStr(const std::string &data)
+{
+    clearStatus();
+    if (checkBackgroundSync("cannot import key images"))
+        return false;
+    if (!trustedDaemon()) {
+        setStatusError(tr("Key images can only be imported with a trusted daemon"));
+        return false;
+    }
+    try
+    {
+        uint64_t spent = 0, unspent = 0;
+        uint64_t height = m_wallet->import_key_images_from_str(data, spent, unspent);
+        LOG_PRINT_L2("Signed key images imported to height " << height << ", "
+                << print_money(spent) << " spent, " << print_money(unspent) << " unspent");
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR("Error importing key images: " << e.what());
+        setStatusError(string(tr("Failed to import key images: ")) + e.what());
+        return false;
+    }
+
+    return true;
+}
+
 bool WalletImpl::exportOutputs(const string &filename, bool all)
 {
     if (checkBackgroundSync("cannot export outputs"))
@@ -1234,8 +1352,8 @@ bool WalletImpl::exportOutputs(const string &filename, bool all)
 
     try
     {
-        std::string data = m_wallet->export_outputs_to_str(all);
-        bool r = m_wallet->save_to_file(filename, data);
+        std::string data = exportEnotesToStr(all);
+        bool r = saveToFile(filename, data);
         if (!r)
         {
             LOG_ERROR("Failed to save file " << filename);
@@ -1265,7 +1383,7 @@ bool WalletImpl::importOutputs(const string &filename)
     }
 
     std::string data;
-    bool r = m_wallet->load_from_file(filename, data);
+    bool r = loadFromFile(filename, data);
     if (!r)
     {
         LOG_ERROR("Failed to read file: " << filename);
@@ -1275,7 +1393,9 @@ bool WalletImpl::importOutputs(const string &filename)
 
     try
     {
-        size_t n_outputs = m_wallet->import_outputs_from_str(data);
+        size_t n_outputs = importEnotesFromStr(data);
+        if (!statusOk())
+            throw runtime_error(errorString());
         LOG_PRINT_L2(std::to_string(n_outputs) << " outputs imported");
     }
     catch (const std::exception &e)
@@ -1492,7 +1612,7 @@ string WalletImpl::makeMultisig(const vector<string>& info, const uint32_t thres
     try {
         clearStatus();
 
-        if (m_wallet->get_multisig_status().multisig_is_active) {
+        if (multisig().isMultisig) {
             throw runtime_error("Wallet is already multisig");
         }
 
@@ -1643,6 +1763,10 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
 
     PendingTransactionImpl * transaction = new PendingTransactionImpl(*this);
 
+    uint32_t adjusted_priority = adjustPriority(static_cast<uint32_t>(priority));
+    if (!statusOk())
+        return transaction;
+
     do {
         if (checkBackgroundSync("cannot create transactions"))
             break;
@@ -1694,7 +1818,7 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
                 dsts.push_back(de);
             } else {
                 if (subaddr_indices.empty()) {
-                    for (uint32_t index = 0; index < m_wallet->get_num_subaddresses(subaddr_account); ++index)
+                    for (uint32_t index = 0; index < numSubaddresses(subaddr_account); ++index)
                         subaddr_indices.insert(index);
                 }
             }
@@ -1707,7 +1831,7 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
             break;
         }
         try {
-            size_t fake_outs_count = mixin_count > 0 ? mixin_count : m_wallet->default_mixin();
+            size_t fake_outs_count = mixin_count > 0 ? mixin_count : defaultMixin();
             fake_outs_count = m_wallet->adjust_mixin(mixin_count);
 
             if (amount) {
@@ -1727,7 +1851,6 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
                 transaction->m_signers = tx_set.m_signers;
             }
         } catch (const tools::error::daemon_busy&) {
-            // TODO: make it translatable with "tr"?
             setStatusError(tr("daemon is busy. Please try again later."));
         } catch (const tools::error::no_connection_to_daemon&) {
             setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
@@ -1821,7 +1944,6 @@ PendingTransaction *WalletImpl::createSweepUnmixableTransaction()
             pendingTxPostProcess(transaction);
 
         } catch (const tools::error::daemon_busy&) {
-            // TODO: make it translatable with "tr"?
             setStatusError(tr("daemon is busy. Please try again later."));
         } catch (const tools::error::no_connection_to_daemon&) {
             setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
@@ -1902,16 +2024,16 @@ uint64_t WalletImpl::estimateTransactionFee(const std::vector<std::pair<std::str
     const size_t extra_size = pubkey_size + encrypted_paymentid_size;
 
     return m_wallet->estimate_fee(
-        m_wallet->use_fork_rules(HF_VERSION_PER_BYTE_FEE, 0),
-        m_wallet->use_fork_rules(4, 0),
+        useForkRules(HF_VERSION_PER_BYTE_FEE, 0),
+        useForkRules(4, 0),
         1,
         m_wallet->get_min_ring_size() - 1,
         destinations.size() + 1,
         extra_size,
-        m_wallet->use_fork_rules(8, 0),
-        m_wallet->use_fork_rules(HF_VERSION_CLSAG, 0),
-        m_wallet->use_fork_rules(HF_VERSION_BULLETPROOF_PLUS, 0),
-        m_wallet->use_fork_rules(HF_VERSION_VIEW_TAGS, 0),
+        useForkRules(8, 0),
+        useForkRules(HF_VERSION_CLSAG, 0),
+        useForkRules(HF_VERSION_BULLETPROOF_PLUS, 0),
+        useForkRules(HF_VERSION_VIEW_TAGS, 0),
         m_wallet->get_base_fee(static_cast<uint32_t>(priority)),
         m_wallet->get_fee_quantization_mask());
 }
@@ -2234,13 +2356,15 @@ bool WalletImpl::checkReserveProof(const std::string &address, const std::string
     }
 }
 
-std::string WalletImpl::signMessage(const std::string &message, const std::string &address)
+std::string WalletImpl::signMessage(const std::string &message, const std::string &address, bool sign_with_view_key)
 {
     if (checkBackgroundSync("cannot sign message"))
         return "";
 
+    tools::wallet2::message_signature_type_t sig_type = sign_with_view_key ? tools::wallet2::sign_with_view_key : tools::wallet2::sign_with_spend_key;
+
     if (address.empty()) {
-        return m_wallet->sign(message, tools::wallet2::sign_with_spend_key);
+        return m_wallet->sign(message, sig_type);
     }
 
     cryptonote::address_parse_info info;
@@ -2254,7 +2378,7 @@ std::string WalletImpl::signMessage(const std::string &message, const std::strin
         return "";
     }
 
-    return m_wallet->sign(message, tools::wallet2::sign_with_spend_key, *index);
+    return m_wallet->sign(message, sig_type, *index);
 }
 
 bool WalletImpl::verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const
@@ -2529,11 +2653,11 @@ bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_a
     // If daemon isn't synced a calculated block height will be used instead
     if (isNewWallet() && daemonSynced()) {
         LOG_PRINT_L2(__FUNCTION__ << ":New Wallet - fast refresh until " << daemonBlockChainHeight());
-        m_wallet->set_refresh_from_block_height(daemonBlockChainHeight());
+        setRefreshFromBlockHeight(daemonBlockChainHeight());
     }
 
     if (m_rebuildWalletCache)
-      LOG_PRINT_L2(__FUNCTION__ << ": Rebuilding wallet cache, fast refresh until block " << m_wallet->get_refresh_from_block_height());
+      LOG_PRINT_L2(__FUNCTION__ << ": Rebuilding wallet cache, fast refresh until block " << getRefreshFromBlockHeight());
 
     if (Utils::isAddressLocal(daemon_address)) {
         this->setTrustedDaemon(true);
@@ -2614,8 +2738,19 @@ void WalletImpl::hardForkInfo(uint8_t &version, uint64_t &earliest_height) const
 
 bool WalletImpl::useForkRules(uint8_t version, int64_t early_blocks) const 
 {
-    return m_wallet->use_fork_rules(version,early_blocks);
+    clearStatus();
+
+    try
+    {
+        return m_wallet->use_fork_rules(version, early_blocks);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError((boost::format(tr("Failed to check if fork rules for version `%u` with `%d` early blocks should be used: %s")) % version % early_blocks % e.what()).str());
+    }
+    return false;
 }
+//-------------------------------------------------------------------------------------------------------------------
 
 bool WalletImpl::getRing(const std::string &key_image, std::vector<uint64_t> &ring) const
 {
@@ -2751,5 +2886,906 @@ uint64_t WalletImpl::getBytesSent()
 {
     return m_wallet->get_bytes_sent();
 }
+
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::getMultisigSeed(const std::string &seed_offset) const
+{
+    clearStatus();
+
+    if (checkBackgroundSync("cannot get multisig seed"))
+        return std::string();
+
+    try
+    {
+        checkMultisigWalletReady(m_wallet);
+
+        epee::wipeable_string seed;
+        if (m_wallet->get_multisig_seed(seed, seed_offset))
+            return std::string(seed.data(), seed.size());
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError(string(tr("Failed to get multisig seed: ")) + e.what());
+    }
+    return "";
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::pair<std::uint32_t, std::uint32_t> WalletImpl::getSubaddressIndex(const std::string &address) const
+{
+    clearStatus();
+
+    cryptonote::address_parse_info info;
+    std::pair<std::uint32_t, std::uint32_t> indices{0, 0};
+    if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), address))
+    {
+        setStatusError(string(tr("Failed to parse address: ") + address));
+        return indices;
+    }
+
+    auto index = m_wallet->get_subaddress_index(info.address);
+    if (!index)
+        setStatusError(string(tr("Address doesn't belong to the wallet: ") + address));
+    else
+        indices = std::make_pair((*index).major, (*index).minor);
+
+    return indices;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::freeze(const std::string &key_image)
+{
+    clearStatus();
+
+    crypto::key_image ki_pod;
+    if (!epee::string_tools::hex_to_pod(key_image, ki_pod))
+    {
+        setStatusError((boost::format(tr("Failed to parse key image `%s`")) % key_image).str());
+        return;
+    }
+
+    try
+    {
+        m_wallet->freeze(ki_pod);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to freeze enote with key image `%s`: %s")) % key_image % e.what()).str());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::freezeByPubKey(const std::string &public_key)
+{
+    clearStatus();
+
+    crypto::public_key pk;
+    if (!epee::string_tools::hex_to_pod(public_key, pk))
+    {
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
+        return;
+    }
+
+    try
+    {
+        m_wallet->freeze(m_wallet->get_output_index(pk));
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to freeze enote with public key `%s`: %s")) % public_key % e.what()).str());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::thaw(const std::string &key_image)
+{
+    clearStatus();
+
+    crypto::key_image ki_pod;
+    if (!epee::string_tools::hex_to_pod(key_image, ki_pod))
+    {
+        setStatusError((boost::format(tr("Failed to parse key image `%s`")) % key_image).str());
+        return;
+    }
+
+    try
+    {
+        m_wallet->thaw(ki_pod);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to thaw enote with key image `%s`: %s")) % key_image % e.what()).str());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::thawByPubKey(const std::string &public_key)
+{
+    clearStatus();
+
+    crypto::public_key pk;
+    if (!epee::string_tools::hex_to_pod(public_key, pk))
+    {
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
+        return;
+    }
+
+    try
+    {
+        m_wallet->thaw(m_wallet->get_output_index(pk));
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to thaw enote with public key `%s`: %s")) % public_key % e.what()).str());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::isFrozen(const std::string &key_image) const
+{
+    clearStatus();
+
+    crypto::key_image ki_pod;
+    if (!epee::string_tools::hex_to_pod(key_image, ki_pod))
+    {
+        setStatusError((boost::format(tr("Failed to parse key image `%s`")) % key_image).str());
+        return false;
+    }
+
+    try
+    {
+        return m_wallet->frozen(ki_pod);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to determine if enote with key image `%s` is frozen: %s")) % key_image % e.what()).str());
+    }
+
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::isFrozenByPubKey(const std::string &public_key)
+{
+    clearStatus();
+
+    crypto::public_key pk;
+    if (!epee::string_tools::hex_to_pod(public_key, pk))
+    {
+        setStatusError((boost::format(tr("Failed to parse public key `%s`")) % public_key).str());
+        return false;
+    }
+
+    try
+    {
+        return m_wallet->frozen(m_wallet->get_output_index(pk));
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to determine if enote with public key `%s` is frozen: %s")) % public_key % e.what()).str());
+    }
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::createOneOffSubaddress(std::uint32_t account_index, std::uint32_t address_index)
+{
+    m_wallet->create_one_off_subaddress({account_index, address_index});
+}
+//-------------------------------------------------------------------------------------------------------------------
+Wallet::WalletState WalletImpl::getWalletState() const
+{
+    WalletState wallet_state{};
+
+    wallet_state.is_deprecated = m_wallet->is_deprecated();
+    wallet_state.ring_size = 16;
+    wallet_state.daemon_address = m_wallet->get_daemon_address();
+
+    return wallet_state;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::rewriteWalletFile(const std::string &wallet_name, const std::string &password)
+{
+    clearStatus();
+
+    try
+    {
+        m_wallet->rewrite(wallet_name, epee::wipeable_string(password.data(), password.size()));
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError((boost::format(tr("Failed to rewrite wallet file with wallet name `%s`: %s")) % wallet_name % e.what()).str());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name)
+{
+    clearStatus();
+
+    try
+    {
+        m_wallet->write_watch_only_wallet(m_wallet->get_wallet_file(), epee::wipeable_string(password.data(), password.size()), new_keys_file_name);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError(string(tr("Failed to write watch only wallet: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::refreshPoolOnly(bool refreshed /*false*/, bool try_incremental /*false*/)
+{
+    clearStatus();
+
+    // Update pool state
+    std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> process_txs_pod;
+    try
+    {
+        m_wallet->update_pool_state(process_txs_pod, refreshed, try_incremental);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError(string(tr("Failed to update pool state: ")) + e.what());
+        return;
+    }
+
+    if (process_txs_pod.empty())
+        return;
+
+    // Process pool state
+    try
+    {
+        m_wallet->process_pool_state(process_txs_pod);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR(__FUNCTION__ << " error: " << e.what());
+        setStatusError(string(tr("Failed to process pool state: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const
+{
+    tools::wallet2::transfer_container tc;
+    m_wallet->get_transfers(tc);
+    enote_details.reserve(tc.size());
+
+    for (const auto &td : tc)
+    {
+        auto ed = std::make_unique<EnoteDetailsImpl>();
+
+        cryptonote::txout_target_v txout_v = td.m_tx.vout[td.m_internal_output_index].target;
+        if (txout_v.type() == typeid(cryptonote::txout_to_key))
+            ed->m_onetime_address = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_key>(txout_v).key);
+        else if (txout_v.type() == typeid(cryptonote::txout_to_tagged_key))
+        {
+            ed->m_onetime_address = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_tagged_key>(txout_v).key);
+            ed->m_view_tag = epee::string_tools::pod_to_hex(boost::get<cryptonote::txout_to_tagged_key>(txout_v).view_tag);
+        }
+
+        ed->m_block_height = td.m_block_height;
+        ed->m_tx_id = epee::string_tools::pod_to_hex(td.m_txid);
+        ed->m_internal_enote_index = td.m_internal_output_index;
+        ed->m_global_enote_index = td.m_global_output_index;
+        ed->m_spent = td.m_spent;
+        ed->m_frozen = td.m_frozen;
+        ed->m_spent_height = td.m_spent_height;
+        ed->m_key_image = epee::string_tools::pod_to_hex(td.m_key_image);
+        ed->m_mask = epee::string_tools::pod_to_hex(td.m_mask);
+        ed->m_amount = td.m_amount;
+        ed->m_protocol_version = td.m_rct ? EnoteDetails::TxProtocol_RingCT : EnoteDetails::TxProtocol_CryptoNote;
+        ed->m_key_image_known = td.m_key_image_known;
+        ed->m_key_image_request = td.m_key_image_request;
+        ed->m_pk_index = td.m_pk_index;
+        ed->m_uses.reserve(td.m_uses.size());
+        for (auto &u : td.m_uses)
+            ed->m_uses.push_back(std::make_pair(u.first, epee::string_tools::pod_to_hex(u.second)));
+        ed->m_key_image_partial = td.m_key_image_partial;
+
+        enote_details.push_back(std::move(ed));
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const
+{
+    clearStatus();
+
+    if (checkBackgroundSync("cannot get multisig seed"))
+        return std::string();
+
+    try
+    {
+        checkMultisigWalletReady(m_wallet);
+
+        const PendingTransactionImpl *ptx_impl = dynamic_cast<const PendingTransactionImpl*>(&multisig_ptx);
+
+        tools::wallet2::multisig_tx_set multisig_tx_set;
+        multisig_tx_set.m_ptx = ptx_impl->m_pending_tx;
+        multisig_tx_set.m_signers = ptx_impl->m_signers;
+
+        return m_wallet->save_multisig_tx(multisig_tx_set);
+    }
+    catch (const exception &e)
+    {
+        setStatusError(string(tr("Failed to convert pending multisig tx to string: ")) + e.what());
+    }
+
+    return "";
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const
+{
+    clearStatus();
+
+    if (checkBackgroundSync("cannot get multisig seed"))
+        return false;
+
+    try
+    {
+        checkMultisigWalletReady(m_wallet);
+
+        const PendingTransactionImpl *ptx_impl = dynamic_cast<const PendingTransactionImpl*>(&multisig_ptx);
+
+        tools::wallet2::multisig_tx_set multisig_tx_set;
+        multisig_tx_set.m_ptx = ptx_impl->m_pending_tx;
+        multisig_tx_set.m_signers = ptx_impl->m_signers;
+
+        return m_wallet->save_multisig_tx(multisig_tx_set, filename);
+    }
+    catch (const exception &e)
+    {
+        setStatusError((boost::format(tr("Failed to save multisig tx to file with filename `%s`: %s")) % filename % e.what()).str());
+    }
+
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const
+{
+    PendingTransactionImpl *ptx_impl = dynamic_cast<PendingTransactionImpl*>(&ptx);
+    std::shared_ptr<tools::wallet2::signed_tx_set> signed_tx_set_out = std::make_shared<tools::wallet2::signed_tx_set>();
+    bool r = m_wallet->parse_tx_from_str(signed_tx_str, ptx_impl->m_pending_tx, /* accept_func = */ NULL, signed_tx_set_out.get(), /* do_handle_key_images = */ false);
+    if (r)
+        ptx_impl->m_tx_key_images = signed_tx_set_out->tx_key_images;
+    return r;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::insertColdKeyImages(PendingTransaction &ptx)
+{
+    m_wallet->insert_cold_key_images(dynamic_cast<PendingTransactionImpl*>(&ptx)->m_tx_key_images);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const
+{
+    clearStatus();
+
+    try
+    {
+        checkMultisigWalletReady(m_wallet);
+
+        PendingTransactionImpl *ptx_impl = dynamic_cast<PendingTransactionImpl*>(&exported_txs);
+        tools::wallet2::multisig_tx_set multisig_tx;
+
+        if (!m_wallet->parse_multisig_tx_from_str(multisig_tx_str, multisig_tx))
+            throw runtime_error(tr("Failed to parse multisig transaction from string."));
+
+        ptx_impl->m_pending_tx = multisig_tx.m_ptx;
+        ptx_impl->m_signers = multisig_tx.m_signers;
+
+        return true;
+    }
+    catch (const exception &e)
+    {
+        setStatusError(e.what());
+    }
+
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const
+{
+    clearStatus();
+
+    try
+    {
+        return m_wallet->get_fee_multiplier(priority, fee_algorithm);
+    }
+    catch (const exception &e)
+    {
+        setStatusError((boost::format(tr("Failed to get fee multiplier for priority `%u` and fee algorithm `%d`: %s")) % priority % fee_algorithm % e.what()).str());
+    }
+    return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getBaseFee() const
+{
+    return m_wallet->get_base_fee();
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint32_t WalletImpl::adjustPriority(std::uint32_t priority)
+{
+    return m_wallet->adjust_priority(priority);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::coldTxAuxImport(const PendingTransaction &ptx, const std::vector<std::string> &tx_device_aux) const
+{
+    clearStatus();
+
+    const PendingTransactionImpl *ptx_impl = dynamic_cast<const PendingTransactionImpl*>(&ptx);
+
+    try
+    {
+        m_wallet->cold_tx_aux_import(ptx_impl->m_pending_tx, tx_device_aux);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to import cold tx aux: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::coldSignTx(const PendingTransaction &ptx_in, PendingTransaction &exported_txs_out) const
+{
+    clearStatus();
+
+    try
+    {
+        const PendingTransactionImpl *ptx_impl_in = dynamic_cast<const PendingTransactionImpl*>(&ptx_in);
+        PendingTransactionImpl *ptx_impl_out = dynamic_cast<PendingTransactionImpl*>(&exported_txs_out);
+        tools::wallet2::signed_tx_set signed_txs;
+        std::vector<cryptonote::address_parse_info> dsts_info;
+
+        m_wallet->cold_sign_tx(ptx_impl_in->m_pending_tx, signed_txs, dsts_info, ptx_impl_out->m_tx_device_aux);
+        ptx_impl_out->m_key_images = signed_txs.key_images;
+        ptx_impl_out->m_pending_tx = signed_txs.ptx;
+        ptx_impl_out->m_tx_key_images = signed_txs.tx_key_images;
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to cold sign tx: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::discardUnmixableEnotes()
+{
+    clearStatus();
+
+    try
+    {
+        m_wallet->discard_unmixable_outputs();
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to discard unmixable enotes: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setTxKey(const std::string &txid, const std::string &tx_key, const std::vector<std::string> &additional_tx_keys, const std::string &single_destination_subaddress)
+{
+    clearStatus();
+
+    crypto::hash txid_pod;
+    if (!epee::string_tools::hex_to_pod(txid, txid_pod))
+    {
+        setStatusError(string(tr("Failed to parse tx id: ")) + txid);
+        return;
+    }
+
+    crypto::secret_key tx_key_pod;
+    if (!epee::string_tools::hex_to_pod(tx_key, tx_key_pod))
+    {
+        setStatusError(tr("Failed to parse tx key"));
+        return;
+    }
+
+    std::vector<crypto::secret_key> additional_tx_keys_pod;
+    crypto::secret_key tmp_additional_tx_key_pod;
+    additional_tx_keys_pod.reserve(additional_tx_keys.size());
+    for (std::string additional_tx_key : additional_tx_keys)
+    {
+        if (!epee::string_tools::hex_to_pod(additional_tx_key, tmp_additional_tx_key_pod))
+        {
+            setStatusError(string(tr("Failed to parse additional tx key: ")) + additional_tx_key);
+            return;
+        }
+        additional_tx_keys_pod.push_back(tmp_additional_tx_key_pod);
+    }
+
+    boost::optional<cryptonote::account_public_address> single_destination_subaddress_pod = boost::none;
+    cryptonote::address_parse_info info;
+    if (!single_destination_subaddress.empty())
+    {
+        if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), single_destination_subaddress))
+        {
+            setStatusError(string(tr("Failed to get account address from string: ")) + single_destination_subaddress);
+            return;
+        }
+        single_destination_subaddress_pod = info.address;
+    }
+
+    try
+    {
+        m_wallet->set_tx_key(txid_pod, tx_key_pod, additional_tx_keys_pod, info.address);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to set tx key: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& WalletImpl::getAccountTags() const
+{
+    return m_wallet->get_account_tags();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAccountTag(const std::set<uint32_t> &account_indices, const std::string &tag)
+{
+    clearStatus();
+
+    try
+    {
+        m_wallet->set_account_tag(account_indices, tag);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to set account tag: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAccountTagDescription(const std::string &tag, const std::string &description)
+{
+    clearStatus();
+
+    try
+    {
+        m_wallet->set_account_tag_description(tag, description);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to set account tag description: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::string WalletImpl::exportEnotesToStr(bool all, std::uint32_t start, std::uint32_t count) const
+{
+    clearStatus();
+    if (checkBackgroundSync("cannot export enotes"))
+        return "";
+    if (m_wallet->key_on_device())
+    {
+        setStatusError(string(tr("Not supported on HW wallets.")));
+        return "";
+    }
+
+    try
+    {
+        return m_wallet->export_outputs_to_str(all, start, count);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to export enotes to string: ")) + e.what());
+    }
+    return "";
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::size_t WalletImpl::importEnotesFromStr(const std::string &enotes_str)
+{
+    clearStatus();
+    if (checkBackgroundSync("cannot import enotes"))
+        return 0;
+    if (m_wallet->key_on_device())
+    {
+        setStatusError(string(tr("Not supported on HW wallets.")));
+        return 0;
+    }
+
+    try
+    {
+        return m_wallet->import_outputs_from_str(enotes_str);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to import enotes from string: ")) + e.what());
+    }
+    return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::getBlockchainHeightByDate(std::uint16_t year, std::uint8_t month, std::uint8_t day) const
+{
+    clearStatus();
+
+    try
+    {
+        return m_wallet->get_blockchain_height_by_date(year, month, day);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to get blockchain height by date: ")) + e.what());
+    }
+    return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::vector<std::pair<std::uint64_t, std::uint64_t>> WalletImpl::estimateBacklog(const std::vector<std::pair<double, double>> &fee_levels) const
+{
+    clearStatus();
+
+    try
+    {
+        return m_wallet->estimate_backlog(fee_levels);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to estimate backlog: ")) + e.what());
+    }
+    return { std::make_pair(0, 0) };
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable /* = false */) const
+{
+    return m_wallet->save_to_file(path_to_file, binary, is_printable);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size /* = 1000000000 */) const
+{
+    return m_wallet->load_from_file(path_to_file, target_str, max_size);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::hashEnotes(std::uint64_t enote_idx, std::string &hash) const
+{
+    clearStatus();
+
+    try
+    {
+        crypto::hash hash_pod;
+        boost::optional<std::uint64_t> idx = enote_idx == 0 ? boost::none : boost::optional<std::uint64_t>(enote_idx);
+        std::uint64_t current_height = m_wallet->hash_m_transfers(idx, hash_pod);
+        hash = epee::string_tools::pod_to_hex(hash_pod);
+        return current_height;
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to hash enotes: ")) + e.what());
+    }
+    return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::finishRescanBcKeepKeyImages(std::uint64_t enote_idx, const std::string &hash)
+{
+    clearStatus();
+
+    try
+    {
+        crypto::hash hash_pod;
+        if (!epee::string_tools::hex_to_pod(hash, hash_pod))
+            setStatusError(tr("Failed to parse hash"));
+        else
+            m_wallet->finish_rescan_bc_keep_key_images(enote_idx, hash_pod);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to finish rescan blockchain: ")) + e.what());
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> WalletImpl::getPublicNodes(bool white_only /* = true */) const
+{
+    clearStatus();
+
+    std::vector<cryptonote::public_node> public_nodes;
+    std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> public_nodes_out;
+    try
+    {
+        public_nodes = m_wallet->get_public_nodes(white_only);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to get public nodes: ")) + e.what());
+        return std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>>{};
+    }
+
+    for (auto pub_node : public_nodes)
+        public_nodes_out.push_back(std::tuple<std::string, std::uint16_t, std::uint64_t>{pub_node.host, pub_node.rpc_port, pub_node.last_seen});
+
+    return public_nodes_out;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::pair<std::size_t, std::uint64_t> WalletImpl::estimateTxSizeAndWeight(bool use_rct, int n_inputs, int ring_size, int n_outputs, std::size_t extra_size) const
+{
+    clearStatus();
+
+    try
+    {
+        return m_wallet->estimate_tx_size_and_weight(use_rct, n_inputs, ring_size, n_outputs, extra_size);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to estimate transaction size and weight: ")) + e.what());
+    }
+    return std::make_pair(0, 0);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t WalletImpl::importKeyImages(const std::vector<std::pair<std::string, std::string>> &signed_key_images, std::size_t offset, std::uint64_t &spent, std::uint64_t &unspent, bool check_spent)
+{
+    clearStatus();
+
+    std::vector<std::pair<crypto::key_image, crypto::signature>> signed_key_images_pod;
+    crypto::key_image tmp_key_image_pod;
+    crypto::signature tmp_signature_pod{};
+    size_t sig_size = sizeof(crypto::signature);
+
+    signed_key_images_pod.reserve(signed_key_images.size());
+
+    for (auto ski : signed_key_images)
+    {
+        if (!epee::string_tools::hex_to_pod(ski.first, tmp_key_image_pod))
+        {
+            setStatusError(string(tr("Failed to parse key image: ")) + ski.first);
+            return false;
+        }
+        if (!epee::string_tools::hex_to_pod(ski.second.substr(0, sig_size/2), tmp_signature_pod.c))
+        {
+            setStatusError(string(tr("Failed to parse signature.c: ")) + ski.second.substr(0, sig_size/2));
+            return false;
+        }
+        if (!epee::string_tools::hex_to_pod(ski.second.substr(sig_size/2, sig_size), tmp_signature_pod.r))
+        {
+            setStatusError(string(tr("Failed to parse signature.r: ")) + ski.second.substr(sig_size/2, sig_size));
+            return false;
+        }
+        signed_key_images_pod.push_back(std::make_pair(tmp_key_image_pod, tmp_signature_pod));
+    }
+
+    try
+    {
+        return m_wallet->import_key_images(signed_key_images_pod, offset, spent, unspent, check_spent);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to import key images: ")) + e.what());
+    }
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::importKeyImages(const std::vector<std::string> &key_images, std::size_t offset, const std::unordered_set<std::size_t> &selected_enotes_indices)
+{
+    clearStatus();
+
+    std::vector<crypto::key_image> key_images_pod;
+    crypto::key_image tmp_key_image_pod;
+    key_images_pod.reserve(key_images.size());
+    for (std::string key_image : key_images)
+    {
+        if (!epee::string_tools::hex_to_pod(key_image, tmp_key_image_pod))
+        {
+            setStatusError(string(tr("Failed to parse key image: ")) + key_image);
+            return false;
+        }
+        key_images_pod.push_back(tmp_key_image_pod);
+    }
+
+    try
+    {
+        boost::optional<std::unordered_set<std::size_t>> optional_selected_enote_indices = selected_enotes_indices.empty() ? boost::none : boost::optional<std::unordered_set<std::size_t>>(selected_enotes_indices);
+        return m_wallet->import_key_images(key_images_pod, offset, optional_selected_enote_indices);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to import key images: ")) + e.what());
+    }
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::getAllowMismatchedDaemonVersion() const
+{
+    return m_wallet->is_mismatched_daemon_version_allowed();
+}
+//-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setAllowMismatchedDaemonVersion(bool allow_mismatch)
+{
+    m_wallet->allow_mismatched_daemon_version(allow_mismatch);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::setDaemon(const std::string &daemon_address,
+        const std::string &daemon_username /* = "" */,
+        const std::string &daemon_password /* = "" */,
+        bool trusted_daemon /* = false */,
+        const std::string &ssl_support /* = "autodetect" */,
+        const std::string &ssl_private_key_path /* = "" */,
+        const std::string &ssl_certificate_path /* = "" */,
+        const std::string &ssl_ca_file_path /* = "" */,
+        const std::vector<std::string> &ssl_allowed_fingerprints_str /* = {} */,
+        bool ssl_allow_any_cert /* = false */,
+        const std::string &proxy /* = "" */)
+{
+    clearStatus();
+
+    // SSL allowed fingerprints
+    std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints;
+    ssl_allowed_fingerprints.reserve(ssl_allowed_fingerprints_str.size());
+    for (const std::string &fp: ssl_allowed_fingerprints_str)
+    {
+        ssl_allowed_fingerprints.push_back({});
+        std::vector<uint8_t> &v = ssl_allowed_fingerprints.back();
+        for (auto c: fp)
+            v.push_back(c);
+    }
+
+    // SSL options
+    epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
+    if (ssl_allow_any_cert)
+        ssl_options.verification = epee::net_utils::ssl_verification_t::none;
+    else if (!ssl_allowed_fingerprints.empty() || !ssl_ca_file_path.empty())
+        ssl_options = epee::net_utils::ssl_options_t{std::move(ssl_allowed_fingerprints), std::move(ssl_ca_file_path)};
+
+    if (!epee::net_utils::ssl_support_from_string(ssl_options.support, ssl_support))
+    {
+        setStatusError(string(tr("Invalid ssl support option (allowed options:`disabled` | `enabled` | `autodetect`), actual value: ")) + ssl_support);
+        return false;
+    }
+
+    ssl_options.auth = epee::net_utils::ssl_authentication_t{
+        std::move(ssl_private_key_path), std::move(ssl_certificate_path)
+    };
+
+    const bool verification_required =
+        ssl_options.verification != epee::net_utils::ssl_verification_t::none &&
+        ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_enabled;
+
+    if (verification_required && !ssl_options.has_strong_verification(boost::string_ref{}))
+    {
+        setStatusError(string(tr("SSL is enabled but no user certificate or fingerprints were provided")));
+        return false;
+    }
+
+    // daemon login
+    if(daemon_username != "")
+        m_daemon_login.emplace(daemon_username, daemon_password);
+
+    // set daemon
+    try
+    {
+        return m_wallet->set_daemon(daemon_address, m_daemon_login, trusted_daemon, ssl_options, proxy);
+    }
+    catch (const std::exception &e)
+    {
+        setStatusError(string(tr("Failed to set daemon: ")) + e.what());
+    }
+    return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+
+//-------------------------------------------------------------------------------------------------------------------
+// PRIVATE
+//-------------------------------------------------------------------------------------------------------------------
+std::size_t WalletImpl::getEnoteIndex(const std::string &key_image) const
+{
+    std::vector<std::unique_ptr<EnoteDetails>> enote_details;
+    getEnoteDetails(enote_details);
+    for (size_t idx = 0; idx < enote_details.size(); ++idx)
+    {
+        const auto &ed = dynamic_cast<EnoteDetailsImpl &>(*enote_details[idx].get());
+        if (ed.m_key_image == key_image)
+        {
+            if (ed.m_key_image_known)
+                return idx;
+            else if (ed.m_key_image_partial)
+            {
+                setStatusError("Failed to get enote index by key image: Enote detail lookups are not allowed for multisig partial key images");
+                return 0;
+            }
+        }
+    }
+
+    setStatusError("Failed to get enote index by key image: Key image not found");
+    return 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool WalletImpl::statusOk() const
+{
+    boost::lock_guard<boost::mutex> l(m_statusMutex);
+    return m_status == Status_Ok;
+}
+//-------------------------------------------------------------------------------------------------------------------
+
 
 } // namespace

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -29,6 +29,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 
+#include "device/device.hpp"
 #include "wallet.h"
 #include "device/device.hpp"
 #include "crypto/crypto.h"
@@ -573,7 +574,6 @@ bool WalletImpl::create(const std::string &path, const std::string &password, co
     crypto::secret_key recovery_val, secret_key;
     try {
         recovery_val = m_wallet->generate(path, password, secret_key, /* recover */ false, non_deterministic, create_address_file);
-        m_password = password;
         clearStatus();
     } catch (const std::exception &e) {
         LOG_ERROR("Error creating wallet: " << e.what());
@@ -755,7 +755,6 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
         setStatusError(string(tr("failed to generate new wallet: ")) + e.what());
         return false;
     }
-    m_password = password;
     m_wallet->set_ring_database(get_default_ringdb_path(m_wallet->nettype()));
     return true;
 }
@@ -837,7 +836,6 @@ bool WalletImpl::recoverFromDevice(const std::string &path, const std::string &p
         setStatusError(string(tr("failed to generate new wallet: ")) + e.what());
         return false;
     }
-    m_password = password;
     return true;
 }
 
@@ -862,9 +860,7 @@ bool WalletImpl::open(const std::string &path, const std::string &password)
             m_rebuildWalletCache = true;
         }
         m_wallet->set_ring_database(get_default_ringdb_path(m_wallet->nettype()));
-        m_wallet->load(path, password);
-
-        m_password = password;
+        m_wallet->load(path, epee::wipeable_string(password));
     } catch (const std::exception &e) {
         LOG_ERROR("Error opening wallet: " << e.what());
         setStatusCritical(e.what());
@@ -908,7 +904,6 @@ bool WalletImpl::recover(const std::string &path, const std::string &password, c
         if (!statusOk())
             return false;
         m_wallet->generate(path, password, recovery_key, /*recover*/ true, /*non_deterministic*/ false, create_address_file);
-        m_password = password;
 
     } catch (const std::exception &e) {
         setStatusCritical(e.what());
@@ -974,23 +969,19 @@ void WalletImpl::statusWithErrorString(int& status, std::string& errorString, in
         *extendedStatusOut = m_extendedStatus;
 }
 
-bool WalletImpl::setPassword(const std::string &password)
+bool WalletImpl::setPassword(const std::string_view &old_password, const std::string_view &new_password)
 {
     if (checkBackgroundSync("cannot change password"))
         return false;
     clearStatus();
     try {
-        m_wallet->change_password(m_wallet->get_wallet_file(), m_password, password);
-        m_password = password;
+        m_wallet->change_password(m_wallet->get_wallet_file(),
+                                  epee::wipeable_string(old_password.data(), old_password.size()),
+                                  epee::wipeable_string(new_password.data(), new_password.size()));
     } catch (const std::exception &e) {
         setStatusError(e.what());
     }
     return statusOk();
-}
-
-const std::string& WalletImpl::getPassword() const
-{
-    return m_password;
 }
 
 bool WalletImpl::setDevicePin(const std::string &pin)
@@ -1069,14 +1060,18 @@ void WalletImpl::stop()
     m_wallet->stop();
 }
 
-bool WalletImpl::store(const std::string &path)
+bool WalletImpl::store(const std::string &path,
+                       const optional<std::string_view> &password /* = empty optional */)
 {
     clearStatus();
     try {
         if (path.empty()) {
             m_wallet->store();
+        } else if (password) {
+            m_wallet->store_to(path, epee::wipeable_string((*password).data(), (*password).size()));
         } else {
-            m_wallet->store_to(path, m_password);
+            setStatusError(tr("saving the wallet to a new path requires a password."));
+            return false;
         }
     } catch (const std::exception &e) {
         LOG_ERROR("Error saving wallet: " << e.what());
@@ -1770,7 +1765,7 @@ string WalletImpl::getMultisigInfo() const {
     return string();
 }
 
-string WalletImpl::makeMultisig(const vector<string>& info, const uint32_t threshold) {
+string WalletImpl::makeMultisig(const vector<string>& info, const uint32_t threshold, const std::string_view &password) {
     if (checkBackgroundSync("cannot make multisig"))
         return string();
     try {
@@ -1780,7 +1775,7 @@ string WalletImpl::makeMultisig(const vector<string>& info, const uint32_t thres
             throw runtime_error("Wallet is already multisig");
         }
 
-        return m_wallet->make_multisig(epee::wipeable_string(m_password), info, threshold);
+        return m_wallet->make_multisig(epee::wipeable_string(password.data(), password.size()), info, threshold);
     } catch (const exception& e) {
         LOG_ERROR("Error on making multisig wallet: " << e.what());
         setStatusError(string(tr("Failed to make multisig: ")) + e.what());
@@ -1789,12 +1784,12 @@ string WalletImpl::makeMultisig(const vector<string>& info, const uint32_t thres
     return string();
 }
 
-std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &info, const bool force_update_use_with_caution /*= false*/) {
+std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &info, const std::string_view &password, const bool force_update_use_with_caution /*= false*/) {
     try {
         clearStatus();
         checkMultisigWalletNotReady(m_wallet);
 
-        return m_wallet->exchange_multisig_keys(epee::wipeable_string(m_password), info, force_update_use_with_caution);
+        return m_wallet->exchange_multisig_keys(epee::wipeable_string(password.data(), password.size()), info, force_update_use_with_caution);
     } catch (const exception& e) {
         LOG_ERROR("Error on exchanging multisig keys: " << e.what());
         setStatusError(string(tr("Failed to exchange multisig keys: ")) + e.what());
@@ -1805,11 +1800,12 @@ std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &inf
 
 std::string WalletImpl::getMultisigKeyExchangeBooster(const std::vector<std::string> &info,
     const std::uint32_t threshold,
-    const std::uint32_t num_signers) {
+    const std::uint32_t num_signers,
+    const std::string_view &password) {
     try {
         clearStatus();
 
-        return m_wallet->get_multisig_key_exchange_booster(epee::wipeable_string(m_password), info, threshold, num_signers);
+        return m_wallet->get_multisig_key_exchange_booster(epee::wipeable_string(password.data(), password.size()), info, threshold, num_signers);
     } catch (const exception& e) {
         LOG_ERROR("Error on boosting multisig key exchange: " << e.what());
         setStatusError(string(tr("Failed to boost multisig key exchange: ")) + e.what());

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -43,12 +43,14 @@
 #include "subaddress.h"
 #include "subaddress_account.h"
 #include "common_defines.h"
+#include "common/notify.h"
 #include "common/util.h"
 #include "multisig/multisig_account.h"
 
 #include "mnemonics/electrum-words.h"
 #include "mnemonics/english.h"
 #include "wallet/fee_priority.h"
+#include "wallet/wallet_errors.h"
 #include <boost/format.hpp>
 #include <sstream>
 #include <unordered_map>
@@ -571,6 +573,7 @@ bool WalletImpl::create(const std::string &path, const std::string &password, co
     crypto::secret_key recovery_val, secret_key;
     try {
         recovery_val = m_wallet->generate(path, password, secret_key, /* recover */ false, non_deterministic, create_address_file);
+        m_password = password;
         clearStatus();
     } catch (const std::exception &e) {
         LOG_ERROR("Error creating wallet: " << e.what());
@@ -661,7 +664,8 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
                                  const std::string &language,
                                  const std::string &address_string,
                                  const std::string &viewkey_string,
-                                 const std::string &spendkey_string)
+                                 const std::string &spendkey_string /* = "" */,
+                                 const bool create_address_file /* = false */)
 {
     cryptonote::address_parse_info info;
     if(!get_account_address_from_str(info, m_wallet->nettype(), address_string))
@@ -731,15 +735,15 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
     try
     {
         if (has_spendkey && has_viewkey) {
-            m_wallet->generate(path, password, info.address, spendkey, viewkey);
+            m_wallet->generate(path, password, info.address, spendkey, viewkey, create_address_file);
             LOG_PRINT_L1("Generated new wallet from spend key and view key");
         }
         if(!has_spendkey && has_viewkey) {
-            m_wallet->generate(path, password, info.address, viewkey);
+            m_wallet->generate(path, password, info.address, viewkey, create_address_file);
             LOG_PRINT_L1("Generated new view only wallet from keys");
         }
         if(has_spendkey && !has_viewkey) {
-           m_wallet->generate(path, password, spendkey, /* recover */ true, /* non-deterministic */ false);
+           m_wallet->generate(path, password, spendkey, /* recover */ true, /* non-deterministic */ false, create_address_file);
            setSeedLanguage(language);
            if (!statusOk())
                return false;
@@ -819,14 +823,14 @@ bool WalletImpl::recoverFromMultisigSeed(const std::string &path,
     return true;
 }
 
-bool WalletImpl::recoverFromDevice(const std::string &path, const std::string &password, const std::string &device_name)
+bool WalletImpl::recoverFromDevice(const std::string &path, const std::string &password, const std::string &device_name, const bool create_address_file /* = false */)
 {
     clearStatus();
     m_recoveringFromSeed = false;
     m_recoveringFromDevice = true;
     try
     {
-        m_wallet->restore(path, password, device_name);
+        m_wallet->restore(path, password, device_name, create_address_file);
         LOG_PRINT_L1("Generated new wallet from device: " + device_name);
     }
     catch (const std::exception& e) {
@@ -873,7 +877,7 @@ bool WalletImpl::recover(const std::string &path, const std::string &seed)
     return recover(path, "", seed);
 }
 
-bool WalletImpl::recover(const std::string &path, const std::string &password, const std::string &seed, const std::string &seed_offset/* = {}*/)
+bool WalletImpl::recover(const std::string &path, const std::string &password, const std::string &seed, const std::string &seed_offset/* = {}*/, const bool create_address_file /* false */)
 {
     clearStatus();
     m_errorString.clear();
@@ -903,7 +907,7 @@ bool WalletImpl::recover(const std::string &path, const std::string &password, c
         setSeedLanguage(old_language);
         if (!statusOk())
             return false;
-        m_wallet->generate(path, password, recovery_key, true, false);
+        m_wallet->generate(path, password, recovery_key, /*recover*/ true, /*non_deterministic*/ false, create_address_file);
         m_password = password;
 
     } catch (const std::exception &e) {
@@ -962,10 +966,12 @@ std::string WalletImpl::errorString() const
     return m_errorString;
 }
 
-void WalletImpl::statusWithErrorString(int& status, std::string& errorString) const {
+void WalletImpl::statusWithErrorString(int& status, std::string& errorString, int* extendedStatusOut /* = nullptr */) const {
     boost::lock_guard<boost::mutex> l(m_statusMutex);
     status = m_status;
     errorString = m_errorString;
+    if (extendedStatusOut)
+        *extendedStatusOut = m_extendedStatus;
 }
 
 bool WalletImpl::setPassword(const std::string &password)
@@ -1114,26 +1120,27 @@ void WalletImpl::setRecoveringFromDevice(bool recoveringFromDevice)
     m_recoveringFromDevice = recoveringFromDevice;
 }
 
-uint64_t WalletImpl::balance(uint32_t accountIndex) const
+uint64_t WalletImpl::balance(uint32_t accountIndex, bool is_strict /* = false */) const
 {
-    return m_wallet->balance(accountIndex, false);
+    return m_wallet->balance(accountIndex, is_strict);
 }
 
-std::map<uint32_t, uint64_t> WalletImpl::balancePerSubaddress(uint32_t accountIndex /* = 0 */) const
+std::map<uint32_t, uint64_t> WalletImpl::balancePerSubaddress(uint32_t accountIndex /* = 0 */, bool is_strict /* = false */) const
 {
-    return m_wallet->balance_per_subaddress(accountIndex, false);
+    return m_wallet->balance_per_subaddress(accountIndex, is_strict);
 }
 
 uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex /* = 0 */,
                                      uint64_t *blocks_to_unlock /* = NULL */,
-                                     uint64_t *time_to_unlock /* = NULL */) const
+                                     uint64_t *time_to_unlock /* = NULL */,
+                                     bool is_strict /* = false */) const
 {
-    return m_wallet->unlocked_balance(accountIndex, false, blocks_to_unlock, time_to_unlock);
+    return m_wallet->unlocked_balance(accountIndex, is_strict, blocks_to_unlock, time_to_unlock);
 }
 
-std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> WalletImpl::unlockedBalancePerSubaddress(uint32_t accountIndex /* = 0 */) const
+std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> WalletImpl::unlockedBalancePerSubaddress(uint32_t accountIndex /* = 0 */, bool is_strict /* = false */) const
 {
-    return m_wallet->unlocked_balance_per_subaddress(accountIndex, false);
+    return m_wallet->unlocked_balance_per_subaddress(accountIndex, is_strict);
 }
 
 uint64_t WalletImpl::blockChainHeight() const
@@ -1202,12 +1209,13 @@ bool WalletImpl::refresh(std::uint64_t start_height /* = 0 */,
                          bool check_pool /* = true */,
                          bool try_incremental /* = false */,
                          std::uint64_t max_blocks /* = std::numeric_limits<uint64_t>::max() */,
+                         bool skip_refresh_if_daemon_not_synced /* = true */,
                          std::uint64_t *blocks_fetched_out /* = nullptr */,
                          bool *received_money_out /* = nullptr */)
 {
     clearStatus();
     bool did_error_occur;
-    doRefresh(start_height, check_pool, try_incremental, max_blocks, &did_error_occur, blocks_fetched_out, received_money_out);
+    doRefresh(start_height, check_pool, try_incremental, max_blocks, skip_refresh_if_daemon_not_synced, &did_error_occur, blocks_fetched_out, received_money_out);
     return !did_error_occur;
 }
 
@@ -1370,6 +1378,35 @@ std::string WalletImpl::exportKeyImagesAsString(bool all /* = false */)
         return "";
     }
     return "";
+}
+
+void WalletImpl::exportKeyImages(bool all, std::uint64_t &offset_out, std::vector<std::pair<std::string, std::string>> &key_images_and_signatures_out)
+{
+    clearStatus();
+    if (watchOnly())
+    {
+        setStatusError(tr("Wallet is view only"));
+        return;
+    }
+    if (checkBackgroundSync("cannot export key images"))
+        return;
+
+    try
+    {
+        auto ski = m_wallet->export_key_images(all);
+        offset_out = ski.first;
+        key_images_and_signatures_out.resize(ski.second.size());
+        for (size_t i = 0; i < ski.second.size(); ++i)
+        {
+            key_images_and_signatures_out[i].first = epee::string_tools::pod_to_hex(ski.second[i].first);
+            key_images_and_signatures_out[i].second = epee::string_tools::pod_to_hex(ski.second[i].second);
+        }
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR("Error exporting key images: " << e.what());
+        setStatusError(e.what());
+    }
 }
 
 bool WalletImpl::importKeyImages(const std::string &filename, std::uint64_t *spent_out /* = nullptr */, std::uint64_t *unspent_out /* = nullptr */, std::uint64_t *import_height /* = nullptr */)
@@ -1600,13 +1637,27 @@ bool WalletImpl::startBackgroundSync()
     return true;
 }
 
-bool WalletImpl::stopBackgroundSync(const std::string &wallet_password)
+bool WalletImpl::stopBackgroundSync(const std::string &wallet_password, const std::string_view *spend_secret_key /* = nullptr */)
 {
     try
     {
         PRE_VALIDATE_BACKGROUND_SYNC();
         LOCK_REFRESH();
-        m_wallet->stop_background_sync(epee::wipeable_string(wallet_password));
+        crypto::secret_key spendkey = crypto::null_skey;
+        if (spend_secret_key) {
+            cryptonote::blobdata spendkey_data;
+            std::string tmp_spend_key = std::string(spend_secret_key->data(), spend_secret_key->size());
+            const epee::scope_guard ssk_scope_exit_handler([&](){
+                memwipe(&tmp_spend_key[0], tmp_spend_key.size());
+            });
+            if(!epee::string_tools::parse_hexstr_to_binbuff(tmp_spend_key, spendkey_data) || spendkey_data.size() != sizeof(crypto::secret_key))
+            {
+                setStatusError(tr("failed to parse secret spend key"));
+                return false;
+            }
+            spendkey = *reinterpret_cast<const crypto::secret_key*>(spendkey_data.data());
+        }
+        m_wallet->stop_background_sync(epee::wipeable_string(wallet_password), spendkey);
     }
     catch (const std::exception &e)
     {
@@ -1621,7 +1672,15 @@ void WalletImpl::addSubaddressAccount(const std::string& label)
 {
     if (checkBackgroundSync("cannot add account"))
         return;
-    m_wallet->add_subaddress_account(label);
+    try
+    {
+        m_wallet->add_subaddress_account(label);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR("Error adding subaddress account: " << e.what());
+        setStatusError(string(tr("Failed to add subaddress account: ")) + e.what());
+    }
 }
 size_t WalletImpl::numSubaddressAccounts() const
 {
@@ -1635,7 +1694,21 @@ void WalletImpl::addSubaddress(uint32_t accountIndex, const std::string& label)
 {
     if (checkBackgroundSync("cannot add subaddress"))
         return;
-    m_wallet->add_subaddress(accountIndex, label);
+    try
+    {
+        m_wallet->add_subaddress(accountIndex, label);
+    }
+    catch (const tools::error::account_index_outofbound &e)
+    {
+        LOG_ERROR("Error adding subaddress: " << e.what());
+        int extended_error = ExtendedStatus_AccountIndexOutOfBounds;
+        setStatusError(string(tr("Failed to add subaddress: ")) + e.what(), &extended_error);
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR("Error adding subaddress: " << e.what());
+        setStatusError(string(tr("Failed to add subaddress: ")) + e.what());
+    }
 }
 std::string WalletImpl::getSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex) const
 {
@@ -1963,9 +2036,11 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
                 transaction->m_signers = tx_set.m_signers;
             }
         } catch (const tools::error::daemon_busy&) {
-            setStatusError(tr("daemon is busy. Please try again later."));
+            int extended_error = ExtendedStatus_DaemonIsBusy;
+            setStatusError(tr("daemon is busy. Please try again later."), &extended_error);
         } catch (const tools::error::no_connection_to_daemon&) {
-            setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+            int extended_error = ExtendedStatus_NoDaemonConnection;
+            setStatusError(tr("no connection to daemon. Please make sure daemon is running."), &extended_error);
         } catch (const tools::error::wallet_rpc_error& e) {
             setStatusError(tr("RPC error: ") +  e.to_string());
         } catch (const tools::error::get_outs_error &e) {
@@ -1976,14 +2051,16 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
             writer << boost::format(tr("not enough money to transfer, available only %s, sent amount %s")) %
                       print_money(e.available()) %
                       print_money(e.tx_amount());
-            setStatusError(writer.str());
+            int extended_error = ExtendedStatus_NotEnoughUnlockedMoney;
+            setStatusError(writer.str(), &extended_error);
         } catch (const tools::error::not_enough_money& e) {
             std::ostringstream writer;
 
             writer << boost::format(tr("not enough money to transfer, overall balance only %s, sent amount %s")) %
                       print_money(e.available()) %
                       print_money(e.tx_amount());
-            setStatusError(writer.str());
+            int extended_error = ExtendedStatus_NotEnoughMoney;
+            setStatusError(writer.str(), &extended_error);
         } catch (const tools::error::tx_not_possible& e) {
             std::ostringstream writer;
 
@@ -1992,7 +2069,8 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
                       print_money(e.tx_amount() + e.fee())  %
                       print_money(e.tx_amount()) %
                       print_money(e.fee());
-            setStatusError(writer.str());
+            int extended_error = ExtendedStatus_TxNotPossible;
+            setStatusError(writer.str(), &extended_error);
         } catch (const tools::error::not_enough_outs_to_mix& e) {
             std::ostringstream writer;
             writer << tr("not enough outputs for specified ring size") << " = " << (e.mixin_count() + 1) << ":";
@@ -2000,7 +2078,8 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
                 writer << "\n" << tr("output amount") << " = " << print_money(outs_for_amount.first) << ", " << tr("found outputs to use") << " = " << outs_for_amount.second;
             }
             writer << "\n" << tr("Please sweep unmixable outputs.");
-            setStatusError(writer.str());
+            int extended_error = ExtendedStatus_NotEnoughOutsToMix;
+            setStatusError(writer.str(), &extended_error);
         } catch (const tools::error::tx_not_constructed&) {
             setStatusError(tr("transaction was not constructed"));
         } catch (const tools::error::tx_rejected& e) {
@@ -2010,9 +2089,11 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
         } catch (const tools::error::tx_sum_overflow& e) {
             setStatusError(e.what());
         } catch (const tools::error::zero_amount&) {
-            setStatusError(tr("destination amount is zero"));
+            int extended_error = ExtendedStatus_ZeroAmount;
+            setStatusError(tr("destination amount is zero"), &extended_error);
         } catch (const tools::error::zero_destination&) {
-            setStatusError(tr("transaction has no destination"));
+            int extended_error = ExtendedStatus_ZeroDestination;
+            setStatusError(tr("transaction has no destination"), &extended_error);
         } catch (const tools::error::tx_too_big& e) {
             setStatusError(tr("failed to find a suitable way to split transactions"));
         } catch (const tools::error::transfer_error& e) {
@@ -2059,9 +2140,11 @@ PendingTransaction *WalletImpl::createSweepUnmixableTransaction()
             pendingTxPostProcess(transaction);
 
         } catch (const tools::error::daemon_busy&) {
-            setStatusError(tr("daemon is busy. Please try again later."));
+            int extended_error = ExtendedStatus_DaemonIsBusy;
+            setStatusError(tr("daemon is busy. Please try again later."), &extended_error);
         } catch (const tools::error::no_connection_to_daemon&) {
-            setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+            int extended_error = ExtendedStatus_NoDaemonConnection;
+            setStatusError(tr("no connection to daemon. Please make sure daemon is running."), &extended_error);
         } catch (const tools::error::wallet_rpc_error& e) {
             setStatusError(tr("RPC error: ") +  e.to_string());
         } catch (const tools::error::get_outs_error&) {
@@ -2506,7 +2589,8 @@ bool WalletImpl::verifySignedMessage(const std::string &message,
                                      const std::string &address,
                                      const std::string &signature,
                                      bool *is_old_out /* = nullptr */,
-                                     std::string *signature_type_out /* = nullptr */) const
+                                     std::string *signature_type_out /* = nullptr */,
+                                     unsigned *version_out /* = nullptr */) const
 {
   cryptonote::address_parse_info info;
 
@@ -2517,8 +2601,10 @@ bool WalletImpl::verifySignedMessage(const std::string &message,
       *is_old_out = result.old;
   if (signature_type_out)
       *signature_type_out = (result.type == tools::wallet2::sign_with_spend_key
-                        ? "spend key" : result.type == tools::wallet2::sign_with_view_key
-                        ? "view key" : "unknown key combination (suspicious)");
+                        ? "spend" : result.type == tools::wallet2::sign_with_view_key
+                        ? "view" : "invalid");
+  if (version_out)
+      *version_out = result.version;
   return result.valid;
 }
 
@@ -2639,11 +2725,12 @@ void WalletImpl::clearStatus() const
     boost::lock_guard<boost::mutex> l(m_statusMutex);
     m_status = Status_Ok;
     m_errorString.clear();
+    m_extendedStatus = ExtendedStatus_Ok;
 }
 
-void WalletImpl::setStatusError(const std::string& message) const
+void WalletImpl::setStatusError(const std::string& message, const int* extended_status /* = nullptr */) const
 {
-    setStatus(Status_Error, message);
+    setStatus(Status_Error, message, extended_status);
 }
 
 void WalletImpl::setStatusCritical(const std::string& message) const
@@ -2651,11 +2738,13 @@ void WalletImpl::setStatusCritical(const std::string& message) const
     setStatus(Status_Critical, message);
 }
 
-void WalletImpl::setStatus(int status, const std::string& message) const
+void WalletImpl::setStatus(int status, const std::string& message, const int* extended_status /* = nullptr */) const
 {
     boost::lock_guard<boost::mutex> l(m_statusMutex);
     m_status = status;
     m_errorString = message;
+    m_extendedStatus = (extended_status ? *extended_status : status == Status_Ok ? ExtendedStatus_Ok : ExtendedStatus_Unknown_Error);
+
 }
 
 void WalletImpl::refreshThreadFunc()
@@ -2693,6 +2782,7 @@ void WalletImpl::doRefresh(std::uint64_t start_height /* = 0 */,
                            bool check_pool /* = true */,
                            bool try_incremental /* = false */,
                            std::uint64_t max_blocks /* = std::numeric_limits<uint64_t>::max() */,
+                           bool skip_refresh_if_daemon_not_synced /* = true */,
                            bool *error_out /* = nullptr */,
                            std::uint64_t *blocks_fetched_out /* = nullptr */,
                            bool *received_money_out /* = nullptr */)
@@ -2706,7 +2796,7 @@ void WalletImpl::doRefresh(std::uint64_t start_height /* = 0 */,
         LOG_PRINT_L3(__FUNCTION__ << ": doRefresh, rescan = "<<rescan);
         // Syncing daemon and refreshing wallet simultaneously is very resource intensive.
         // Disable refresh if wallet is disconnected or daemon isn't synced.
-        if (daemonSynced()) {
+        if (!skip_refresh_if_daemon_not_synced || daemonSynced()) {
             if(rescan)
                 m_wallet->rescan_blockchain(m_do_hard_rescan, /* refresh */ false, m_do_keep_key_images_on_rescan);
             std::uint64_t blocks_fetched_ignored;
@@ -2729,10 +2819,12 @@ void WalletImpl::doRefresh(std::uint64_t start_height /* = 0 */,
            LOG_PRINT_L3(__FUNCTION__ << ": skipping refresh - daemon is not synced");
         }
     } catch (const tools::error::daemon_busy&) {
-        setStatusError(tr("daemon is busy. Please try again later."));
+        int extended_error = ExtendedStatus_DaemonIsBusy;
+        setStatusError(tr("daemon is busy. Please try again later."), &extended_error);
         break;
     } catch (const tools::error::no_connection_to_daemon&) {
-        setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        int extended_error = ExtendedStatus_NoDaemonConnection;
+        setStatusError(tr("no connection to daemon. Please make sure daemon is running."), &extended_error);
         break;
     } catch (const tools::error::deprecated_rpc_access&) {
         setStatusError(tr("Daemon requires deprecated RPC payment. See https://github.com/monero-project/monero/issues/8722"));
@@ -2836,9 +2928,16 @@ bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_a
 
     // in case new wallet, this will force fast-refresh (pulling hashes instead of blocks)
     // If daemon isn't synced a calculated block height will be used instead
+    // TODO : We need to do something about setting the restore height here.
+    //        Currently I witnessed two issues with this:
+    //          1. When setting a restore height on wallet creation under certain conditions this can overwrite the set restore height to a higher height which leads to missing enotes when scanning. (Discovered during debugging failing functional_test multisig.py for the wallet-rpc based on the Wallet API. The tests pass with setRefreshFromBlockHeight() below commented out.)
+    //          2. Similar, when creating a wallet offline, let's say you open it for example 3 months later, the code-block below will cause the restore height to be set to the current blockchain height at that time. So there would be 3 months worth of blocks where you could have received enotes which do not get scanned.
+    // PROPOSAL : Remove this entire block and rely on the restore height
+    //          1. provided when restoring a wallet with `recoveryWallet()`, `createWalletFromKeys()`, `createWalletFromMultisigSeed()`, `createWalletFromDevice()` (all these get the restore height by argument) and `createWalletFromJson()` (gets restore height from .json file)
+    //          2. estimated when creating a wallet with `createWallet()` (calls `wallet2::generate()` which uses `wallet2::estimate_blockchain_height()` to set the initial restore height ([src](https://github.com/monero-project/monero/blob/abe4eb60ea62f357bd71efc9037dbbc021cd6271/src/wallet/wallet2.cpp#L5732))) and let Wallet API users decide under which conditions they want to `setRrefreshFromBlockHeight()`
     if (isNewWallet() && daemonSynced()) {
         LOG_PRINT_L2(__FUNCTION__ << ":New Wallet - fast refresh until " << daemonBlockChainHeight());
-        setRefreshFromBlockHeight(daemonBlockChainHeight());
+//        setRefreshFromBlockHeight(daemonBlockChainHeight());
     }
 
     if (m_rebuildWalletCache)
@@ -2901,12 +3000,14 @@ bool WalletImpl::rescanSpent()
     }
     catch (const tools::error::daemon_busy&)
     {
-        setStatusError(tr("daemon is busy. Please try again later."));
+        int extended_error = ExtendedStatus_DaemonIsBusy;
+        setStatusError(tr("daemon is busy. Please try again later."), &extended_error);
         return false;
     }
     catch (const tools::error::no_connection_to_daemon&)
     {
-        setStatusError(tr("no connection to daemon. Please make sure daemon is running."));
+        int extended_error = ExtendedStatus_NoDaemonConnection;
+        setStatusError(tr("no connection to daemon. Please make sure daemon is running."), &extended_error);
         return false;
     }
     catch (const tools::error::deprecated_rpc_access&)
@@ -3288,6 +3389,7 @@ Wallet::WalletState WalletImpl::getWalletState() const
     wallet_state.is_deprecated  = m_wallet->is_deprecated();
     wallet_state.is_unattended  = m_wallet->is_unattended();
     wallet_state.daemon_address = m_wallet->get_daemon_address();
+    wallet_state.has_proxy_flag = m_wallet->has_proxy_option();
     wallet_state.ring_database  = m_wallet->get_ring_database();
     wallet_state.n_enotes       = m_wallet->get_num_transfer_details();
 
@@ -3350,6 +3452,12 @@ void WalletImpl::refreshPoolOnly(bool refreshed /*false*/, bool try_incremental 
     try
     {
         m_wallet->update_pool_state(process_txs_pod, refreshed, try_incremental);
+    }
+    catch (const tools::error::daemon_busy&)
+    {
+        int extended_error = ExtendedStatus_DaemonIsBusy;
+        setStatusError(string(tr("Failed to update pool state: daemon is busy")), &extended_error);
+        return;
     }
     catch (const std::exception &e)
     {
@@ -3561,6 +3669,26 @@ PendingTransaction* WalletImpl::parseMultisigTxFromStr(const std::string &multis
     }
 
     return ptx.release();
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::unique_ptr<PendingTransaction> WalletImpl::deserializePtxFromBlobStr(const std::string &tx_blob)
+{
+    clearStatus();
+
+    std::unique_ptr<PendingTransactionImpl> ptx(new PendingTransactionImpl(*this));
+    try
+    {
+      ptx->m_pending_tx.push_back({});
+      binary_archive<false> ar{epee::strspan<std::uint8_t>(tx_blob)};
+      if (!::serialization::serialize(ar, ptx->m_pending_tx[0]))
+          throw runtime_error("Failed to parse tx metadata");
+        m_status = Status_Error;
+    }
+    catch(const exception &e) {
+        setStatusError(e.what());
+        return nullptr;
+    }
+    return ptx;
 }
 //-------------------------------------------------------------------------------------------------------------------
 std::uint64_t WalletImpl::getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const
@@ -3882,7 +4010,6 @@ std::uint64_t WalletImpl::importKeyImages(const std::vector<std::pair<std::strin
     std::vector<std::pair<crypto::key_image, crypto::signature>> signed_key_images_pod;
     crypto::key_image tmp_key_image_pod;
     crypto::signature tmp_signature_pod{};
-    size_t sig_size = sizeof(crypto::signature);
 
     signed_key_images_pod.reserve(signed_key_images.size());
 
@@ -3893,14 +4020,9 @@ std::uint64_t WalletImpl::importKeyImages(const std::vector<std::pair<std::strin
             setStatusError(string(tr("Failed to parse key image: ")) + ski.first);
             return false;
         }
-        if (!epee::string_tools::hex_to_pod(ski.second.substr(0, sig_size/2), tmp_signature_pod.c))
+        if (!epee::string_tools::hex_to_pod(ski.second, tmp_signature_pod))
         {
-            setStatusError(string(tr("Failed to parse signature.c: ")) + ski.second.substr(0, sig_size/2));
-            return false;
-        }
-        if (!epee::string_tools::hex_to_pod(ski.second.substr(sig_size/2, sig_size), tmp_signature_pod.r))
-        {
-            setStatusError(string(tr("Failed to parse signature.r: ")) + ski.second.substr(sig_size/2, sig_size));
+            setStatusError(string(tr("Failed to parse signature: ")) + ski.second);
             return false;
         }
         signed_key_images_pod.push_back(std::make_pair(tmp_key_image_pod, tmp_signature_pod));
@@ -4117,6 +4239,11 @@ void WalletImpl::setExplicitRefreshFromBlockHeight(bool do_explicit_refresh)
     m_wallet->explicit_refresh_from_block_height(do_explicit_refresh);
 }
 //-------------------------------------------------------------------------------------------------------------------
+void WalletImpl::setTxNotify(const std::string &tx_notify)
+{
+    m_wallet->set_tx_notify(std::shared_ptr<tools::Notify>(new tools::Notify(tx_notify.c_str())));
+}
+//-------------------------------------------------------------------------------------------------------------------
 // Wallet Settings getter/setter
 //-------------------------------------------------------------------------------------------------------------------
 std::string WalletImpl::getSeedLanguage() const
@@ -4129,7 +4256,7 @@ void WalletImpl::setSeedLanguage(const std::string &arg)
     if (checkBackgroundSync("cannot set seed language"))
         return;
 
-    if (crypto::ElectrumWords::is_valid_language(arg))
+    if (arg.empty() || crypto::ElectrumWords::is_valid_language(arg))
         m_wallet->set_seed_language(arg);
     else
         setStatusError(string(tr("Failed to set seed language. Language not valid: ")) + arg);
@@ -4324,7 +4451,13 @@ std::pair<std::uint32_t, std::uint32_t> WalletImpl::getSubaddressLookahead() con
 //-------------------------------------------------------------------------------------------------------------------
 void WalletImpl::setSubaddressLookahead(uint32_t major, uint32_t minor)
 {
-    m_wallet->set_subaddress_lookahead(major, minor);
+    clearStatus();
+    try {
+        m_wallet->set_subaddress_lookahead(major, minor);
+    }
+    catch (const std::exception &e) {
+        setStatusError((boost::format(tr("failed to set subaddresss lookahead: %s")) % e.what()).str());
+    }
 }
 //-------------------------------------------------------------------------------------------------------------------
 std::uint64_t WalletImpl::getSegregationHeight() const
@@ -4494,6 +4627,192 @@ bool WalletImpl::statusOk() const
 {
     boost::lock_guard<boost::mutex> l(m_statusMutex);
     return m_status == Status_Ok;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::unique_ptr<TransactionDescription> WalletImpl::getTxDescription(const std::vector<tools::wallet2::tx_construction_data> &cds, int &error_code_out, std::string &error_msg_out) const
+{
+    error_code_out = Status_Ok;
+    error_msg_out = "";
+
+    std::unique_ptr<TransactionDescription> tx_desc{new TransactionDescription{}};
+    TxSummary &tx_sum = tx_desc->tx_summary;
+    // init summary
+    tx_sum = TxSummary{
+        /* amount_in */ 0,
+        /* amount_out */ 0,
+        /* recipients */ {},
+        /* change_amount */ 0,
+        /* change_address */ "",
+        /* fee */ 0
+    };
+
+    try
+    {
+        std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> tx_dests;
+        std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> all_dests;
+        int first_known_non_zero_change_index = -1;
+
+        // construction data per tx
+        for (size_t n = 0; n < cds.size(); ++n)
+        {
+            const tools::wallet2::tx_construction_data &cd = cds[n];
+            // init construction data entry
+            tx_desc->tx_descriptions.push_back({
+                /* amount_in */ 0,
+                /* amount_out */ 0,
+                /* ring_size */ numeric_limits<std::uint32_t>::max(),
+                /* unlock_time */ 0,
+                /* sources */ {},
+                /* recipients */ {},
+                /* payment_id */ "",
+                /* change_amount */ 0,
+                /* change_address */ "",
+                /* fee */ 0,
+                /* dummy_outputs */ 0,
+                /* extra */ ""}
+            );
+            TxDescriptionSingle &desc = tx_desc->tx_descriptions.back();
+
+            // Clear the recipients collection ready for this loop iteration
+            tx_dests.clear();
+
+            // get payment id from tx extra
+            std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+            bool has_encrypted_payment_id = false;
+            crypto::hash8 payment_id8 = crypto::null_hash8;
+            if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
+            {
+                cryptonote::tx_extra_nonce extra_nonce;
+                if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+                {
+                    crypto::hash payment_id;
+                    if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
+                    {
+                        if (payment_id8 != crypto::null_hash8)
+                        {
+                            desc.payment_id = epee::string_tools::pod_to_hex(payment_id8);
+                            has_encrypted_payment_id = true;
+                        }
+                    }
+                    else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
+                    {
+                        desc.payment_id = epee::string_tools::pod_to_hex(payment_id);
+                    }
+                }
+            }
+
+            // fill sources
+            for (size_t s = 0; s < cd.sources.size(); ++s)
+            {
+                const cryptonote::tx_source_entry &src_in = cd.sources[s];
+                TxSource &src_out = desc.sources.emplace_back();
+                src_out.amount = src_in.amount;
+                src_out.global_index = src_in.outputs.at(src_in.real_output_in_tx_index).first;
+                src_out.rct = src_in.rct;
+                src_out.pubkey = epee::string_tools::pod_to_hex(src_in.outputs.at(src_in.real_output_in_tx_index).second);
+                desc.amount_in += src_in.amount;
+                size_t ring_size = src_in.outputs.size();
+                if (ring_size < desc.ring_size)
+                    desc.ring_size = ring_size;
+            }
+
+            // fill destinations
+            for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
+            {
+                const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
+                std::string address = cryptonote::get_account_address_as_str(static_cast<cryptonote::network_type>(nettype()), entry.is_subaddress, entry.addr);
+                if (has_encrypted_payment_id && !entry.is_subaddress && address != entry.original)
+                    address = cryptonote::get_account_integrated_address_as_str(static_cast<cryptonote::network_type>(nettype()), entry.addr, payment_id8);
+                auto i = tx_dests.find(entry.addr);
+                if (i == tx_dests.end())
+                    tx_dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
+                else
+                    i->second.second += entry.amount;
+                desc.amount_out += entry.amount;
+            }
+
+            // handle change amount
+            if (cd.change_dts.amount > 0)
+            {
+                auto it = tx_dests.find(cd.change_dts.addr);
+                if (it == tx_dests.end())
+                {
+                    error_code_out = Status_Error;
+                    error_msg_out = "Claimed change does not go to a paid address";
+                    return nullptr;
+                }
+                if (it->second.second < cd.change_dts.amount)
+                {
+                    error_code_out = Status_Error;
+                    error_msg_out = "Claimed change is larger than payment to the change address";
+                    return nullptr;
+                }
+                if (cd.change_dts.amount > 0)
+                {
+                    if (first_known_non_zero_change_index == -1)
+                        first_known_non_zero_change_index = n;
+                    const tools::wallet2::tx_construction_data &cdn = cds[first_known_non_zero_change_index];
+                    if (memcmp(&cd.change_dts.addr, &cdn.change_dts.addr, sizeof(cd.change_dts.addr)))
+                    {
+                        error_code_out = Status_Error;
+                        error_msg_out = "Change goes to more than one address";
+                        return nullptr;
+                    }
+                }
+                desc.change_amount += cd.change_dts.amount;
+                it->second.second -= cd.change_dts.amount;
+                if (it->second.second == 0)
+                    tx_dests.erase(cd.change_dts.addr);
+            }
+
+            // separate dummy outputs from real outputs
+            for (auto i = tx_dests.begin(); i != tx_dests.end(); ++i)
+            {
+                if (i->second.second > 0)
+                {
+                    desc.recipients.push_back({i->second.first, i->second.second});
+                    auto it_in_all = all_dests.find(i->first);
+                    if (it_in_all == all_dests.end())
+                        all_dests.insert(std::make_pair(i->first, i->second));
+                    else
+                        it_in_all->second.second += i->second.second;
+                }
+                else
+                    ++desc.dummy_outputs;
+            }
+
+            // set change address
+            if (desc.change_amount > 0)
+            {
+                const tools::wallet2::tx_construction_data &cd0 = cds[0];
+                desc.change_address = get_account_address_as_str(static_cast<cryptonote::network_type>(nettype()), cd0.subaddr_account > 0, cd0.change_dts.addr);
+                tx_sum.change_address = desc.change_address;
+            }
+
+            desc.fee = desc.amount_in - desc.amount_out;
+            desc.unlock_time = cd.unlock_time;
+            desc.extra = epee::to_hex::string({cd.extra.data(), cd.extra.size()});
+
+            // Update summary items
+            tx_sum.amount_in += desc.amount_in;
+            tx_sum.amount_out += desc.amount_out;
+            tx_sum.change_amount += desc.change_amount;
+            tx_sum.fee += desc.fee;
+        }
+
+        // Populate the summary recipients list
+        for (auto i = all_dests.begin(); i != all_dests.end(); ++i)
+        {
+            tx_sum.recipients.push_back({i->second.first, i->second.second});
+        }
+    }
+    catch (const std::exception &e)
+    {
+        error_code_out = Status_Error;
+        error_msg_out = "failed to describe transfer";
+        return nullptr;
+    }
+    return tx_desc;
 }
 //-------------------------------------------------------------------------------------------------------------------
 

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -2740,7 +2740,6 @@ void WalletImpl::setStatus(int status, const std::string& message, const int* ex
     m_status = status;
     m_errorString = message;
     m_extendedStatus = (extended_status ? *extended_status : status == Status_Ok ? ExtendedStatus_Ok : ExtendedStatus_Unknown_Error);
-
 }
 
 void WalletImpl::refreshThreadFunc()

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -62,13 +62,14 @@ public:
                             const std::string &language) const override;
     bool open(const std::string &path, const std::string &password);
     bool recover(const std::string &path,const std::string &password,
-                            const std::string &seed, const std::string &seed_offset = {});
+                            const std::string &seed, const std::string &seed_offset = {}, const bool create_address_file = false);
     bool recoverFromKeysWithPassword(const std::string &path,
                             const std::string &password,
                             const std::string &language,
                             const std::string &address_string,
                             const std::string &viewkey_string,
-                            const std::string &spendkey_string = "");
+                            const std::string &spendkey_string = "",
+                            const bool create_address_file = false);
     // following two methods are deprecated since they create passwordless wallets
     // use the two equivalent methods above
     bool recover(const std::string &path, const std::string &seed);
@@ -87,13 +88,14 @@ public:
                                  const bool do_create_address_file = false);
     bool recoverFromDevice(const std::string &path,
                            const std::string &password,
-                           const std::string &device_name);
+                           const std::string &device_name,
+                           const bool create_address_file = false);
     Device getDeviceType() const override;
     bool close(bool store = true);
     std::string seed(const std::string& seed_offset = "") const override;
     int status() const override;
     std::string errorString() const override;
-    void statusWithErrorString(int& status, std::string& errorString) const override;
+    void statusWithErrorString(int& status, std::string& errorString, int* extendedStatusOut = nullptr) const override;
     bool setPassword(const std::string &password) override;
     const std::string& getPassword() const override;
     bool setDevicePin(const std::string &password) override;
@@ -117,10 +119,10 @@ public:
     void setTrustedDaemon(bool arg) override;
     bool trustedDaemon() const override;
     bool setProxy(const std::string &address) override;
-    uint64_t balance(uint32_t accountIndex = 0) const override;
-    std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0) const override;
-    uint64_t unlockedBalance(uint32_t accountIndex = 0, std::uint64_t *blocks_to_unlock = NULL, std::uint64_t *time_to_unlock = NULL) const override;
-    std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0) const override;
+    uint64_t balance(uint32_t accountIndex = 0, bool is_strict = false) const override;
+    std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0, bool is_strict = false) const override;
+    uint64_t unlockedBalance(uint32_t accountIndex = 0, std::uint64_t *blocks_to_unlock = NULL, std::uint64_t *time_to_unlock = NULL, bool is_strict = false) const override;
+    std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0, bool is_strict = false) const override;
     uint64_t blockChainHeight() const override;
     uint64_t approximateBlockChainHeight() const override;
     uint64_t estimateBlockChainHeight() const override;
@@ -128,7 +130,7 @@ public:
     uint64_t daemonBlockChainTargetHeight() const override;
     bool daemonSynced() const override;
     bool synchronized() const override;
-    bool refresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr) override;
+    bool refresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), bool skip_refresh_if_daemon_not_synced = true, std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr) override;
     void refreshAsync() override;
     bool rescanBlockchain(bool do_hard_rescan = true, bool do_keep_key_images = false, bool do_skip_refresh = false) override;
     void rescanBlockchainAsync(bool do_hard_rescan = true, bool do_keep_key_images = false) override;
@@ -180,6 +182,7 @@ public:
     UnsignedTransaction * loadUnsignedTxFromStr(const std::string &unsigned_tx_str) override;
     bool exportKeyImages(const std::string &filename, bool all = false) override;
     std::string exportKeyImagesAsString(bool all = false) override;
+    void exportKeyImages(bool all, std::uint64_t &offset_out, std::vector<std::pair<std::string, std::string>> &key_images_and_signatures_out) override;
     bool importKeyImages(const std::string &filename, std::uint64_t *spent_out = nullptr, std::uint64_t *unspent_out = nullptr, std::uint64_t *import_height = nullptr) override;
     bool importKeyImagesFromStr(const std::string &data) override;
     bool exportOutputs(const std::string &filename, bool all = false) override;
@@ -189,7 +192,7 @@ public:
     bool setupBackgroundSync(const BackgroundSyncType background_sync_type, const std::string &wallet_password, const optional<std::string> &background_cache_password = optional<std::string>()) override;
     BackgroundSyncType getBackgroundSyncType() const override;
     bool startBackgroundSync() override;
-    bool stopBackgroundSync(const std::string &wallet_password) override;
+    bool stopBackgroundSync(const std::string &wallet_password, const std::string_view *spend_secret_key = nullptr) override;
     bool isBackgroundSyncing() const override;
     bool isBackgroundWallet() const override;
 
@@ -221,7 +224,7 @@ public:
     virtual std::string getReserveProof(bool all, uint32_t account_index, uint64_t amount, const std::string &message) const override;
     virtual bool checkReserveProof(const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &total, uint64_t &spent) const override;
     virtual std::string signMessage(const std::string &message, const std::string &address, bool sign_with_view_key = false) override;
-    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr) const override;
+    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr, unsigned *version_out = nullptr) const override;
     virtual std::string signMultisigParticipant(const std::string &message) const override;
     virtual bool verifyMessageWithPublicKey(const std::string &message, const std::string &publicKey, const std::string &signature) const override;
     virtual void startRefresh() override;
@@ -265,6 +268,7 @@ public:
     bool saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const override;
     PendingTransaction* parseTxFromStr(const std::string &signed_tx_str) override;
     PendingTransaction* parseMultisigTxFromStr(const std::string &multisig_tx_str) override;
+    std::unique_ptr<PendingTransaction> deserializePtxFromBlobStr(const std::string &tx_blob) override;
     std::uint64_t getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const override;
     std::uint64_t getBaseFee() const override;
     std::uint32_t adjustPriority(std::uint32_t priority) override;
@@ -303,6 +307,8 @@ public:
 
     bool getExplicitRefreshFromBlockHeight() const override;
     void setExplicitRefreshFromBlockHeight(bool do_explicit_refresh) override;
+
+    void setTxNotify(const std::string &tx_notify) override;
 
     // Wallet Settings getter/setter
     std::string getSeedLanguage() const override;
@@ -370,11 +376,11 @@ public:
 
 private:
     void clearStatus() const;
-    void setStatusError(const std::string& message) const;
+    void setStatusError(const std::string& messagee, const int* extended_status = nullptr) const;
     void setStatusCritical(const std::string& message) const;
-    void setStatus(int status, const std::string& message) const;
+    void setStatus(int status, const std::string& message, const int* extended_status = nullptr) const;
     void refreshThreadFunc();
-    void doRefresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), bool *error_out = nullptr, std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr);
+    void doRefresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), bool skip_refresh_if_daemon_not_synced = true, bool *error_out = nullptr, std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr);
     void stopRefresh();
     bool isNewWallet() const;
     void pendingTxPostProcess(PendingTransactionImpl * pending);
@@ -400,6 +406,14 @@ private:
     * return: true if status is ok, else false
     */
     bool statusOk() const;
+    /**
+    * brief: getTxDescription - helper for [Pending/Unsigned]Transaction::getTransactionDescription()
+    * param: cds - all the tx construction data
+    * param: error_code_out - [Pending/Unsigned]Transaction::m_status
+    * param: error_msg_out - [Pending/Unsigned]Transaction::m_errorString
+    * return: TransactionDescription on success, else nullptr
+    */
+    std::unique_ptr<TransactionDescription> getTxDescription(const std::vector<tools::wallet2::tx_construction_data> &cds, int &error_code_out, std::string &error_msg_out) const;
 
 private:
     friend class PendingTransactionImpl;
@@ -415,6 +429,7 @@ private:
     mutable boost::mutex m_statusMutex;
     mutable int m_status;
     mutable std::string m_errorString;
+    mutable int m_extendedStatus;
     // TODO: harden password handling in the wallet API, see relevant discussion
     // https://github.com/monero-project/monero-gui/issues/1537
     // https://github.com/feather-wallet/feather/issues/72#issuecomment-1405602142

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -42,6 +42,7 @@
 class WalletApiAccessorTest;
 
 namespace Monero {
+class EnoteDetailsImpl;
 class TransactionHistoryImpl;
 class PendingTransactionImpl;
 class UnsignedTransactionImpl;
@@ -169,8 +170,11 @@ public:
     virtual PendingTransaction * createSweepUnmixableTransaction() override;
     bool submitTransaction(const std::string &fileName) override;
     virtual UnsignedTransaction * loadUnsignedTx(const std::string &unsigned_filename) override;
+    UnsignedTransaction * loadUnsignedTxFromStr(const std::string &unsigned_tx_str) override;
     bool exportKeyImages(const std::string &filename, bool all = false) override;
+    std::string exportKeyImagesAsString(bool all = false) override;
     bool importKeyImages(const std::string &filename) override;
+    bool importKeyImagesFromStr(const std::string &data) override;
     bool exportOutputs(const std::string &filename, bool all = false) override;
     bool importOutputs(const std::string &filename) override;
     bool scanTransactions(const std::vector<std::string> &txids) override;
@@ -209,7 +213,7 @@ public:
     virtual bool checkSpendProof(const std::string &txid, const std::string &message, const std::string &signature, bool &good) const override;
     virtual std::string getReserveProof(bool all, uint32_t account_index, uint64_t amount, const std::string &message) const override;
     virtual bool checkReserveProof(const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &total, uint64_t &spent) const override;
-    virtual std::string signMessage(const std::string &message, const std::string &address) override;
+    virtual std::string signMessage(const std::string &message, const std::string &address, bool sign_with_view_key = false) override;
     virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const override;
     virtual std::string signMultisigParticipant(const std::string &message) const override;
     virtual bool verifyMessageWithPublicKey(const std::string &message, const std::string &publicKey, const std::string &signature) const override;
@@ -233,6 +237,51 @@ public:
     virtual uint64_t getBytesReceived() override;
     virtual uint64_t getBytesSent() override;
 
+    std::string getMultisigSeed(const std::string &seed_offset) const override;
+    std::pair<std::uint32_t, std::uint32_t> getSubaddressIndex(const std::string &address) const override;
+    void freeze(const std::string &key_image) override;
+    void freezeByPubKey(const std::string &public_key) override;
+    void thaw(const std::string &key_image) override;
+    void thawByPubKey(const std::string &public_key) override;
+    bool isFrozen(const std::string &key_image) const override;
+    bool isFrozenByPubKey(const std::string &public_key) override;
+    void createOneOffSubaddress(std::uint32_t account_index, std::uint32_t address_index) override;
+    WalletState getWalletState() const override;
+    void rewriteWalletFile(const std::string &wallet_name, const std::string &password) override;
+    void writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name) override;
+    void refreshPoolOnly(bool refreshed = false, bool try_incremental = false) override;
+    void getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const override;
+    std::string convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const override;
+    bool saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const override;
+    bool parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const override;
+    void insertColdKeyImages(PendingTransaction &ptx) override;
+    bool parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const override;
+    std::uint64_t getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const override;
+    std::uint64_t getBaseFee() const override;
+    std::uint32_t adjustPriority(std::uint32_t priority) override;
+    void coldTxAuxImport(const PendingTransaction &ptx, const std::vector<std::string> &tx_device_aux) const override;
+    void coldSignTx(const PendingTransaction &ptx_in, PendingTransaction &exported_txs_out) const override;
+    void discardUnmixableEnotes() override;
+    void setTxKey(const std::string &txid, const std::string &tx_key, const std::vector<std::string> &additional_tx_keys, const std::string &single_destination_subaddress) override;
+    const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& getAccountTags() const override;
+    void setAccountTag(const std::set<uint32_t> &account_indices, const std::string &tag) override;
+    void setAccountTagDescription(const std::string &tag, const std::string &description) override;
+    std::string exportEnotesToStr(bool all = false, std::uint32_t start = 0, std::uint32_t count = 0xffffffff) const override;
+    std::size_t importEnotesFromStr(const std::string &enotes_str) override;
+    std::uint64_t getBlockchainHeightByDate(std::uint16_t year, std::uint8_t month, std::uint8_t day) const override;
+    std::vector<std::pair<std::uint64_t, std::uint64_t>> estimateBacklog(const std::vector<std::pair<double, double>> &fee_levels) const override;
+    bool saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable = false) const override;
+    bool loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size = 1000000000) const override;
+    std::uint64_t hashEnotes(std::uint64_t enote_idx, std::string &hash) const override;
+    void finishRescanBcKeepKeyImages(std::uint64_t enote_idx, const std::string &hash) override;
+    std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> getPublicNodes(bool white_only = true) const override;
+    std::pair<std::size_t, std::uint64_t> estimateTxSizeAndWeight(bool use_rct, int n_inputs, int ring_size, int n_outputs, std::size_t extra_size) const override;
+    std::uint64_t importKeyImages(const std::vector<std::pair<std::string, std::string>> &signed_key_images, std::size_t offset, std::uint64_t &spent, std::uint64_t &unspent, bool check_spent = true) override;
+    bool importKeyImages(const std::vector<std::string> &key_images, std::size_t offset = 0, const std::unordered_set<std::size_t> &selected_enotes_indices = {}) override;
+    bool getAllowMismatchedDaemonVersion() const override;
+    void setAllowMismatchedDaemonVersion(bool allow_mismatch) override;
+    bool setDaemon(const std::string &daemon_address, const std::string &daemon_username = "", const std::string &daemon_password = "", bool trusted_daemon = false, const std::string &ssl_support = "autodetect", const std::string &ssl_private_key_path = "", const std::string &ssl_certificate_path = "", const std::string &ssl_ca_file_path = "", const std::vector<std::string> &ssl_allowed_fingerprints_str = {}, bool ssl_allow_any_cert = false, const std::string &proxy = "") override;
+
 private:
     void clearStatus() const;
     void setStatusError(const std::string& message) const;
@@ -246,6 +295,18 @@ private:
     void pendingTxPostProcess(PendingTransactionImpl * pending);
     bool doInit(const std::string &daemon_address, const std::string &proxy_address, uint64_t upper_transaction_size_limit = 0, bool ssl = false);
     bool checkBackgroundSync(const std::string &message) const;
+
+    /**
+    * brief: getEnoteIndex - get the index of an enote in local enote storage
+    * param: key_image - key image to identify the enote
+    * return: enote index
+    */
+    std::size_t getEnoteIndex(const std::string &key_image) const;
+    /**
+    * brief: statusOk -
+    * return: true if status is ok, else false
+    */
+    bool statusOk() const;
 
 private:
     friend class PendingTransactionImpl;

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -54,10 +54,10 @@ struct Wallet2CallbackImpl;
 class WalletImpl : public Wallet
 {
 public:
-    WalletImpl(NetworkType nettype = MAINNET, uint64_t kdf_rounds = 1);
+    WalletImpl(NetworkType nettype = MAINNET, uint64_t kdf_rounds = 1, const bool unattended = true);
     ~WalletImpl();
     bool create(const std::string &path, const std::string &password,
-                const std::string &language);
+                const std::string &language, bool create_address_file = false, bool non_deterministic = false);
     bool createWatchOnly(const std::string &path, const std::string &password,
                             const std::string &language) const override;
     bool open(const std::string &path, const std::string &password);
@@ -78,15 +78,19 @@ public:
                             const std::string &address_string, 
                             const std::string &viewkey_string,
                             const std::string &spendkey_string = "");
+    bool createFromJson(const std::string &json_file_path, std::string &pw_out);
+    bool recoverFromMultisigSeed(const std::string &path,
+                                 const std::string &password,
+                                 const std::string &language,
+                                 const std::string &multisig_seed,
+                                 const std::string seed_pass = "",
+                                 const bool do_create_address_file = false);
     bool recoverFromDevice(const std::string &path,
                            const std::string &password,
                            const std::string &device_name);
     Device getDeviceType() const override;
     bool close(bool store = true);
     std::string seed(const std::string& seed_offset = "") const override;
-    std::string getSeedLanguage() const override;
-    void setSeedLanguage(const std::string &arg) override;
-    // void setListener(Listener *) {}
     int status() const override;
     std::string errorString() const override;
     void statusWithErrorString(int& status, std::string& errorString) const override;
@@ -107,36 +111,35 @@ public:
     std::string filename() const override;
     std::string keysFilename() const override;
     bool init(const std::string &daemon_address, uint64_t upper_transaction_size_limit = 0, const std::string &daemon_username = "", const std::string &daemon_password = "", bool use_ssl = false, bool lightWallet = false, const std::string &proxy_address = "") override;
-    void allowMismatchedDaemonVersion(bool allow_mismatch) override;
     void setRingDatabase(const std::string &path) override;
-    bool connectToDaemon() override;
+    bool connectToDaemon(uint32_t *version = NULL, bool *ssl = NULL, uint32_t timeout = 20000, bool *wallet_is_outdated = NULL, bool *daemon_is_outdated = NULL) override;
     ConnectionStatus connected() const override;
     void setTrustedDaemon(bool arg) override;
     bool trustedDaemon() const override;
     bool setProxy(const std::string &address) override;
     uint64_t balance(uint32_t accountIndex = 0) const override;
-    uint64_t unlockedBalance(uint32_t accountIndex = 0) const override;
+    std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0) const override;
+    uint64_t unlockedBalance(uint32_t accountIndex = 0, std::uint64_t *blocks_to_unlock = NULL, std::uint64_t *time_to_unlock = NULL) const override;
+    std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0) const override;
     uint64_t blockChainHeight() const override;
     uint64_t approximateBlockChainHeight() const override;
     uint64_t estimateBlockChainHeight() const override;
     uint64_t daemonBlockChainHeight() const override;
     uint64_t daemonBlockChainTargetHeight() const override;
+    bool daemonSynced() const override;
     bool synchronized() const override;
-    bool refresh() override;
+    bool refresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr) override;
     void refreshAsync() override;
-    bool rescanBlockchain() override;
-    void rescanBlockchainAsync() override;    
+    bool rescanBlockchain(bool do_hard_rescan = true, bool do_keep_key_images = false, bool do_skip_refresh = false) override;
+    void rescanBlockchainAsync(bool do_hard_rescan = true, bool do_keep_key_images = false) override;
     void setAutoRefreshInterval(int millis) override;
     int autoRefreshInterval() const override;
-    void setRefreshFromBlockHeight(uint64_t refresh_from_block_height) override;
-    uint64_t getRefreshFromBlockHeight() const override { return m_wallet->get_refresh_from_block_height(); };
     void setRecoveringFromSeed(bool recoveringFromSeed) override;
     void setRecoveringFromDevice(bool recoveringFromDevice) override;
-    void setSubaddressLookahead(uint32_t major, uint32_t minor) override;
     bool watchOnly() const override;
     bool isDeterministic() const override;
     bool rescanSpent() override;
-    NetworkType nettype() const override {return static_cast<NetworkType>(m_wallet->nettype());}
+    NetworkType nettype() const override;
     void hardForkInfo(uint8_t &version, uint64_t &earliest_height) const override;
     bool useForkRules(uint8_t version, int64_t early_blocks) const override;
 
@@ -155,13 +158,17 @@ public:
     bool exportMultisigImages(std::string& images) override;
     size_t importMultisigImages(const std::vector<std::string>& images) override;
     bool hasMultisigPartialKeyImages() const override;
-    PendingTransaction*  restoreMultisigTransaction(const std::string& signData) override;
+    PendingTransaction* restoreMultisigTransaction(const std::string& signData, bool ask_for_confirmation = false) override;
 
     PendingTransaction * createTransactionMultDest(const std::vector<std::string> &dst_addr, const std::string &payment_id,
                                         optional<std::vector<uint64_t>> amount, uint32_t mixin_count,
                                         PendingTransaction::Priority priority = PendingTransaction::Priority_Low,
                                         uint32_t subaddr_account = 0,
-                                        std::set<uint32_t> subaddr_indices = {}) override;
+                                        std::set<uint32_t> subaddr_indices = {},
+                                        std::set<uint32_t> subtract_fee_from_outputs = {},
+                                        const std::string key_image = "",
+                                        const size_t outputs = 1,
+                                        const std::uint64_t below = 0) override;
     PendingTransaction * createTransaction(const std::string &dst_addr, const std::string &payment_id,
                                         optional<uint64_t> amount, uint32_t mixin_count,
                                         PendingTransaction::Priority priority = PendingTransaction::Priority_Low,
@@ -173,11 +180,11 @@ public:
     UnsignedTransaction * loadUnsignedTxFromStr(const std::string &unsigned_tx_str) override;
     bool exportKeyImages(const std::string &filename, bool all = false) override;
     std::string exportKeyImagesAsString(bool all = false) override;
-    bool importKeyImages(const std::string &filename) override;
+    bool importKeyImages(const std::string &filename, std::uint64_t *spent_out = nullptr, std::uint64_t *unspent_out = nullptr, std::uint64_t *import_height = nullptr) override;
     bool importKeyImagesFromStr(const std::string &data) override;
     bool exportOutputs(const std::string &filename, bool all = false) override;
     bool importOutputs(const std::string &filename) override;
-    bool scanTransactions(const std::vector<std::string> &txids) override;
+    bool scanTransactions(const std::vector<std::string> &txids, bool *wont_reprocess_recent_txs_via_untrusted_daemon = nullptr) override;
 
     bool setupBackgroundSync(const BackgroundSyncType background_sync_type, const std::string &wallet_password, const optional<std::string> &background_cache_password = optional<std::string>()) override;
     BackgroundSyncType getBackgroundSyncType() const override;
@@ -214,7 +221,7 @@ public:
     virtual std::string getReserveProof(bool all, uint32_t account_index, uint64_t amount, const std::string &message) const override;
     virtual bool checkReserveProof(const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &total, uint64_t &spent) const override;
     virtual std::string signMessage(const std::string &message, const std::string &address, bool sign_with_view_key = false) override;
-    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const override;
+    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr) const override;
     virtual std::string signMultisigParticipant(const std::string &message) const override;
     virtual bool verifyMessageWithPublicKey(const std::string &message, const std::string &publicKey, const std::string &signature) const override;
     virtual void startRefresh() override;
@@ -231,6 +238,7 @@ public:
     virtual bool lockKeysFile() override;
     virtual bool unlockKeysFile() override;
     virtual bool isKeysFileLocked() override;
+    std::unique_ptr<WalletKeysDecryptGuard> createKeysDecryptGuard(const std::string_view &password) override;
     virtual uint64_t coldKeyImageSync(uint64_t &spent, uint64_t &unspent) override;
     virtual void deviceShowAddress(uint32_t accountIndex, uint32_t addressIndex, const std::string &paymentId) override;
     virtual bool reconnectDevice() override;
@@ -240,22 +248,23 @@ public:
     std::string getMultisigSeed(const std::string &seed_offset) const override;
     std::pair<std::uint32_t, std::uint32_t> getSubaddressIndex(const std::string &address) const override;
     void freeze(const std::string &key_image) override;
-    void freezeByPubKey(const std::string &public_key) override;
+    void freezeByPubKey(const std::string &enote_pub_key) override;
     void thaw(const std::string &key_image) override;
-    void thawByPubKey(const std::string &public_key) override;
+    void thawByPubKey(const std::string &enote_pub_key) override;
     bool isFrozen(const std::string &key_image) const override;
-    bool isFrozenByPubKey(const std::string &public_key) override;
     void createOneOffSubaddress(std::uint32_t account_index, std::uint32_t address_index) override;
     WalletState getWalletState() const override;
-    void rewriteWalletFile(const std::string &wallet_name, const std::string &password) override;
-    void writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name) override;
+    DeviceState getDeviceState() const override;
+    void rewriteWalletFile(const std::string &wallet_name, const std::string_view &password) override;
+    void writeWatchOnlyWallet(const std::string_view &password, std::string &new_keys_file_name) override;
     void refreshPoolOnly(bool refreshed = false, bool try_incremental = false) override;
-    void getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const override;
+    std::vector<std::unique_ptr<EnoteDetails>> getEnoteDetails() const override;
+    std::unique_ptr<EnoteDetails> getEnoteDetails(const std::string &enote_pub_key) const override;
+    std::unique_ptr<EnoteDetails> getEnoteDetails(const std::size_t enote_index) const override;
     std::string convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const override;
     bool saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const override;
-    bool parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const override;
-    void insertColdKeyImages(PendingTransaction &ptx) override;
-    bool parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const override;
+    PendingTransaction* parseTxFromStr(const std::string &signed_tx_str) override;
+    PendingTransaction* parseMultisigTxFromStr(const std::string &multisig_tx_str) override;
     std::uint64_t getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const override;
     std::uint64_t getBaseFee() const override;
     std::uint32_t adjustPriority(std::uint32_t priority) override;
@@ -270,8 +279,6 @@ public:
     std::size_t importEnotesFromStr(const std::string &enotes_str) override;
     std::uint64_t getBlockchainHeightByDate(std::uint16_t year, std::uint8_t month, std::uint8_t day) const override;
     std::vector<std::pair<std::uint64_t, std::uint64_t>> estimateBacklog(const std::vector<std::pair<double, double>> &fee_levels) const override;
-    bool saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable = false) const override;
-    bool loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size = 1000000000) const override;
     std::uint64_t hashEnotes(std::uint64_t enote_idx, std::string &hash) const override;
     void finishRescanBcKeepKeyImages(std::uint64_t enote_idx, const std::string &hash) override;
     std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> getPublicNodes(bool white_only = true) const override;
@@ -280,7 +287,86 @@ public:
     bool importKeyImages(const std::vector<std::string> &key_images, std::size_t offset = 0, const std::unordered_set<std::size_t> &selected_enotes_indices = {}) override;
     bool getAllowMismatchedDaemonVersion() const override;
     void setAllowMismatchedDaemonVersion(bool allow_mismatch) override;
-    bool setDaemon(const std::string &daemon_address, const std::string &daemon_username = "", const std::string &daemon_password = "", bool trusted_daemon = false, const std::string &ssl_support = "autodetect", const std::string &ssl_private_key_path = "", const std::string &ssl_certificate_path = "", const std::string &ssl_ca_file_path = "", const std::vector<std::string> &ssl_allowed_fingerprints_str = {}, bool ssl_allow_any_cert = false, const std::string &proxy = "") override;
+    std::string getDeviceDerivationPath() const override;
+    void setDeviceDerivationPath(std::string device_derivation_path) override;
+    bool setDaemon(const std::string &daemon_address, const std::string &daemon_username = "", const std::string &daemon_password = "", bool trusted_daemon = false, Wallet::SSLSupport ssl_support = Wallet::SSLSupport::SSLSupport_Autodetect, const std::string &ssl_private_key_path = "", const std::string &ssl_certificate_path = "", const std::string &ssl_ca_file_path = "", const std::vector<std::string> &ssl_allowed_fingerprints_str = {}, bool ssl_allow_any_cert = false, const std::string &proxy = "") override;
+    bool verifyPassword(const std::string_view &password) override;
+    void encryptKeys(const std::string_view &password) override;
+    void decryptKeys(const std::string_view &password) override;
+    std::uint64_t getMinRingSize() const override;
+    std::uint64_t getMaxRingSize() const override;
+    std::uint64_t adjustMixin(const std::uint64_t fake_outs_count) const override;
+
+    std::uint64_t getDaemonAdjustedTime() const override;
+    std::uint64_t getLastBlockReward() const override;
+    bool hasUnknownKeyImages() const override;
+
+    bool getExplicitRefreshFromBlockHeight() const override;
+    void setExplicitRefreshFromBlockHeight(bool do_explicit_refresh) override;
+
+    // Wallet Settings getter/setter
+    std::string getSeedLanguage() const override;
+    void setSeedLanguage(const std::string &arg) override;
+    bool getAlwaysConfirmTransfers() const override;
+    void setAlwaysConfirmTransfers(bool do_always_confirm) override;
+    bool getPrintRingMembers() const override;
+    void setPrintRingMembers(bool do_print_ring_members) override;
+    bool getStoreTxInfo() const override;
+    void setStoreTxInfo(bool do_store_tx_info) override;
+    bool getAutoRefresh() const override;
+    void setAutoRefresh(bool do_auto_refresh) override;
+    RefreshType getRefreshType() const override;
+    void setRefreshType(RefreshType refresh_type) override;
+    std::uint32_t getDefaultPriority() const override;
+    void setDefaultPriority(std::uint32_t default_priority) override;
+    AskPasswordType getAskPasswordType() const override;
+    void setAskPasswordType(AskPasswordType ask_password_type) override;
+    std::uint64_t getMaxReorgDepth() const override;
+    void setMaxReorgDepth(std::uint64_t max_reorg_depth) override;
+    std::uint32_t getMinOutputCount() const override;
+    void setMinOutputCount(std::uint32_t min_output_count) override;
+    std::uint64_t getMinOutputValue() const override;
+    void setMinOutputValue(std::uint64_t min_output_value) override;
+    bool getMergeDestinations() const override;
+    void setMergeDestinations(bool do_merge_destinations) override;
+    std::uint32_t getConfirmBacklogThreshold() const override;
+    bool getConfirmBacklog() const override;
+    void setConfirmBacklog(bool do_confirm_backlog) override;
+    void setConfirmBacklogThreshold(std::uint32_t confirm_backlog_threshold) override;
+    bool getConfirmExportOverwrite() const override;
+    void setConfirmExportOverwrite(bool do_confirm_export_overwrite) override;
+    uint64_t getRefreshFromBlockHeight() const override;
+    void setRefreshFromBlockHeight(uint64_t refresh_from_block_height) override;
+    bool getAutoLowPriority() const override;
+    void setAutoLowPriority(bool use_auto_low_priority) override;
+    bool getSegregatePreForkOutputs() const override;
+    void setSegregatePreForkOutputs(bool do_segregate) override;
+    bool getKeyReuseMitigation2() const override;
+    void setKeyReuseMitigation2(bool mitigation) override;
+    std::pair<std::uint32_t, std::uint32_t> getSubaddressLookahead() const override;
+    void setSubaddressLookahead(uint32_t major, uint32_t minor) override;
+    std::uint64_t getSegregationHeight() const override;
+    void setSegregationHeight(std::uint64_t height) override;
+    bool getIgnoreFractionalOutputs() const override;
+    void setIgnoreFractionalOutputs(bool do_ignore_fractional_outputs) override;
+    std::uint64_t getIgnoreOutputsAbove() const override;
+    void setIgnoreOutputsAbove(std::uint64_t ignore_outputs_above) override;
+    std::uint64_t getIgnoreOutputsBelow() const override;
+    void setIgnoreOutputsBelow(std::uint64_t ignore_outputs_below) override;
+    bool getTrackUses() const override;
+    void setTrackUses(bool do_track_uses) override;
+    BackgroundMiningSetupType getSetupBackgroundMining() const override;
+    void setSetupBackgroundMining(BackgroundMiningSetupType background_mining_setup) override;
+    std::string getDeviceName() const override;
+    void setDeviceName(const std::string &device_name) override;
+    ExportFormat getExportFormat() const override;
+    void setExportFormat(ExportFormat export_format) override;
+    bool getShowWalletNameWhenLocked() const override;
+    void setShowWalletNameWhenLocked(bool do_show_wallet_name) override;
+    std::uint32_t getInactivityLockTimeout() const override;
+    void setInactivityLockTimeout(std::uint32_t seconds) override;
+    bool getEnableMultisig() const override;
+    void setEnableMultisig(bool do_enable_multisig) override;
 
 private:
     void clearStatus() const;
@@ -288,8 +374,7 @@ private:
     void setStatusCritical(const std::string& message) const;
     void setStatus(int status, const std::string& message) const;
     void refreshThreadFunc();
-    void doRefresh();
-    bool daemonSynced() const;
+    void doRefresh(std::uint64_t start_height = 0, bool check_pool = true, bool try_incremental = false, std::uint64_t max_blocks = std::numeric_limits<uint64_t>::max(), bool *error_out = nullptr, std::uint64_t *blocks_fetched_out = nullptr, bool *received_money_out = nullptr);
     void stopRefresh();
     bool isNewWallet() const;
     void pendingTxPostProcess(PendingTransactionImpl * pending);
@@ -302,6 +387,14 @@ private:
     * return: enote index
     */
     std::size_t getEnoteIndex(const std::string &key_image) const;
+    /**
+    * brief: getPaymentIdFromExtra -
+    * param: tx_extra - as raw bytes
+    * return: payment_id if succeeded, else empty string
+    *         (size is either A) 16 for 8 byte short encrypted payment IDs,
+    *                         B) 64 for obsolete 32 byte long unencrypted payment IDs)
+    */
+    std::string getPaymentIdFromExtra(const std::vector<std::uint8_t> &tx_extra) const;
     /**
     * brief: statusOk -
     * return: true if status is ok, else false
@@ -338,6 +431,8 @@ private:
     std::atomic<bool> m_refreshThreadDone;
     std::atomic<int>  m_refreshIntervalMillis;
     std::atomic<bool> m_refreshShouldRescan;
+    std::atomic<bool> m_do_hard_rescan;
+    std::atomic<bool> m_do_keep_key_images_on_rescan;
     // synchronizing  refresh loop;
     boost::mutex        m_refreshMutex;
 
@@ -355,6 +450,8 @@ private:
     // cache connection status to avoid unnecessary RPC calls
     mutable std::atomic<bool>   m_is_connected;
     boost::optional<epee::net_utils::http::login> m_daemon_login{};
+    // number of rounds for key derivation function for wallet password
+    std::uint64_t m_kdf_rounds;
 };
 
 

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -33,11 +33,13 @@
 
 #include "wallet/api/wallet2_api.h"
 #include "wallet/wallet2.h"
+#include "wipeable_string.h"
 
 #include <string>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition_variable.hpp>
+#include <string_view>
 
 class WalletApiAccessorTest;
 
@@ -96,8 +98,7 @@ public:
     int status() const override;
     std::string errorString() const override;
     void statusWithErrorString(int& status, std::string& errorString, int* extendedStatusOut = nullptr) const override;
-    bool setPassword(const std::string &password) override;
-    const std::string& getPassword() const override;
+    bool setPassword(const std::string_view &old_password, const std::string_view &new_password) override;
     bool setDevicePin(const std::string &password) override;
     bool setDevicePassphrase(const std::string &password) override;
     std::string address(uint32_t accountIndex = 0, uint32_t addressIndex = 0) const override;
@@ -109,7 +110,7 @@ public:
     std::string publicMultisigSignerKey() const override;
     std::string path() const override;
     void stop() override;
-    bool store(const std::string &path) override;
+    bool store(const std::string &path, const optional<std::string_view> &password = optional<std::string_view>()) override;
     std::string filename() const override;
     std::string keysFilename() const override;
     bool init(const std::string &daemon_address, uint64_t upper_transaction_size_limit = 0, const std::string &daemon_username = "", const std::string &daemon_password = "", bool use_ssl = false, bool lightWallet = false, const std::string &proxy_address = "") override;
@@ -154,9 +155,9 @@ public:
 
     MultisigState multisig() const override;
     std::string getMultisigInfo() const override;
-    std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold) override;
-    std::string exchangeMultisigKeys(const std::vector<std::string> &info, const bool force_update_use_with_caution = false) override;
-    std::string getMultisigKeyExchangeBooster(const std::vector<std::string> &info, const uint32_t threshold, const uint32_t num_signers) override;
+    std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold, const std::string_view &password) override;
+    std::string exchangeMultisigKeys(const std::vector<std::string> &info, const std::string_view &password, const bool force_update_use_with_caution = false) override;
+    std::string getMultisigKeyExchangeBooster(const std::vector<std::string> &info, const uint32_t threshold, const uint32_t num_signers, const std::string_view &password) override;
     bool exportMultisigImages(std::string& images) override;
     size_t importMultisigImages(const std::vector<std::string>& images) override;
     bool hasMultisigPartialKeyImages() const override;
@@ -430,11 +431,6 @@ private:
     mutable int m_status;
     mutable std::string m_errorString;
     mutable int m_extendedStatus;
-    // TODO: harden password handling in the wallet API, see relevant discussion
-    // https://github.com/monero-project/monero-gui/issues/1537
-    // https://github.com/feather-wallet/feather/issues/72#issuecomment-1405602142
-    // https://github.com/monero-project/monero/pull/8619#issuecomment-1632951461
-    std::string m_password;
     std::unique_ptr<TransactionHistoryImpl> m_history;
     std::unique_ptr<Wallet2CallbackImpl> m_wallet2Callback;
     std::unique_ptr<AddressBookImpl>  m_addressBook;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -134,6 +134,74 @@ struct EnoteDetails
 };
 
 /**
+ * @brief TxSource -
+ */
+struct TxSource
+{
+    // enote amount
+    std::uint64_t amount;
+    // part of amount-global output index pair {rct ? 0 : amount, global_index}
+    std::uint64_t global_index;
+    // true if enote was created in RingCT, else false
+    bool rct;
+    // enote pubkey
+    std::string pubkey;
+};
+/**
+ * @brief TxRecipient -
+ */
+struct TxRecipient
+{
+    std::string address;
+    std::uint64_t amount;
+};
+/**
+ * @brief TxDesctiptionSingle - description of a single tx in PendingTransaction/UnsignedTransaction
+ */
+struct TxDescriptionSingle
+{
+    std::uint64_t amount_in;
+    std::uint64_t amount_out;
+    std::uint32_t ring_size;
+    std::uint64_t unlock_time;
+    std::list<TxSource> sources;
+    std::list<TxRecipient> recipients;
+    std::string payment_id;
+    std::uint64_t change_amount;
+    std::string change_address;
+    std::uint64_t fee;
+    std::uint32_t dummy_outputs;
+    std::string extra;
+};
+/**
+ * @brief TxSummary - summary for all txs in a PendingTransaction/UnsignedTransaction
+ */
+struct TxSummary
+{
+    // Sum of amounts for all enotes that were used to create the tx
+    std::uint64_t amount_in;
+    // Sum of amounts for all enotes that were created by this tx
+    std::uint64_t amount_out;
+    // All recipients, excluding change
+    std::list<TxRecipient> recipients;
+    // Sum of all change amounts created by this tx
+    std::uint64_t change_amount;
+    // Address receiving change
+    std::string change_address;
+    // Total fee
+    std::uint64_t fee;
+};
+/**
+ * @brief TransactionDescription - description of each tx in a PendingTransaction/UnsignedTransaction
+ *                                 and a summary for the entire PendingTransaction/UnsignedTransaction
+ */
+struct TransactionDescription
+{
+    std::list<TxDescriptionSingle> tx_descriptions;
+    TxSummary tx_summary;
+};
+
+/**
  * @brief Transaction-like interface for sending money
  */
 struct PendingTransaction
@@ -156,13 +224,25 @@ struct PendingTransaction
     virtual ~PendingTransaction() = 0;
     virtual int status() const = 0;
     virtual std::string errorString() const = 0;
+    virtual int extendedStatus() const = 0;
     virtual std::string confirmationMessage() const = 0;
     // commit transaction or save to file if filename is provided.
+    // note: be careful, after calling this method other methods in this class may not work as expected anymore
+    //       if you want to get any info about the ptx, you should fetch it before calling commit()
+    // note: this method sets extendedStatus if it catches one of the following exceptions:
+    //          `no_connection_to_daemon`, `daemon_busy`, `not_enough_unlocked_money`, `not_enough_money`,
+    //          `tx_not_possible`, `not_enough_outs_to_mix`, `zero_amount`, `zero_destination`
     virtual bool commit(const std::string &filename = "", bool overwrite = false) = 0;
+    // summed up total amount for all txs and destinations, excluding change and fee
     virtual uint64_t amount() const = 0;
+    // amount for each destination per tx
+    virtual std::vector<std::vector<uint64_t>> amountsPerDestination() const = 0;
     virtual uint64_t dust() const = 0;
     virtual uint64_t dustInFee() const = 0;
+    // summed up total fee for all txs
     virtual uint64_t fee() const = 0;
+    // fee amount per tx
+    virtual std::vector<uint64_t> fees() const = 0;
     virtual uint64_t change() const = 0;
     virtual std::vector<std::string> txid() const = 0;
     /*!
@@ -194,6 +274,20 @@ struct PendingTransaction
     */
     virtual std::vector<std::string> convertTxToRawBlobStr() = 0;
     /**
+    * brief: asHexStr - create hex string for each tx in `PendingTransaction`
+    *                   which can be used as arguments for `tx_as_hex`
+    *                   for daemon RPC `/send_raw_transaction`
+    * return: serialized ptx objects as hex strings if succeeded, else empty vector
+    * note: sets status error on failure
+    */
+    virtual std::vector<std::string> asHexStr() = 0;
+    /**
+    * brief: txWeights -
+    * return: weight per tx
+    * note: sets status error on failure
+    */
+    virtual std::vector<std::uint64_t> txWeights() = 0;
+    /**
     * brief: getWorstFeePerByte - needed when checking for backlog
     * return: worst fee per bytes
     */
@@ -220,6 +314,11 @@ struct PendingTransaction
     */
     virtual std::vector<std::vector<std::uint64_t>> vinAmounts() const = 0;
     /**
+    * brief: getTxKeys - tx_key + optional additional_tx_keys concatenated to a single string per tx
+    * return: secret tx keys
+    */
+    virtual std::vector<std::string> getTxKeys() const = 0;
+    /**
     * brief: getEnoteDetailsIn -
     * return: enote details for all enotes that are used as inputs per tx
     *         [ tx_idx : [ enote_idx : EnoteDetails, ... ], ... ]
@@ -233,6 +332,12 @@ struct PendingTransaction
     * return: true on success
     */
     virtual bool finishParsingTx() = 0;
+    /**
+    * brief: getTransactionDescription - details for each tx
+    * return: TransactionDescription on success, else nullptr
+    * note: sets status error on failure
+    */
+    virtual std::unique_ptr<TransactionDescription> getTransactionDescription() = 0;
 
     /**
      * @brief multisigSignData
@@ -314,6 +419,12 @@ struct UnsignedTransaction
     * note: sets status error on failure
     */
     virtual std::string signAsString() = 0;
+    /**
+    * brief: getTransactionDescription - details for each tx
+    * return: TransactionDescription on success, else nullptr
+    * note: sets status error on failure
+    */
+    virtual std::unique_ptr<TransactionDescription> getTransactionDescription() = 0;
 };
 
 /**
@@ -376,7 +487,9 @@ struct TransactionHistory
     virtual int count() const = 0;
     virtual TransactionInfo * transaction(int index)  const = 0;
     virtual TransactionInfo * transaction(const std::string &id) const = 0;
-    virtual std::vector<TransactionInfo*> getAll() const = 0;
+    // note: usually you would call tx_history->refresh() on the wallets moneyReceived/moneySpent callbacks
+    //       though there are no callbacks if the wallet is unattended
+    virtual std::vector<TransactionInfo*> getAll(bool do_refresh = false) = 0;
     virtual void refresh() = 0;
     virtual void setTxNote(const std::string &txid, const std::string &note) = 0;
 };
@@ -422,6 +535,7 @@ struct AddressBook
     virtual bool addRow(const std::string &dst_addr , const std::string &payment_id, const std::string &description) = 0;  
     virtual bool deleteRow(std::size_t rowId) = 0;
     virtual bool setDescription(std::size_t index, const std::string &description) = 0;
+    virtual bool setAddress(std::size_t index, const std::string &address) = 0;
     virtual void refresh() = 0;  
     virtual std::string errorString() const = 0;
     virtual int errorCode() const = 0;
@@ -634,6 +748,26 @@ struct Wallet
         Status_Critical
     };
 
+    // Matching error codes in src/wallet/wallet_rpc_server_error_codes.h
+    enum ExtendedStatus {
+        ExtendedStatus_Ok                       =   0,
+        ExtendedStatus_Unknown_Error            =  -1,
+        ExtendedStatus_DaemonIsBusy             =  -3,
+        ExtendedStatus_WrongSignature           =  -9,
+        ExtendedStatus_AccountIndexOutOfBounds  = -14,
+        ExtendedStatus_AddressIndexOutOfBounds  = -15,
+        ExtendedStatus_TxNotPossible            = -16,
+        ExtendedStatus_NotEnoughMoney           = -17,
+        ExtendedStatus_NotEnoughOutsToMix       = -19,
+        ExtendedStatus_ZeroDestination          = -20,
+        ExtendedStatus_WalletAlreadyExists      = -21,
+        ExtendedStatus_InvalidPassword          = -22,
+        ExtendedStatus_NotEnoughUnlockedMoney   = -37,
+        ExtendedStatus_NoDaemonConnection       = -38,
+        ExtendedStatus_ZeroAmount               = -46,
+        ExtendedStatus_NonZeroUnlockTime        = -50,
+    };
+
     enum ConnectionStatus {
         ConnectionStatus_Disconnected,
         ConnectionStatus_Connected,
@@ -702,6 +836,7 @@ struct Wallet
         // is wallet file format deprecated
         bool is_deprecated;
         bool is_unattended;
+        bool has_proxy_flag;
         std::string daemon_address;
         std::string ring_database;
         std::uint64_t n_enotes;
@@ -709,12 +844,12 @@ struct Wallet
 
     virtual ~Wallet() = 0;
     virtual std::string seed(const std::string& seed_offset = "") const = 0;
-    //! returns wallet status (Status_Ok | Status_Error)
+    //! returns wallet status (Status_Ok | Status_Error | Status_Critical)
     virtual int status() const = 0; //deprecated: use safe alternative statusWithErrorString
     //! in case error status, returns error string
     virtual std::string errorString() const = 0; //deprecated: use safe alternative statusWithErrorString
-    //! returns both error and error string atomically. suggested to use in instead of status() and errorString()
-    virtual void statusWithErrorString(int& status, std::string& errorString) const = 0;
+    //! returns both error and error string atomically. suggested to use in instead of status() and errorString(), optionally gives ExtendedStatus code if any
+    virtual void statusWithErrorString(int& status, std::string& errorString, int* extendedStatus = nullptr) const = 0;
     virtual bool setPassword(const std::string &password) = 0;
     virtual const std::string& getPassword() const = 0;
     virtual bool setDevicePin(const std::string &pin) { (void)pin; return false; };
@@ -807,7 +942,6 @@ struct Wallet
      * \return  - true on success
      */
     virtual bool init(const std::string &daemon_address, uint64_t upper_transaction_size_limit = 0, const std::string &daemon_username = "", const std::string &daemon_password = "", bool use_ssl = false, bool lightWallet = false, const std::string &proxy_address = "") = 0;
-    virtual void allowMismatchedDaemonVersion(bool allow_mismatch) = 0;
     virtual void setRingDatabase(const std::string &path) = 0;
 
    /*!
@@ -852,20 +986,36 @@ struct Wallet
     virtual void setTrustedDaemon(bool arg) = 0;
     virtual bool trustedDaemon() const = 0;
     virtual bool setProxy(const std::string &address) = 0;
-    virtual uint64_t balance(uint32_t accountIndex = 0) const = 0;
-    virtual std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0) const = 0;
-    uint64_t balanceAll() const {
+    virtual uint64_t balance(uint32_t accountIndex = 0, bool is_strict = false) const = 0;
+    virtual std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0, bool is_strict = false) const = 0;
+    /**
+     * @brief balanceAll - sum of balances for all accounts and subaddresses
+     * @param is_strict - true = only consider blockchain state, false = also consider pool state (Default: false)
+     * @return - balance
+     */
+    uint64_t balanceAll(bool is_strict = false) const {
         uint64_t result = 0;
         for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
-            result += balance(i);
+            result += balance(i, is_strict);
         return result;
     }
-    virtual uint64_t unlockedBalance(uint32_t accountIndex = 0, uint64_t *blocks_to_unlock = NULL, uint64_t *time_to_unlock = NULL) const = 0;
-    virtual std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0) const = 0;
-    uint64_t unlockedBalanceAll() const {
+    virtual uint64_t unlockedBalance(uint32_t accountIndex = 0, uint64_t *blocks_to_unlock = NULL, uint64_t *time_to_unlock = NULL, bool is_strict = false) const = 0;
+    virtual std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0, bool is_strict = false) const = 0;
+    uint64_t unlockedBalanceAll(uint64_t *blocks_to_unlock = nullptr, uint64_t *time_to_unlock = nullptr, bool is_strict = false) const {
         uint64_t result = 0;
+        if (blocks_to_unlock)
+            *blocks_to_unlock = 0;
+        if (time_to_unlock)
+            *time_to_unlock = 0;
         for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
-            result += unlockedBalance(i);
+        {
+            uint64_t local_blocks_to_unlock, local_time_to_unlock;
+            result += unlockedBalance(i, blocks_to_unlock ? &local_blocks_to_unlock : nullptr,  time_to_unlock ? &local_time_to_unlock : nullptr, is_strict);
+            if (blocks_to_unlock)
+                *blocks_to_unlock = std::max(*blocks_to_unlock, local_blocks_to_unlock);
+            if (time_to_unlock)
+                *time_to_unlock = std::max(*time_to_unlock, local_time_to_unlock);
+        }
         return result;
     }
 
@@ -975,6 +1125,7 @@ struct Wallet
      * @param check_pool            - wether to also scan tx pool (Default: true)
      * @param try_incremental       - if daemon supports it, only get txs from the pool which the wallet hasn't seen before (Default: false)
      * @param max_blocks            - refresh returns when blocks fetched reaches max_blocks (Default: std::numeric_limits<std::uint64_t>::max())
+     * @param skip_refresh_if_daemon_not_synced - (Default: true)
      * @outparam blocks_fetched_out - number of blocks fetched during refresh (Default: nullptr)
      * @outparam received_money_out - true if the wallet received money in the blocks fetched during refresh (Default: nullptr)
      * @return - true if refreshed successfully;
@@ -983,6 +1134,7 @@ struct Wallet
                          bool check_pool = true,
                          bool try_incremental = false,
                          std::uint64_t max_blocks = std::numeric_limits<std::uint64_t>::max(),
+                         bool skip_refresh_if_daemon_not_synced = true,
                          std::uint64_t *blocks_fetched_out = nullptr,
                          bool *received_money_out = nullptr) = 0;
 
@@ -1028,6 +1180,7 @@ struct Wallet
     /**
      * @brief addSubaddressAccount - appends a new subaddress account at the end of the last major index of existing subaddress accounts
      * @param label - the label for the new account (which is the as the label of the primary address (accountIndex,0))
+     * @note - sets status error on failure
      */
     virtual void addSubaddressAccount(const std::string& label) = 0;
     /**
@@ -1043,6 +1196,7 @@ struct Wallet
      * @brief addSubaddress - appends a new subaddress at the end of the last minor index of the specified subaddress account
      * @param accountIndex - the major index specifying the subaddress account
      * @param label - the label for the new subaddress
+     * @note - sets status error on failure
      */
     virtual void addSubaddress(uint32_t accountIndex, const std::string& label) = 0;
     /**
@@ -1135,6 +1289,10 @@ struct Wallet
      * \param below                     threshold for sweep_below, only used if `amount` is not set (Default: 0)
      * \return                          PendingTransaction object. caller is responsible to check PendingTransaction::status()
      *                                  after object returned
+     * \note: sets status error on failure
+     * \note: this method sets `extendedStatus` if it catches one of the following exceptions:
+     *           `no_connection_to_daemon`, `daemon_busy`, `not_enough_unlocked_money`, `not_enough_money`,
+     *           `tx_not_possible`, `not_enough_outs_to_mix`, `zero_amount`, `zero_destination`
      */
 
     virtual PendingTransaction * createTransactionMultDest(const std::vector<std::string> &dst_addr, const std::string &payment_id,
@@ -1229,6 +1387,14 @@ struct Wallet
     * note: sets status error on failure
     */
     virtual std::string exportKeyImagesAsString(bool all = false) = 0;
+    /**
+    * brief: exportKeyImages - export key images
+    * param: all - export all key images or only those that have not yet been exported
+    * outparam: offset_out - number of skipped key images, 0 if `all = true`
+    * outparam: key_images_and_signatures_out - pairs of key_image + signature both as hex string
+    * note: sets status error on failure
+    */
+    virtual void exportKeyImages(bool all, std::uint64_t &offset_out, std::vector<std::pair<std::string, std::string>> &key_images_and_signatures_out) = 0;
    
    /*!
     * \brief importKeyImages  - imports key images from file
@@ -1292,8 +1458,9 @@ struct Wallet
     /**
      * @brief stopBackgroundSync  - bring back spend key and process background synced txs
      * \param wallet_password
+     * \param spend_secret_key (optional)
      */
-    virtual bool stopBackgroundSync(const std::string &wallet_password) = 0;
+    virtual bool stopBackgroundSync(const std::string &wallet_password, const std::string_view *spend_secret_key = nullptr) = 0;
 
     /**
      * @brief isBackgroundSyncing - returns true if the wallet is background syncing
@@ -1375,10 +1542,11 @@ struct Wallet
      * \param address - the address the signature claims to be made with
      * \param signature - the signature
      * \outparam is_old_out - true if signature uses old format (optional)
-     * \outparam signature_type_out - either signed by: spendkey | viewkey | unkown (suspicious); (optional)
+     * \outparam signature_type_out - signed by which key: [ "spend" | "view" | "invalid" (suspicious) ] (optional)
+     * \outparam version_out - currently supported signature versions: [ 1 = "SigV1", 2 = "SigV2" ] (optional)
      * \return true if the signature verified, false otherwise
      */
-    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr) const = 0;
+    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr, unsigned *version_out = nullptr) const = 0;
 
     /*!
      * \brief signMultisigParticipant   signs given message with the multisig public signer key
@@ -1540,6 +1708,8 @@ struct Wallet
     * param: refreshed - (default: false)
     * param: try_incremental - (default: false)
     * note: sets status error on failure
+    * note: this method sets `extendedStatus` if it catches one of the following exceptions:
+    *          `no_connection_to_daemon`, `daemon_busy`
     */
     virtual void refreshPoolOnly(bool refreshed = false, bool try_incremental = false) = 0;
     /**
@@ -1592,6 +1762,13 @@ struct Wallet
     * note: sets status error on failure
     */
     virtual PendingTransaction* parseMultisigTxFromStr(const std::string &multisig_tx_str) = 0;
+    /**
+    * brief: deserializePtxFromBlobStr - get pending transaction from unencrypted BLOB string
+    * param: tx_blob - also known as `tx_metadata` returned by wallet-rpc transfer/sweep methods
+    * return: ptx if succeeded, else nullptr
+    * note: sets status error on failure
+    */
+    virtual std::unique_ptr<PendingTransaction> deserializePtxFromBlobStr(const std::string &tx_blob) = 0;
     /**
     * brief: getFeeMultiplier -
     * param: priority -
@@ -1853,6 +2030,9 @@ struct Wallet
     virtual bool getExplicitRefreshFromBlockHeight() const = 0;
     virtual void setExplicitRefreshFromBlockHeight(bool do_explicit_refresh) = 0;
 
+    // "Run a program for each new incoming transaction, '%s' will be replaced by the transaction hash" (Default: disabled)
+    virtual void setTxNotify(const std::string &tx_notify) = 0;
+
     // Wallet Settings getter/setter
     virtual std::string getSeedLanguage() const = 0;
     // note: sets status error on failure
@@ -1895,6 +2075,7 @@ struct Wallet
     virtual bool getKeyReuseMitigation2() const = 0;
     virtual void setKeyReuseMitigation2(bool do_key_reuse_mitigation) = 0;
     virtual std::pair<std::uint32_t, std::uint32_t> getSubaddressLookahead() const = 0;
+    // note: sets status error on failure
     virtual void setSubaddressLookahead(uint32_t major, uint32_t minor) = 0;
     virtual std::uint64_t getSegregationHeight() const = 0;
     virtual void setSegregationHeight(std::uint64_t segregation_height) = 0;
@@ -1933,14 +2114,17 @@ struct WalletManager
      * \param  language       Language to be used to generate electrum seed mnemonic
      * \param  nettype        Network type
      * \param  kdf_rounds     Number of rounds for key derivation function
-     * \param  create_address_file - Create <wallet_name>.address.txt file (Default: false)
-     *                               NOTE: gets irgnored for stagenet and testnet and will create .address.txt file even if set to false
-     * \param  non_determinisitc - Whether to create a non-deterministic wallet, where the secret-spend-key and secret-view-key are both random and not in relation (Default: false)
-     *                             NOTE: this old way to create keys should not be used, except you have a good reason and you know what you do
-     * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
+     * \param  create_address_file  - Create <wallet_name>.address.txt file (Default: false)
+     *                                NOTE: gets irgnored for stagenet and testnet and will create .address.txt file even if set to false
+     * \param  non_determinisitc    - Whether to create a non-deterministic wallet, where the secret-spend-key and secret-view-key are both random and not in relation (Default: false)
+     *                                NOTE: this old way to create keys should not be used, except you have a good reason and you know what you do
+     * \param  unattended           - Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
+     * \param  extra_entropy_file   - "File containing extra entropy to initialize the PRNG
+     *                                 (any data, aim for 256 bits of entropy to be useful, which typically means more than 256 bits of data)"
+     *                                (Default: empty string)
      * \return                Wallet instance (Wallet::status() needs to be called to check if created successfully)
      */
-    virtual Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, const bool create_address_file = false, const bool non_determinisitc = false, const bool unattended = true) = 0;
+    virtual Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, const bool create_address_file = false, const bool non_determinisitc = false, const bool unattended = true, const std::string extra_entropy_file = "") = 0;
     Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, bool testnet = false)      // deprecated
     {
         return createWallet(path, password, language, testnet ? TESTNET : MAINNET);
@@ -1971,12 +2155,13 @@ struct WalletManager
      * \param  restoreHeight  restore from start height
      * \param  kdf_rounds     Number of rounds for key derivation function
      * \param  seed_offset    Seed offset passphrase (optional)
+     * \param  create_address_file Create <wallet_name>.address.txt file (Default: false)
      * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
     virtual Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &mnemonic,
                                     NetworkType nettype = MAINNET, uint64_t restoreHeight = 0, uint64_t kdf_rounds = 1,
-                                    const std::string &seed_offset = {}, const bool unattended = true) = 0;
+                                    const std::string &seed_offset = {}, const bool create_address_file = false, const bool unattended = true) = 0;
     Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &mnemonic,
                                     bool testnet = false, uint64_t restoreHeight = 0)           // deprecated
     {
@@ -2202,8 +2387,8 @@ struct WalletManager
     //! returns verbose error string regarding last error;
     virtual std::string errorString() const = 0;
 
-    //! set the daemon address (hostname and port)
-    virtual void setDaemonAddress(const std::string &address) = 0;
+    //! set the daemon address (hostname and port) and, if necessary, daemon login
+    virtual void setDaemonAddress(const std::string &address, std::pair<std::string, std::string> *daemon_username_password = nullptr) = 0;
 
     //! returns whether the daemon can be reached, and its version number
     virtual bool connected(uint32_t *version = NULL) = 0;
@@ -2222,9 +2407,6 @@ struct WalletManager
 
     //! returns current block target
     virtual uint64_t blockTarget() = 0;
-
-    //! returns true if bootstrap mode was used by daemon or if bootstrap daemon address is set
-    virtual bool wasBootstrapEverUsed() = 0;
 
     //! returns true iff backgound mining is enabled
     virtual bool isBackgroundMiningEnabled() = 0;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -850,8 +850,7 @@ struct Wallet
     virtual std::string errorString() const = 0; //deprecated: use safe alternative statusWithErrorString
     //! returns both error and error string atomically. suggested to use in instead of status() and errorString(), optionally gives ExtendedStatus code if any
     virtual void statusWithErrorString(int& status, std::string& errorString, int* extendedStatus = nullptr) const = 0;
-    virtual bool setPassword(const std::string &password) = 0;
-    virtual const std::string& getPassword() const = 0;
+    virtual bool setPassword(const std::string_view &old_password, const std::string_view &new_password) = 0;
     virtual bool setDevicePin(const std::string &pin) { (void)pin; return false; };
     virtual bool setDevicePassphrase(const std::string &passphrase) { (void)passphrase; return false; };
     virtual std::string address(uint32_t accountIndex = 0, uint32_t addressIndex = 0) const = 0;
@@ -915,9 +914,10 @@ struct Wallet
      * \brief store - stores wallet to file.
      * \param path - main filename to store wallet to. additionally stores address file and keys file.
      *               to store to the same file - just pass empty string;
+     * \param password - only needed if path is not empty (default: empty optional)
      * \return
      */
-    virtual bool store(const std::string &path) = 0;
+    virtual bool store(const std::string &path, const optional<std::string_view> &password = optional<std::string_view>()) = 0;
     /*!
      * \brief filename - returns wallet filename
      * \return
@@ -1227,25 +1227,28 @@ struct Wallet
      * @brief makeMultisig - switches wallet in multisig state. The one and only creation phase for N / N wallets
      * @param info - vector of multisig infos from other participants obtained with getMulitisInfo call
      * @param threshold - number of required signers to make valid transaction. Must be <= number of participants
+     * @param password - wallet password
      * @return in case of N / N wallets returns empty string since no more key exchanges needed. For N - 1 / N wallets returns base58 encoded extra multisig info
      */
-    virtual std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold) = 0;
+    virtual std::string makeMultisig(const std::vector<std::string>& info, uint32_t threshold, const std::string_view &password) = 0;
     /**
      * @brief exchange_multisig_keys - provides additional key exchange round for arbitrary multisig schemes (like N-1/N, M/N)
      * @param info - base58 encoded key derivations returned by makeMultisig or exchangeMultisigKeys function call
+     * @param password - wallet password
      * @param force_update_use_with_caution - force multisig account to update even if not all signers contribute round messages
      * @return new info string if more rounds required or an empty string if wallet creation is done
      */
-    virtual std::string exchangeMultisigKeys(const std::vector<std::string> &info, const bool force_update_use_with_caution) = 0;
+    virtual std::string exchangeMultisigKeys(const std::vector<std::string> &info, const std::string_view &password, const bool force_update_use_with_caution) = 0;
     /**
      * @brief getMultisigKeyExchangeBooster - obtain partial information for the key exchange round after the in-progress round,
      *                                        to speed up another signer's key exchange process
      * @param info - base58 encoded key derivations returned by makeMultisig or exchangeMultisigKeys function call
      * @param threshold - number of required signers to make valid transaction. Must be <= number of participants.
      * @param num_signers - total number of multisig participants.
+     * @param password - wallet password
      * @return new info string if more rounds required or exception if no more rounds (i.e. no rounds to boost)
      */
-    virtual std::string getMultisigKeyExchangeBooster(const std::vector<std::string> &info, const uint32_t threshold, const uint32_t num_signers) = 0;
+    virtual std::string getMultisigKeyExchangeBooster(const std::vector<std::string> &info, const uint32_t threshold, const uint32_t num_signers, const std::string_view &password) = 0;
     /**
      * @brief exportMultisigImages - exports transfers' key images
      * @param images - output parameter for hex encoded array of images

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -35,11 +35,15 @@
 #include <ctime>
 #include <iostream>
 #include <list>
+#include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <vector>
+
 
 //  Public interface for libwallet library
 namespace Monero {
@@ -58,6 +62,39 @@ enum NetworkType : uint8_t {
     // backwards compatible shim for old declaration of handmade optional<> struct
     template<typename T>
     using optional = std::optional<T>;
+
+/**
+* brief: EnoteDetails - Container for all the necessary information that belongs to an enote
+*/
+struct EnoteDetails
+{
+    enum TxProtocol {
+        TxProtocol_CryptoNote,
+        TxProtocol_RingCT
+    };
+
+    virtual ~EnoteDetails() = 0;
+    virtual std::string onetimeAddress() const = 0;
+    virtual std::string viewTag() const = 0;
+    virtual std::uint64_t blockHeight() const = 0;
+    virtual std::string txId() const = 0;
+    virtual std::uint64_t internalEnoteIndex() const = 0;
+    virtual std::uint64_t globalEnoteIndex() const = 0;
+    virtual bool isSpent() const = 0;
+    virtual bool isFrozen() const = 0;
+    virtual std::uint64_t spentHeight() const = 0;
+    virtual std::string keyImage() const = 0;
+    virtual std::string mask() const = 0;
+    virtual std::uint64_t amount() const = 0;
+    virtual TxProtocol protocolVersion() const = 0;
+    virtual bool isKeyImageKnown() const = 0;
+    virtual bool isKeyImageRequest() const = 0;
+    virtual std::uint64_t pkIndex() const = 0;
+    virtual std::vector<std::pair<std::uint64_t, std::string>> uses() const = 0;
+
+    // Multisig
+    virtual bool isKeyImagePartial() const = 0;
+};
 
 /**
  * @brief Transaction-like interface for sending money
@@ -118,6 +155,12 @@ struct PendingTransaction
      * @return vector of base58-encoded signers' public keys
      */
     virtual std::vector<std::string> signersKeys() const = 0;
+    /**
+    * brief: convertTxToStr - convert PendingTransaction to hex string (same content which would be saved to file with commit(filename))
+    * return: unsigned tx data as encrypted hex string if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string convertTxToStr() = 0;
 };
 
 /**
@@ -154,6 +197,12 @@ struct UnsignedTransaction
     * return - true on success
     */
     virtual bool sign(const std::string &signedFileName) = 0;
+    /**
+    * brief: signAsString - convert UnsignedTransaction to hex string (same content which would be saved to file with sign(filename))
+    * return: signed tx data as encrypted hex string if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string signAsString() = 0;
 };
 
 /**
@@ -166,6 +215,13 @@ struct TransactionInfo
         Direction_Out
     };
 
+    enum TxState {
+       TxState_Pending,
+       TxState_PendingInPool,
+       TxState_Failed,
+       TxState_Confirmed
+    };
+
     struct Transfer {
         Transfer(uint64_t _amount, const std::string &address);
         const uint64_t amount;
@@ -174,7 +230,9 @@ struct TransactionInfo
 
     virtual ~TransactionInfo() = 0;
     virtual int  direction() const = 0;
+    // legacy : use txState() instead
     virtual bool isPending() const = 0;
+    // legacy : use txState() instead
     virtual bool isFailed() const = 0;
     virtual bool isCoinbase() const = 0;
     virtual uint64_t amount() const = 0;
@@ -192,6 +250,10 @@ struct TransactionInfo
     virtual std::string paymentId() const = 0;
     //! only applicable for output transactions
     virtual const std::vector<Transfer> & transfers() const = 0;
+
+    virtual std::uint64_t receivedChangeAmount() const = 0;
+    virtual TxState txState() const = 0;
+    virtual bool isDoubleSpendSeen() const = 0;
 };
 /**
  * @brief The TransactionHistory - interface for displaying transaction history
@@ -297,7 +359,6 @@ private:
     std::string m_balance;
     std::string m_unlockedBalance;
 public:
-    std::string extra;
     std::string getAddress() const {return m_address;}
     std::string getLabel() const {return m_label;}
     std::string getBalance() const {return m_balance;}
@@ -413,6 +474,18 @@ struct WalletListener
      * @brief If the listener is created before the wallet this enables to set created wallet object
      */
     virtual void onSetWallet(Wallet * wallet) { (void)wallet; };
+    /**
+    * brief: onReorg - called on blockchain reorg
+    */
+    virtual void onReorg(std::uint64_t height, std::uint64_t blocks_detached, std::size_t transfers_detached) = 0;
+    /**
+    * brief: onGetPassword - called by scan_output() to decrypt keys
+    */
+    virtual optional<std::string> onGetPassword(const char *reason) = 0;
+    /**
+    * brief: onPoolTxRemoved - when obsolete pool transactions get removed
+    */
+    virtual void onPoolTxRemoved(const std::string &txid) = 0;
 };
 
 
@@ -443,6 +516,13 @@ struct Wallet
         BackgroundSync_Off = 0,
         BackgroundSync_ReusePassword = 1,
         BackgroundSync_CustomPassword = 2
+    };
+
+    struct WalletState {
+        // is wallet file format deprecated
+        bool is_deprecated;
+        std::uint64_t ring_size;
+        std::string daemon_address;
     };
 
     virtual ~Wallet() = 0;
@@ -694,6 +774,14 @@ struct Wallet
         return paymentIdFromAddress(str, testnet ? TESTNET : MAINNET);
     }
     static uint64_t maximumAllowedAmount();
+    /**
+    * brief: walletExists - check if wallet file and .keys file exist for given path
+    * param: path - filename
+    * outparam: keys_file_exists -
+    * outparam: wallet_file_exists -
+    * return: true if (key_file_exists || wallet_file_exists)
+    */
+    static bool walletExists(const std::string &path, bool &key_file_exists, bool &wallet_file_exists);
     // Easylogger wrapper
     static void init(const char *argv0, const char *default_log_base_name) { init(argv0, default_log_base_name, "", true); }
     static void init(const char *argv0, const char *default_log_base_name, const std::string &log_path, bool console);
@@ -889,6 +977,13 @@ struct Wallet
     *                          after object returned
     */
     virtual UnsignedTransaction * loadUnsignedTx(const std::string &unsigned_filename) = 0;
+    /**
+    * brief: loadUnsignedTxFromStr - create UnsignedTransaction from unsigned tx string
+    * param: unsigned_tx_str - encrypted unsigned tx hex string
+    * return: UnsignedTransaction object. caller is responsible to check UnsignedTransaction::status() after object returned
+    * note: sets status error on fail
+    */
+    virtual UnsignedTransaction * loadUnsignedTxFromStr(const std::string &unsigned_tx_str) = 0;
     
    /*!
     * \brief submitTransaction - submits transaction in signed tx file
@@ -918,6 +1013,13 @@ struct Wallet
     * \return                  - true on success
     */
     virtual bool exportKeyImages(const std::string &filename, bool all = false) = 0;
+    /**
+    * brief: exportKeyImagesAsString - export key images as string
+    * param: all - export all key images or only those that have not yet been exported
+    * return: exported key images as encrypted hex string if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string exportKeyImagesAsString(bool all = false) = 0;
    
    /*!
     * \brief importKeyImages - imports key images from file
@@ -925,6 +1027,13 @@ struct Wallet
     * \return                  - true on success
     */
     virtual bool importKeyImages(const std::string &filename) = 0;
+    /**
+    * brief: importKeyImagesFromStr - import key images from string
+    * param: data - exported key images as encrypted hex string
+    * return: true if succeeded, else false
+    * note: sets status error on fail
+    */
+    virtual bool importKeyImagesFromStr(const std::string &data) = 0;
 
     /*!
      * \brief importOutputs - exports outputs to file
@@ -1038,12 +1147,15 @@ struct Wallet
     virtual std::string getReserveProof(bool all, uint32_t account_index, uint64_t amount, const std::string &message) const = 0;
     virtual bool checkReserveProof(const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &total, uint64_t &spent) const = 0;
 
-    /*
-     * \brief signMessage - sign a message with the spend private key
-     * \param message - the message to sign (arbitrary byte data)
-     * \return the signature
-     */
-    virtual std::string signMessage(const std::string &message, const std::string &address = "") = 0;
+    /**
+    * brief: signMessage - sign a message with your private key (SigV2)
+    * param: message - message to sign (arbitrary byte data)
+    * param: address - address used to sign the message (use main address if empty)
+    * param: sign_with_view_key - (default: false, use spend key to sign)
+    * return: proof type prefix + base58 encoded signature, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string signMessage(const std::string &message, const std::string &address = "", bool sign_with_view_key = false) = 0;
     /*!
      * \brief verifySignedMessage - verify a signature matches a given message
      * \param message - the message (arbitrary byte data)
@@ -1130,6 +1242,328 @@ struct Wallet
 
     //! get bytes sent
     virtual uint64_t getBytesSent() = 0;
+
+    /**
+    * brief: getMultisigSeed - get seed for multisig wallet
+    * param: seed_offset - passphrase
+    * return: seed if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string getMultisigSeed(const std::string &seed_offset) const = 0;
+    /**
+    * brief: getSubaddressIndex - get major and minor index of provided subaddress
+    * param: address - main- or sub-address to get the index from
+    * return: [major_index, minor_index] if succeeded
+    * note: sets status error on fail
+    */
+    virtual std::pair<std::uint32_t, std::uint32_t> getSubaddressIndex(const std::string &address) const = 0;
+    /**
+    * brief: freeze - freeze enote "so they don't appear in balance, nor are considered when creating a transaction, etc." (https://github.com/monero-project/monero/pull/5333)
+    * param: key_image - key image of enote
+    * param: public_key - public key of enote
+    * note: sets status error on fail
+    */
+    virtual void freeze(const std::string &key_image) = 0;
+    virtual void freezeByPubKey(const std::string &public_key) = 0;
+    /**
+    * brief: thaw - thaw enote that is frozen, so it appears in balance and can be spent in a transaction
+    * param: key_image - key image of enote
+    * param: public_key - public key of enote
+    * note: sets status error on fail
+    */
+    virtual void thaw(const std::string &key_image) = 0;
+    virtual void thawByPubKey(const std::string &public_key) = 0;
+    /**
+    * brief: isFrozen - check if enote is frozen
+    * param: key_image - key image of enote
+    * param: public_key - public key of enote
+    * return : true if enote is frozen, else false
+    * note: sets status error on fail
+    */
+    virtual bool isFrozen(const std::string &key_image) const = 0;
+    virtual bool isFrozenByPubKey(const std::string &public_key) = 0;
+    /**
+    * brief: createOneOffSubaddress - create a subaddress for given index
+    * param: account_index - major index
+    * param: address_index - minor index
+    */
+    virtual void createOneOffSubaddress(std::uint32_t account_index, std::uint32_t address_index) = 0;
+    /**
+    * brief: getWalletState - get information about the wallet
+    * return: WalletState object
+    */
+    virtual WalletState getWalletState() const = 0;
+    /**
+    * brief: rewriteWalletFile - rewrite the wallet file for wallet update
+    * param: wallet_name - name of the wallet file (should exist)
+    * param: password - wallet password
+    * note: sets status error on fail
+    */
+    virtual void rewriteWalletFile(const std::string &wallet_name, const std::string &password) = 0;
+    /**
+    * brief: writeWatchOnlyWallet -  create a new watch-only wallet file with view keys from current wallet
+    * param: password - password for new watch-only wallet
+    * outparam: new_keys_file_name - wallet_name + "-watchonly.keys"
+    * note: sets status error on fail
+    */
+    virtual void writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name) = 0;
+    /**
+    * brief: refreshPoolOnly - calls wallet2 update_pool_state and process_pool_state
+    * param: refreshed - (default: false)
+    * param: try_incremental - (default: false)
+    * note: sets status error on fail
+    */
+    virtual void refreshPoolOnly(bool refreshed = false, bool try_incremental = false) = 0;
+    /**
+    * brief: getEnoteDetails - get information about all enotes
+    * outparam: enote_details -
+    */
+    virtual void getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const = 0;
+    /**
+    * brief: convertMultisigTxToString - get the encrypted unsigned multisig transaction as hex string from a multisig pending transaction
+    * param: multisig_ptx - multisig pending transaction
+    * return: encrypted tx data as hex string if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const = 0;
+    /**
+    * brief: saveMultisigTx - save a multisig pending transaction to file
+    * param: multisig_ptx - multisig pending transaction
+    * param: filename -
+    * return: true if succeeded
+    * note: sets status error on fail
+    */
+    virtual bool saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const = 0;
+    /**
+    * brief: parseTxFromStr - get transactions from encrypted signed transaction as hex string
+    * param: signed_tx_str -
+    * outparam: ptx -
+    * return: true if succeeded
+    */
+    virtual bool parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const = 0;
+    /**
+    * brief: insertColdKeyImages - remember cold key images for parsed tx, for when we get those txes from the blockchain
+    *                              Call:
+    *                               - parseTxFromStr()
+    *                               - accept_func() (optional)
+    *                               - importKeyImages()
+    *                               - insertColdKeyImages()
+    * param: ptx - PendingTransaction obtained from parseTxFromStr() outparam ptx
+    */
+    virtual void insertColdKeyImages(PendingTransaction &ptx) = 0;
+    /**
+    * brief: parseMultisigTxFromStr - get pending multisig transaction from encrypted unsigned multisig transaction as hex string
+    * param: multisig_tx_str -
+    * outparam: exported_txs -
+    * return: true if succeeded
+    * note: sets status error on fail
+    */
+    virtual bool parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const = 0;
+    /**
+    * brief: getFeeMultiplier -
+    * param: priority -
+    * param: fee_algorithm -
+    * return: fee multiplier
+    * note: sets status error on fail
+    */
+    virtual std::uint64_t getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const = 0;
+    /**
+    * brief: getBaseFee -
+    * return: dynamic base fee estimate if using dynamic fee, else FEE_PER_KB
+    */
+    virtual std::uint64_t getBaseFee() const = 0;
+    /**
+    * brief: adjustPriority - adjust priority depending on how "full" last N blocks are
+    * param: priority -
+    * return: adjusted priority
+    * warning: doesn't tell if it failed
+    */
+    virtual std::uint32_t adjustPriority(std::uint32_t priority) = 0;
+    /**
+    * brief: coldTxAuxImport -
+    * param: ptx -
+    * param: tx_device_aux -
+    * note: sets status error on fail
+    */
+    virtual void coldTxAuxImport(const PendingTransaction &ptx, const std::vector<std::string> &tx_device_aux) const = 0;
+    /**
+    * brief: coldSignTx -
+    * param: ptx_in -
+    * outparam: exported_txs_out -
+    */
+    virtual void coldSignTx(const PendingTransaction &ptx_in, PendingTransaction &exported_txs_out) const = 0;
+    /**
+    * brief: discardUnmixableEnotes - freeze all unmixable enotes
+    * note: sets status error on fail
+    */
+    virtual void discardUnmixableEnotes() = 0;
+    /**
+    * brief: setTxKey - set the transaction key (r) for a given <txid> in case the tx was made by some other device or 3rd party wallet
+    * param: txid -
+    * param: tx_key - secret transaction key r
+    * param: additional_tx_keys -
+    * param: single_destination_subaddress -
+    * note: sets status error on fail
+    */
+    virtual void setTxKey(const std::string &txid, const std::string &tx_key, const std::vector<std::string> &additional_tx_keys, const std::string &single_destination_subaddress) = 0;
+    /**
+    * brief: getAccountTags - get the list of registered account tags
+    * return: first.Key=(tag's name), first.Value=(tag's label), second[i]=(i-th account's tag)
+    */
+    virtual const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& getAccountTags() const = 0;
+    /**
+    * brief: setAccountTag - set a tag to a set of subaddress accounts by index
+    * param: account_index - major index
+    * param: tag -
+    * note: sets status error on fail
+    */
+    virtual void setAccountTag(const std::set<std::uint32_t> &account_indices, const std::string &tag) = 0;
+    /**
+    * brief: setAccountTagDescription - set a description for a tag, tag must already exist
+    * param: tag -
+    * param: description -
+    * note: sets status error on fail
+    */
+    virtual void setAccountTagDescription(const std::string &tag, const std::string &description) = 0;
+    /**
+    * brief: exportEnotesToStr - export enotes and return encrypted data
+    *                            (comparable with legacy exportOutputs(), with the difference that this returns a string, the other one saves to file)
+    * param: all   - go from `start` for `count` enotes if true, else go incremental from last exported enote for `count` enotes (default: false)
+    * param: start - offset index in enote storage, needs to be 0 for incremental mode (default: 0)
+    * param: count - try to export this quantity of enotes (default: 0xffffffff)
+    * return: encrypted data of exported enotes as hex string if succeeded, else empty string
+    * note: sets status error on fail
+    */
+    virtual std::string exportEnotesToStr(bool all = false, std::uint32_t start = 0, std::uint32_t count = 0xffffffff) const = 0;
+    /**
+    * brief: importEnotesFromStr - import enotes from encrypted hex string
+    * param: enotes_str - enotes data as encrypted hex string
+    * return: total size of enote storage
+    * note: sets status error on fail
+    */
+    virtual std::size_t importEnotesFromStr(const std::string &enotes_str) = 0;
+    /**
+    * brief: getBlockchainHeightByDate -
+    * param: year  -
+    * param: month - in range 1-12
+    * param: day   - in range 1-31
+    * return: blockchain height
+    * note: sets status error on fail
+    */
+    virtual std::uint64_t getBlockchainHeightByDate(std::uint16_t year, std::uint8_t month, std::uint8_t day) const = 0;
+    /**
+    * brief: estimateBacklog -
+    * param: fee_levels - [ [fee per byte min, fee per byte max], ... ]
+    * return: [ [number of blocks min, number of blocks max], ... ]
+    * note: sets status error on fail
+    */
+    virtual std::vector<std::pair<std::uint64_t, std::uint64_t>> estimateBacklog(const std::vector<std::pair<double, double>> &fee_levels) const = 0;
+    /**
+    * brief: saveToFile   - save hex string to file
+    * param: path_to_file - file name
+    * param: binary       - hex string data
+    * param: is_printable - (default: false)
+    * return: true if succeeded
+    */
+    virtual bool saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable = false) const = 0;
+    /**
+    * brief: loadFromFile  - load hex string from file
+    * param: path_to_file  - file name
+    * outparam: target_str - hex string data
+    * param: max_size      - maximum size in bytes (default: 1000000000)
+    * return: true if succeeded
+    */
+    virtual bool loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size = 1000000000) const = 0;
+    /**
+    * brief: hashEnotes - get hash of all enotes in local enote store up until `enote_idx`
+    *                     (formerly in wallet2: `uint64_t wallet2::hash_m_transfers(boost::optional<uint64_t> transfer_height, crypto::hash &hash)`)
+    * param: enote_idx - include all enotes below this index
+    * outparam: hash - hash as hex string
+    * return: number of hashed enotes
+    * note: sets status error on fail
+    */
+    virtual std::uint64_t hashEnotes(std::uint64_t enote_idx, std::string &hash) const = 0;
+    /**
+    * brief: finishRescanBcKeepKeyImages  -
+    * param: enote_idx -
+    * param: hash -
+    * note: sets status error on fail
+    */
+    virtual void finishRescanBcKeepKeyImages(std::uint64_t enote_idx, const std::string &hash) = 0;
+    /**
+    * brief: getPublicNodes - get a list of public notes with information when they were last seen
+    * param: white_only - include gray nodes if false (default: true)
+    * return: [ [ host_ip, host_rpc_port, last_seen ], ... ]
+    * note: sets status error on fail
+    */
+    virtual std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> getPublicNodes(bool white_only = true) const = 0;
+    /**
+    * brief: estimateTxSizeAndWeight -
+    * param: use_rct    -
+    * param: n_inputs   - number of input enotes
+    * param: ring_size  -
+    * param: n_outputs  - number of output enotes
+    * param: extra_size - size of tx_extra
+    * return: [estimated tx size, estimated tx weight]
+    * note: sets status error on fail
+    */
+    virtual std::pair<std::size_t, std::uint64_t> estimateTxSizeAndWeight(bool use_rct, int n_inputs, int ring_size, int n_outputs, std::size_t extra_size) const = 0;
+    /**
+    * brief: importKeyImages -
+    * param: signed_key_images - [ [key_image, signature c || signature r], ... ]
+    * param: offset      - offset in local enote storage
+    * outparam: spent    - total spent amount of the wallet
+    * outparam: unspent  - total unspent amount of the wallet
+    * param: check_spent -
+    * return: blockchain height of last signed key image, can be 0 if height unknown
+    * note: sets status error on fail
+    */
+    virtual std::uint64_t importKeyImages(const std::vector<std::pair<std::string, std::string>> &signed_key_images, std::size_t offset, std::uint64_t &spent, std::uint64_t &unspent, bool check_spent = true) = 0;
+    /**
+    * brief: importKeyImages -
+    * param: key_images -
+    * param: offset     - offset in local enote storage
+    * param: selected_enotes_indices -
+    * return: true if succeeded
+    * note: sets status error on fail
+    */
+    virtual bool importKeyImages(const std::vector<std::string> &key_images, std::size_t offset = 0, const std::unordered_set<std::size_t> &selected_enotes_indices = {}) = 0;
+    /**
+    * brief: getAllowMismatchedDaemonVersion -
+    */
+    virtual bool getAllowMismatchedDaemonVersion() const = 0;
+    /**
+    * brief: setAllowMismatchedDaemonVersion -
+    * param: allow_mismatch -
+    */
+    virtual void setAllowMismatchedDaemonVersion(bool allow_mismatch) = 0;
+    /**
+    * brief: setDaemon -
+    * param: daemon_address       -
+    * param: daemon_username      - for daemon login (default: empty string)
+    * param: daemon_password      - for daemon login (default: empty string)
+    * param: trusted_daemon       - (default: false)
+    * param: ssl_support          - "disabled" | "enabled" | "autodetect" (default: "autodetect")
+    * param: ssl_private_key_path - (default: empty string)
+    * param: ssl_certificate_path - (default: empty string)
+    * param: ssl_ca_file_path     - (default: empty string)
+    * param: ssl_allowed_fingerprints_str - (default: empty vector)
+    * param: ssl_allow_any_cert   - (default: false)
+    * param: proxy                - (default: empty string)
+    * return: true if succeeded
+    * note: sets status error on fail
+    */
+    virtual bool setDaemon(const std::string &daemon_address,
+        const std::string &daemon_username = "",
+        const std::string &daemon_password = "",
+        bool trusted_daemon = false,
+        const std::string &ssl_support = "autodetect",
+        const std::string &ssl_private_key_path = "",
+        const std::string &ssl_certificate_path = "",
+        const std::string &ssl_ca_file_path = "",
+        const std::vector<std::string> &ssl_allowed_fingerprints_str = {},
+        bool ssl_allow_any_cert = false,
+        const std::string &proxy = "") = 0;
 };
 
 /**

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -35,12 +35,14 @@
 #include <ctime>
 #include <iostream>
 #include <list>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 
@@ -68,29 +70,64 @@ enum NetworkType : uint8_t {
 */
 struct EnoteDetails
 {
-    enum TxProtocol {
+    enum class TxProtocol {
         TxProtocol_CryptoNote,
         TxProtocol_RingCT
     };
 
     virtual ~EnoteDetails() = 0;
+    //! enote public key (Ko), as hex string
     virtual std::string onetimeAddress() const = 0;
+    //! view tag, as hex string
     virtual std::string viewTag() const = 0;
+    //! payment id, as 16 char (8 bytes, short encrypted) or 64 char (32 bytes, long unencrypted [DEPRECATED]) hex string
+    virtual std::string paymentId() const = 0;
+    //! blockchain height at which this enote was received
     virtual std::uint64_t blockHeight() const = 0;
+    //! when enote will become spendable
+    // NOTE: there was a change in tx relay rule that prevents to make txs with arbitrary lock times: https://github.com/monero-project/monero/pull/9151
+    // txs that were created before the new rule can still be locked, unlockTime() is represented either as block index if unlockTime() < CRYPTONOTE_MAX_BLOCK_NUMBER or else as time
+    // now with the new rule, txs will have this set to either 0 for normal txs
+    //                        or blockHeight() + CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW for coinbase txs
+    // NOTE: if unlockTime() == 0, the blockchain still has to reach blockHeight() + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE before this enote is actually unlocked
+    virtual std::uint64_t unlockTime() const = 0;
+    //! return true if enote is unlocked
+    virtual bool isUnlocked() const = 0;
+    //! tx id, as hex string
     virtual std::string txId() const = 0;
+    //! index in tx
     virtual std::uint64_t internalEnoteIndex() const = 0;
+    //! index in db
     virtual std::uint64_t globalEnoteIndex() const = 0;
+    //! return true if enote is spent
     virtual bool isSpent() const = 0;
+    //! return true if enote is frozen
     virtual bool isFrozen() const = 0;
+    //! blockchain height at which enote was spent, set to 0 if enote hasn't been spent yet
     virtual std::uint64_t spentHeight() const = 0;
+    //! key image, as hex string
     virtual std::string keyImage() const = 0;
+    //! x, blinding factor in amount commitment C = x G + a H, as hex string
     virtual std::string mask() const = 0;
+    //! amount in piconero
     virtual std::uint64_t amount() const = 0;
+    //! protocol version : TxProtocol_CryptoNote / TxProtocol_RingCT
     virtual TxProtocol protocolVersion() const = 0;
+    //! return true if key image is known
     virtual bool isKeyImageKnown() const = 0;
+    //! return true if:
+    //      a) for view wallets: we want to request the key image for this enote
+    //      b) for cold wallets: the key image for this enote was requested
     virtual bool isKeyImageRequest() const = 0;
+    //! public key index in tx_extra
     virtual std::uint64_t pkIndex() const = 0;
+    //! show uses of this enote as decoy in the blockchain in the format [ [block_height, tx_id], ... ]
+    // Note: tracking this is disabled by default, use `Wallet::setTrackUses(true)` to enable tracking
     virtual std::vector<std::pair<std::uint64_t, std::string>> uses() const = 0;
+    //! account index
+    virtual std::uint32_t subaddressIndexMajor() const = 0;
+    //! subaddress index
+    virtual std::uint32_t subaddressIndexMinor() const = 0;
 
     // Multisig
     virtual bool isKeyImagePartial() const = 0;
@@ -108,21 +145,25 @@ struct PendingTransaction
     };
 
     enum Priority {
-        Priority_Default = 0,
-        Priority_Low = 1,
-        Priority_Medium = 2,
-        Priority_High = 3,
+        Priority_Default  = 0,
+        Priority_Low      = 1,  // unimportant
+        Priority_Medium   = 2,  // normal
+        Priority_High     = 3,  // elevated
+        Priority_VeryHigh = 4,  // priority
         Priority_Last
     };
 
     virtual ~PendingTransaction() = 0;
     virtual int status() const = 0;
     virtual std::string errorString() const = 0;
+    virtual std::string confirmationMessage() const = 0;
     // commit transaction or save to file if filename is provided.
     virtual bool commit(const std::string &filename = "", bool overwrite = false) = 0;
     virtual uint64_t amount() const = 0;
     virtual uint64_t dust() const = 0;
+    virtual uint64_t dustInFee() const = 0;
     virtual uint64_t fee() const = 0;
+    virtual uint64_t change() const = 0;
     virtual std::vector<std::string> txid() const = 0;
     /*!
      * \brief txCount - number of transactions current transaction will be split into
@@ -131,6 +172,67 @@ struct PendingTransaction
     virtual uint64_t txCount() const = 0;
     virtual std::vector<uint32_t> subaddrAccount() const = 0;
     virtual std::vector<std::set<uint32_t>> subaddrIndices() const = 0;
+    /**
+    * brief: convertTxToStr - convert `PendingTransaction` to octal escape sequence string of `UnsignedTransaction`
+    *                         encrypted with the wallet's secret view key
+    *                         (same content which would be saved to file with `ptx->commit(filename)`)
+    *                         which then can be read with `loadUnsignedTxFromStr()`
+    * return: unsigned tx data as encrypted octal escape sequence string if succeeded, else empty string
+    * note: sets status error on failure
+    *       - to get a hex string call:
+    *           `epee::string_tools::buff_to_hex_nodelimer(ptx->convertTxToStr())`
+    */
+    virtual std::string convertTxToStr() = 0;
+    /**
+    * brief: convertTxToRawBlobStr - convert each tx in `PendingTransaction` to octal escape sequence string
+    *                                which can be turned into hex string and used as arguments for `tx_as_hex`
+    *                                for daemon RPC `/send_raw_transaction`
+    * return: serialized tx data as octal escape sequence strings if succeeded, else empty vector
+    * note: sets status error on failure
+    *       - to get a hex string call:
+    *           `epee::string_tools::buff_to_hex_nodelimer(ptx->convertTxToRawBlobStr())`
+    */
+    virtual std::vector<std::string> convertTxToRawBlobStr() = 0;
+    /**
+    * brief: getWorstFeePerByte - needed when checking for backlog
+    * return: worst fee per bytes
+    */
+    virtual double getWorstFeePerByte() const = 0;
+    /**
+    * brief: vinOffsets - relative indices + offsets for all real inputs and decoys for each ring and each tx
+    * return: enote indices
+              [ tx_idx : [ ring_idx : [ enote_idx_0 : global_idx, ..., enote_idx_<n_ring_members> : offset  ], ... ], ... ]
+    * note: - there is one ring for each input enote
+    *         enote_idx_0 is the global enote index in the db, every following enote_idx_<n> is the offset from enote_idx_0
+    *       - these indices (after being converted to absolute indices) are used by RPC /get_outs.bin
+    *       - to get the real inputs indices use constructionDataRealOutputIndices()
+    */
+    virtual std::vector<std::vector<std::vector<std::uint64_t>>> vinOffsets() const = 0;
+    /**
+    * brief: constructionDataRealOutputIndices -
+    * return: indices of real input enotes in ring per tx
+    *         [ tx_idx : [ ring_idx : real_input_idx_in_ring , ... ], ... ]
+    */
+    virtual std::vector<std::vector<std::uint64_t>> constructionDataRealOutputIndices() const = 0;
+    /**
+    * brief: vinAmounts -
+    * return: enote amounts
+    */
+    virtual std::vector<std::vector<std::uint64_t>> vinAmounts() const = 0;
+    /**
+    * brief: getEnoteDetailsIn -
+    * return: enote details for all enotes that are used as inputs per tx
+    *         [ tx_idx : [ enote_idx : EnoteDetails, ... ], ... ]
+    */
+    virtual std::vector<std::vector<std::unique_ptr<EnoteDetails>>> getEnoteDetailsIn() const =0;
+    /**
+    * brief: finishParsingTx - remember cold key images for parsed tx, for when we get those txes from the blockchain
+    *                           call this after both:
+    *                            1.) this ptx was created with Wallet::parseTxFromStr()
+    *                            2.) user accepted the ptx->confirmationMessage()
+    * return: true on success
+    */
+    virtual bool finishParsingTx() = 0;
 
     /**
      * @brief multisigSignData
@@ -149,18 +251,23 @@ struct PendingTransaction
      *              pendingTransaction->commit();
      */
     virtual std::string multisigSignData() = 0;
-    virtual void signMultisigTx() = 0;
+    /**
+     * @brief signMultisigTx
+     * @outparam txids - only gets set if multisig tx is fully signed, else empty if partially signed
+     */
+    virtual void signMultisigTx(std::vector<std::string> *txids = nullptr) = 0;
     /**
      * @brief signersKeys
      * @return vector of base58-encoded signers' public keys
      */
     virtual std::vector<std::string> signersKeys() const = 0;
     /**
-    * brief: convertTxToStr - convert PendingTransaction to hex string (same content which would be saved to file with commit(filename))
-    * return: unsigned tx data as encrypted hex string if succeeded, else empty string
-    * note: sets status error on fail
-    */
-    virtual std::string convertTxToStr() = 0;
+     * @brief finishRestoringMultisigTransaction - call this if:
+     *                                               1.) this ptx was created with Wallet::restoreMultisigTransaction(..., ask_for_confirmation = true)
+     *                                             and then
+     *                                               2.) user accepted the ptx->confirmationMessage()
+     */
+    virtual void finishRestoringMultisigTransaction() = 0;
 };
 
 /**
@@ -194,13 +301,17 @@ struct UnsignedTransaction
    /*!
     * @brief sign - Sign txs and saves to file
     * @param signedFileName
+    * @param do_export_raw - export signed transaction as raw unencrypted hex
+    *                        along normal <signedFileName>
+    *                        as "<signedFileName>_raw[_<n_txs>]" (Default: false)
+    * @param tx_ids_out
     * return - true on success
     */
-    virtual bool sign(const std::string &signedFileName) = 0;
+    virtual bool sign(const std::string &signedFileName, bool do_export_raw = false, std::vector<std::string> *tx_ids_out = nullptr) = 0;
     /**
     * brief: signAsString - convert UnsignedTransaction to hex string (same content which would be saved to file with sign(filename))
     * return: signed tx data as encrypted hex string if succeeded, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string signAsString() = 0;
 };
@@ -215,7 +326,7 @@ struct TransactionInfo
         Direction_Out
     };
 
-    enum TxState {
+    enum class TxState {
        TxState_Pending,
        TxState_PendingInPool,
        TxState_Failed,
@@ -235,6 +346,7 @@ struct TransactionInfo
     // legacy : use txState() instead
     virtual bool isFailed() const = 0;
     virtual bool isCoinbase() const = 0;
+    virtual bool isUnlocked() const = 0;
     virtual uint64_t amount() const = 0;
     virtual uint64_t fee() const = 0;
     virtual uint64_t blockHeight() const = 0;
@@ -406,15 +518,21 @@ struct WalletListener
      * @brief moneySpent - called when money spent
      * @param txId       - transaction id
      * @param amount     - amount
+     * @param enote_pub_key - enote public key
+     * @param subaddr_index - accounnt index (major) and subaddress index (minor)
      */
-    virtual void moneySpent(const std::string &txId, uint64_t amount) = 0;
+    virtual void moneySpent(const std::string &txId, uint64_t amount, const std::string &enote_pub_key, std::pair<uint32_t, uint32_t> subaddr_index = {}) = 0;
 
     /**
      * @brief moneyReceived - called when money received
      * @param txId          - transaction id
-     * @param amount        - amount
+     * @param amount        - amount (after subtracting burnt amount)
+     * @param burnt         - amount burnt
+     * @param enote_pub_key - enote public key
+     * @param is_change     - whether output is change
+     * @param is_coinbase   - whether output is coinbase
      */
-    virtual void moneyReceived(const std::string &txId, uint64_t amount) = 0;
+    virtual void moneyReceived(const std::string &txId, uint64_t amount, const uint64_t burnt, const std::string &enote_pub_key, const bool is_change = false, const bool is_coinbase = false) = 0;
     
    /**
     * @brief unconfirmedMoneyReceived - called when payment arrived in tx pool
@@ -488,6 +606,16 @@ struct WalletListener
     virtual void onPoolTxRemoved(const std::string &txid) = 0;
 };
 
+/**
+ * @brief RAII interface for decrypting in-memory wallet spend-keys
+ */
+struct WalletKeysDecryptGuard
+{
+    /**
+     * @brief Re-encrypt spend-keys on destruct unless other WalletKeysDecryptGuard is in scope for same wallet
+     */
+    virtual ~WalletKeysDecryptGuard() = 0;
+};
 
 /**
  * @brief Interface for wallet operations.
@@ -518,17 +646,69 @@ struct Wallet
         BackgroundSync_CustomPassword = 2
     };
 
+    enum class AskPasswordType {
+      AskPassword_Never = 0,
+      AskPassword_OnAction = 1,
+      AskPassword_ToDecrypt = 2,
+    };
+
+    enum class RefreshType {
+      Refresh_Full = 0,
+      Refresh_OptimizeCoinbase = 1,
+      Refresh_NoCoinbase = 2,
+      Refresh_Default = Refresh_OptimizeCoinbase,
+    };
+
+    enum class BackgroundMiningSetupType {
+      BackgroundMining_Maybe = 0,
+      BackgroundMining_Yes = 1,
+      BackgroundMining_No = 2,
+    };
+
+    enum class ExportFormat {
+      ExportFormat_Binary = 0,
+      ExportFormat_Ascii = 1,
+    };
+
+    enum class SSLSupport {
+        SSLSupport_Disabled = 0,
+        SSLSupport_Enabled = 1,
+        SSLSupport_Autodetect = 2,
+    };
+
+    struct DeviceState {
+        enum class DeviceProtocol {
+          DeviceProtocol_Default = 0,
+          DeviceProtocol_Proxy = 1,
+          DeviceProtocol_Cold = 2,
+        };
+        enum class DeviceType {
+          DeviceType_Software = 0,
+          DeviceType_Ledger = 1,
+          DeviceType_Trezor = 2,
+        };
+
+        bool key_on_device;
+        std::string device_name;
+        bool has_tx_cold_sign;
+        bool has_ki_live_refresh;
+        bool has_ki_cold_sync;
+        std::uint64_t last_ki_sync;
+        DeviceProtocol protocol;
+        DeviceType device_type;
+    };
+
     struct WalletState {
         // is wallet file format deprecated
         bool is_deprecated;
-        std::uint64_t ring_size;
+        bool is_unattended;
         std::string daemon_address;
+        std::string ring_database;
+        std::uint64_t n_enotes;
     };
 
     virtual ~Wallet() = 0;
     virtual std::string seed(const std::string& seed_offset = "") const = 0;
-    virtual std::string getSeedLanguage() const = 0;
-    virtual void setSeedLanguage(const std::string &arg) = 0;
     //! returns wallet status (Status_Ok | Status_Error)
     virtual int status() const = 0; //deprecated: use safe alternative statusWithErrorString
     //! in case error status, returns error string
@@ -640,19 +820,6 @@ struct Wallet
     virtual bool createWatchOnly(const std::string &path, const std::string &password, const std::string &language) const = 0;
 
    /*!
-    * \brief setRefreshFromBlockHeight - start refresh from block height on recover
-    *
-    * \param refresh_from_block_height - blockchain start height
-    */
-    virtual void setRefreshFromBlockHeight(uint64_t refresh_from_block_height) = 0;
-
-   /*!
-    * \brief getRestoreHeight - get wallet creation height
-    *
-    */
-    virtual uint64_t getRefreshFromBlockHeight() const = 0;
-
-   /*!
     * \brief setRecoveringFromSeed - set state recover form seed
     *
     * \param recoveringFromSeed - true/false
@@ -666,19 +833,16 @@ struct Wallet
     */
     virtual void setRecoveringFromDevice(bool recoveringFromDevice) = 0;
 
-    /*!
-     * \brief setSubaddressLookahead - set size of subaddress lookahead
-     *
-     * \param major - size for the major index
-     * \param minor - size for the minor index
-     */
-    virtual void setSubaddressLookahead(uint32_t major, uint32_t minor) = 0;
-
     /**
-     * @brief connectToDaemon - connects to the daemon. TODO: check if it can be removed
-     * @return
+     * @brief connectToDaemon - connects to the daemon.
+     * outparam: version -
+     * outparam: ssl -
+     * param: timeout -
+     * outparam: wallet_is_outdated -
+     * outparam: daemon_is_outdated -
+     * @return true if connected to daemon
      */
-    virtual bool connectToDaemon() = 0;
+    virtual bool connectToDaemon(uint32_t *version = NULL, bool *ssl = NULL, uint32_t timeout = 20000, bool *wallet_is_outdated = NULL, bool *daemon_is_outdated = NULL) = 0;
 
     /**
      * @brief connected - checks if the wallet connected to the daemon
@@ -689,13 +853,15 @@ struct Wallet
     virtual bool trustedDaemon() const = 0;
     virtual bool setProxy(const std::string &address) = 0;
     virtual uint64_t balance(uint32_t accountIndex = 0) const = 0;
+    virtual std::map<uint32_t, uint64_t> balancePerSubaddress(uint32_t accountIndex = 0) const = 0;
     uint64_t balanceAll() const {
         uint64_t result = 0;
         for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
             result += balance(i);
         return result;
     }
-    virtual uint64_t unlockedBalance(uint32_t accountIndex = 0) const = 0;
+    virtual uint64_t unlockedBalance(uint32_t accountIndex = 0, uint64_t *blocks_to_unlock = NULL, uint64_t *time_to_unlock = NULL) const = 0;
+    virtual std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> unlockedBalancePerSubaddress(uint32_t accountIndex = 0) const = 0;
     uint64_t unlockedBalanceAll() const {
         uint64_t result = 0;
         for (uint32_t i = 0; i < numSubaddressAccounts(); ++i)
@@ -746,6 +912,8 @@ struct Wallet
      *             status() will return Status_Error and errorString() will return verbose error description
      */
     virtual uint64_t daemonBlockChainTargetHeight() const = 0;
+    //! return: true if daemon is synced
+    virtual bool daemonSynced() const = 0;
 
     /**
      * @brief synchronized - checks if wallet was ever synchronized
@@ -758,6 +926,8 @@ struct Wallet
     static uint64_t amountFromDouble(double amount);
     static std::string genPaymentId();
     static bool paymentIdValid(const std::string &paiment_id);
+    static bool isSubaddress(const std::string &address, NetworkType nettype);
+    static std::string getAddressFromIntegrated(const std::string &address, NetworkType nettype);
     static bool addressValid(const std::string &str, NetworkType nettype);
     static bool addressValid(const std::string &str, bool testnet)          // deprecated
     {
@@ -801,9 +971,20 @@ struct Wallet
 
     /**
      * @brief refresh - refreshes the wallet, updating transactions from daemon
+     * @param start_height          - (Default: 0)
+     * @param check_pool            - wether to also scan tx pool (Default: true)
+     * @param try_incremental       - if daemon supports it, only get txs from the pool which the wallet hasn't seen before (Default: false)
+     * @param max_blocks            - refresh returns when blocks fetched reaches max_blocks (Default: std::numeric_limits<std::uint64_t>::max())
+     * @outparam blocks_fetched_out - number of blocks fetched during refresh (Default: nullptr)
+     * @outparam received_money_out - true if the wallet received money in the blocks fetched during refresh (Default: nullptr)
      * @return - true if refreshed successfully;
      */
-    virtual bool refresh() = 0;
+    virtual bool refresh(std::uint64_t start_height = 0,
+                         bool check_pool = true,
+                         bool try_incremental = false,
+                         std::uint64_t max_blocks = std::numeric_limits<std::uint64_t>::max(),
+                         std::uint64_t *blocks_fetched_out = nullptr,
+                         bool *received_money_out = nullptr) = 0;
 
     /**
      * @brief refreshAsync - refreshes wallet asynchronously.
@@ -812,14 +993,25 @@ struct Wallet
 
     /**
      * @brief rescanBlockchain - rescans the wallet, updating transactions from daemon
+     * @param do_hard_rescan     - if true you will lose any information which can not be recovered from the blockchain itself (Default: true)
+     * @param do_keep_key_images - keep key images, only works with soft rescan,
+     *                             if set `true` you may want to check `hashEnotes()` and `finishRescanBcKeepKeyImages()` for manual control,
+     *                             else set `do_skip_refresh = false` and the two methods get handled automatically by the backend (Default: false)
+     * @param do_skip_refresh    - if true this functions does not call `refresh()` itself,
+     *                             so you have to call it manually and therefore can make use of the outparams (Default: false)
      * @return - true if refreshed successfully;
+     * @note -  do_hard_rescan   do_keep_key_images
+     *          false            false                  soft rescan
+     *          false            true                   soft rescan, keep key images
+     *          true             false                  hard rescan
+     *          true             true                   ERROR: cannot preserve key images on hard rescan
      */
-    virtual bool rescanBlockchain() = 0;
+    virtual bool rescanBlockchain(bool do_hard_rescan = true, bool do_keep_key_images = false, bool do_skip_refresh = false) = 0;
 
     /**
      * @brief rescanBlockchainAsync - rescans wallet asynchronously, starting from genesis
      */
-    virtual void rescanBlockchainAsync() = 0;
+    virtual void rescanBlockchainAsync(bool do_hard_rescan = true, bool do_keep_key_images = false) = 0;
 
     /**
      * @brief setAutoRefreshInterval - setup interval for automatic refresh.
@@ -921,9 +1113,12 @@ struct Wallet
     /**
      * @brief restoreMultisigTransaction creates PendingTransaction from signData
      * @param signData encrypted unsigned transaction. Obtained with PendingTransaction::multisigSignData
+     * @param ask_for_confirmation - if set true the transaction doesn't get fully loaded,
+     *                               in case you want to get a confirmation text from ptx->confirmationMessage()
+     *                               and then, if the user accepts the message, call ptx->finishRestoringMultisigTransaction() to complete loading the tx (Default: false)
      * @return PendingTransaction
      */
-    virtual PendingTransaction*  restoreMultisigTransaction(const std::string& signData) = 0;
+    virtual PendingTransaction*  restoreMultisigTransaction(const std::string& signData, bool ask_for_confirmation = false) = 0;
 
     /*!
      * \brief createTransactionMultDest creates transaction with multiple destinations. if dst_addr is an integrated address, payment_id is ignored
@@ -931,9 +1126,13 @@ struct Wallet
      * \param payment_id                optional payment_id, can be empty string
      * \param amount                    vector of amounts
      * \param mixin_count               mixin count. if 0 passed, wallet will use default value
+     * \param priority                  fee priority, Priority_[Low|Medium|High|VeryHigh] (Default: Priority_Low)
      * \param subaddr_account           subaddress account from which the input funds are taken
      * \param subaddr_indices           set of subaddress indices to use for transfer or sweeping. if set empty, all are chosen when sweeping, and one or more are automatically chosen when transferring. after execution, returns the set of actually used indices
-     * \param priority
+     * \param subtract_fee_from_outputs transfer amount with fee included #8861
+     * \param key_image                 only used for sweep_single (Default: empty string)
+     * \param outputs                   number of outputs to create, only used for sweeping, for normal transactions `outputs` get determined by `dst_addr` (Default: 1)
+     * \param below                     threshold for sweep_below, only used if `amount` is not set (Default: 0)
      * \return                          PendingTransaction object. caller is responsible to check PendingTransaction::status()
      *                                  after object returned
      */
@@ -942,7 +1141,11 @@ struct Wallet
                                                    optional<std::vector<uint64_t>> amount, uint32_t mixin_count,
                                                    PendingTransaction::Priority = PendingTransaction::Priority_Low,
                                                    uint32_t subaddr_account = 0,
-                                                   std::set<uint32_t> subaddr_indices = {}) = 0;
+                                                   std::set<uint32_t> subaddr_indices = {},
+                                                   std::set<uint32_t> subtract_fee_from_outputs = {},
+                                                   const std::string key_image = "",
+                                                   const size_t outputs = 1,
+                                                   const std::uint64_t below = 0) = 0;
 
     /*!
      * \brief createTransaction creates transaction. if dst_addr is an integrated address, payment_id is ignored
@@ -950,9 +1153,9 @@ struct Wallet
      * \param payment_id        optional payment_id, can be empty string
      * \param amount            amount
      * \param mixin_count       mixin count. if 0 passed, wallet will use default value
+     * \param priority          fee priority, Priority_[Low|Medium|High|VeryHigh] (Default: Priority_Low)
      * \param subaddr_account   subaddress account from which the input funds are taken
      * \param subaddr_indices   set of subaddress indices to use for transfer or sweeping. if set empty, all are chosen when sweeping, and one or more are automatically chosen when transferring. after execution, returns the set of actually used indices
-     * \param priority
      * \return                  PendingTransaction object. caller is responsible to check PendingTransaction::status()
      *                          after object returned
      */
@@ -981,13 +1184,19 @@ struct Wallet
     * brief: loadUnsignedTxFromStr - create UnsignedTransaction from unsigned tx string
     * param: unsigned_tx_str - encrypted unsigned tx hex string
     * return: UnsignedTransaction object. caller is responsible to check UnsignedTransaction::status() after object returned
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual UnsignedTransaction * loadUnsignedTxFromStr(const std::string &unsigned_tx_str) = 0;
-    
    /*!
     * \brief submitTransaction - submits transaction in signed tx file
     * \return                  - true on success
+    * \note                    - this submits the transaction without checking the file content and asking for confirmation
+    *                            if you want to get a confirmationMessage before commiting, use:
+    *                               1. loadFromFile(signed_tx_file, signed_tx_str);
+    *                               2. ptx = parseTxFromStr(signed_tx_str);
+    *                               3. if there are no errors and user accepts ptx->confirmationMessage()
+    *                                  ptx->finishParsingTx()
+    *                               4. ptx->commit()
     */
     virtual bool submitTransaction(const std::string &fileName) = 0;
     
@@ -1017,21 +1226,24 @@ struct Wallet
     * brief: exportKeyImagesAsString - export key images as string
     * param: all - export all key images or only those that have not yet been exported
     * return: exported key images as encrypted hex string if succeeded, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string exportKeyImagesAsString(bool all = false) = 0;
    
    /*!
-    * \brief importKeyImages - imports key images from file
+    * \brief importKeyImages  - imports key images from file
     * \param filename
-    * \return                  - true on success
+    * \outparam spent_out     - spent amount in imported key images
+    * \outparam unspent_out   - unspent amount in imported key images
+    * \outparam import_height - height of most recent imported key image
+    * \return                 - true on success
     */
-    virtual bool importKeyImages(const std::string &filename) = 0;
+    virtual bool importKeyImages(const std::string &filename, std::uint64_t *spent_out = nullptr, std::uint64_t *unspent_out = nullptr, std::uint64_t *import_height = nullptr) = 0;
     /**
     * brief: importKeyImagesFromStr - import key images from string
     * param: data - exported key images as encrypted hex string
     * return: true if succeeded, else false
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual bool importKeyImagesFromStr(const std::string &data) = 0;
 
@@ -1052,9 +1264,10 @@ struct Wallet
     /*!
      * \brief scanTransactions - scan a list of transaction ids, this operation may reveal the txids to the remote node and affect your privacy
      * \param txids            - list of transaction ids
+     * \param wont_reprocess_recent_txs_via_untrusted_daemon - allows you to catch the wallet error with the same name (used by CLI to show certain error message)
      * \return                 - true on success
      */
-    virtual bool scanTransactions(const std::vector<std::string> &txids) = 0;
+    virtual bool scanTransactions(const std::vector<std::string> &txids, bool *wont_reprocess_recent_txs_via_untrusted_daemon = nullptr) = 0;
 
     /*!
      * \brief setupBackgroundSync       - setup background sync mode with just a view key
@@ -1153,7 +1366,7 @@ struct Wallet
     * param: address - address used to sign the message (use main address if empty)
     * param: sign_with_view_key - (default: false, use spend key to sign)
     * return: proof type prefix + base58 encoded signature, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string signMessage(const std::string &message, const std::string &address = "", bool sign_with_view_key = false) = 0;
     /*!
@@ -1161,9 +1374,11 @@ struct Wallet
      * \param message - the message (arbitrary byte data)
      * \param address - the address the signature claims to be made with
      * \param signature - the signature
+     * \outparam is_old_out - true if signature uses old format (optional)
+     * \outparam signature_type_out - either signed by: spendkey | viewkey | unkown (suspicious); (optional)
      * \return true if the signature verified, false otherwise
      */
-    virtual bool verifySignedMessage(const std::string &message, const std::string &addres, const std::string &signature) const = 0;
+    virtual bool verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature, bool *is_old_out = nullptr, std::string *signature_type_out = nullptr) const = 0;
 
     /*!
      * \brief signMultisigParticipant   signs given message with the multisig public signer key
@@ -1208,12 +1423,15 @@ struct Wallet
     virtual bool setRing(const std::string &key_image, const std::vector<uint64_t> &ring, bool relative) = 0;
 
     //! sets whether pre-fork outs are to be segregated
+    // DEPRECATED, use setSegregatePreForkOutputs()
     virtual void segregatePreForkOutputs(bool segregate) = 0;
 
     //! sets the height where segregation should occur
+    // DEPRECATED, use setSegregationHeight()
     virtual void segregationHeight(uint64_t height) = 0;
 
     //! secondary key reuse mitigation
+    // DEPRECATED, use setKeyReuseMitigation2()
     virtual void keyReuseMitigation2(bool mitigation) = 0;
 
     //! locks/unlocks the keys file; returns true on success
@@ -1222,13 +1440,20 @@ struct Wallet
     //! returns true if the keys file is locked
     virtual bool isKeysFileLocked() = 0;
 
+    /**
+     * \brief Decrypt spend-keys if not already decrypted and create a keys decryption guard
+     * \param password password to decrypt in-memory spend-keys
+     * \return Keys decryption guard
+     */
+    virtual std::unique_ptr<WalletKeysDecryptGuard> createKeysDecryptGuard(const std::string_view &password) = 0;
+
     /*!
      * \brief Queries backing device for wallet keys
      * \return Device they are on
      */
     virtual Device getDeviceType() const = 0;
 
-    //! cold-device protocol key image sync
+    //! cold-device protocol key image sync, Note: this can throw
     virtual uint64_t coldKeyImageSync(uint64_t &spent, uint64_t &unspent) = 0;
 
     //! shows address on device display
@@ -1247,41 +1472,39 @@ struct Wallet
     * brief: getMultisigSeed - get seed for multisig wallet
     * param: seed_offset - passphrase
     * return: seed if succeeded, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string getMultisigSeed(const std::string &seed_offset) const = 0;
     /**
     * brief: getSubaddressIndex - get major and minor index of provided subaddress
     * param: address - main- or sub-address to get the index from
     * return: [major_index, minor_index] if succeeded
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::pair<std::uint32_t, std::uint32_t> getSubaddressIndex(const std::string &address) const = 0;
     /**
     * brief: freeze - freeze enote "so they don't appear in balance, nor are considered when creating a transaction, etc." (https://github.com/monero-project/monero/pull/5333)
     * param: key_image - key image of enote
-    * param: public_key - public key of enote
-    * note: sets status error on fail
+    * param: enote_pub_key - public key of enote
+    * note: sets status error on failure
     */
     virtual void freeze(const std::string &key_image) = 0;
-    virtual void freezeByPubKey(const std::string &public_key) = 0;
+    virtual void freezeByPubKey(const std::string &enote_pub_key) = 0;
     /**
     * brief: thaw - thaw enote that is frozen, so it appears in balance and can be spent in a transaction
     * param: key_image - key image of enote
-    * param: public_key - public key of enote
-    * note: sets status error on fail
+    * param: enote_pub_key - public key of enote
+    * note: sets status error on failure
     */
     virtual void thaw(const std::string &key_image) = 0;
-    virtual void thawByPubKey(const std::string &public_key) = 0;
+    virtual void thawByPubKey(const std::string &enote_pub_key) = 0;
     /**
     * brief: isFrozen - check if enote is frozen
     * param: key_image - key image of enote
-    * param: public_key - public key of enote
     * return : true if enote is frozen, else false
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual bool isFrozen(const std::string &key_image) const = 0;
-    virtual bool isFrozenByPubKey(const std::string &public_key) = 0;
     /**
     * brief: createOneOffSubaddress - create a subaddress for given index
     * param: account_index - major index
@@ -1294,36 +1517,55 @@ struct Wallet
     */
     virtual WalletState getWalletState() const = 0;
     /**
+    * brief: getDeviceState - get information about the HW device
+    * return: DeviceState object
+    */
+    virtual DeviceState getDeviceState() const = 0;
+    /**
     * brief: rewriteWalletFile - rewrite the wallet file for wallet update
     * param: wallet_name - name of the wallet file (should exist)
     * param: password - wallet password
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
-    virtual void rewriteWalletFile(const std::string &wallet_name, const std::string &password) = 0;
+    virtual void rewriteWalletFile(const std::string &wallet_name, const std::string_view &password) = 0;
     /**
     * brief: writeWatchOnlyWallet -  create a new watch-only wallet file with view keys from current wallet
     * param: password - password for new watch-only wallet
     * outparam: new_keys_file_name - wallet_name + "-watchonly.keys"
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
-    virtual void writeWatchOnlyWallet(const std::string &password, std::string &new_keys_file_name) = 0;
+    virtual void writeWatchOnlyWallet(const std::string_view &password, std::string &new_keys_file_name) = 0;
     /**
     * brief: refreshPoolOnly - calls wallet2 update_pool_state and process_pool_state
     * param: refreshed - (default: false)
     * param: try_incremental - (default: false)
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void refreshPoolOnly(bool refreshed = false, bool try_incremental = false) = 0;
     /**
     * brief: getEnoteDetails - get information about all enotes
-    * outparam: enote_details -
+    * return: vector of enotes details
     */
-    virtual void getEnoteDetails(std::vector<std::unique_ptr<EnoteDetails>> &enote_details) const = 0;
+    virtual std::vector<std::unique_ptr<EnoteDetails>> getEnoteDetails() const = 0;
+    /**
+    * brief: getEnoteDetails - get information about a single enote
+    * param: enote_pub_key - ephemeral public key
+    * return: enote details if succeeded, else nullptr
+    * note: sets status error on failure
+    */
+    virtual std::unique_ptr<EnoteDetails> getEnoteDetails(const std::string &enote_pub_key) const = 0;
+    /**
+    * brief: getEnoteDetails - get information about a single enote
+    * param: enote_index - index of enote in internal storage
+    * return: enote details if succeeded, else nullptr
+    * note: sets status error on failure
+    */
+    virtual std::unique_ptr<EnoteDetails> getEnoteDetails(const std::size_t enote_index) const = 0;
     /**
     * brief: convertMultisigTxToString - get the encrypted unsigned multisig transaction as hex string from a multisig pending transaction
     * param: multisig_ptx - multisig pending transaction
     * return: encrypted tx data as hex string if succeeded, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string convertMultisigTxToStr(const PendingTransaction &multisig_ptx) const = 0;
     /**
@@ -1331,40 +1573,31 @@ struct Wallet
     * param: multisig_ptx - multisig pending transaction
     * param: filename -
     * return: true if succeeded
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual bool saveMultisigTx(const PendingTransaction &multisig_ptx, const std::string &filename) const = 0;
     /**
     * brief: parseTxFromStr - get transactions from encrypted signed transaction as hex string
     * param: signed_tx_str -
-    * outparam: ptx -
-    * return: true if succeeded
+    * return: PendingTransaction object. caller is responsible to check ptx->status()
+    *         and ptx->confirmationMessage() after object returned, and then ptx->finishParsingTx()
+    *         if user accepts confirmationMessage
+    * note: sets status error on failure
     */
-    virtual bool parseTxFromStr(const std::string &signed_tx_str, PendingTransaction &ptx) const = 0;
-    /**
-    * brief: insertColdKeyImages - remember cold key images for parsed tx, for when we get those txes from the blockchain
-    *                              Call:
-    *                               - parseTxFromStr()
-    *                               - accept_func() (optional)
-    *                               - importKeyImages()
-    *                               - insertColdKeyImages()
-    * param: ptx - PendingTransaction obtained from parseTxFromStr() outparam ptx
-    */
-    virtual void insertColdKeyImages(PendingTransaction &ptx) = 0;
+    virtual PendingTransaction* parseTxFromStr(const std::string &signed_tx_str) = 0;
     /**
     * brief: parseMultisigTxFromStr - get pending multisig transaction from encrypted unsigned multisig transaction as hex string
     * param: multisig_tx_str -
-    * outparam: exported_txs -
-    * return: true if succeeded
-    * note: sets status error on fail
+    * return: ptx if succeeded, else nullptr
+    * note: sets status error on failure
     */
-    virtual bool parseMultisigTxFromStr(const std::string &multisig_tx_str, PendingTransaction &exported_txs) const = 0;
+    virtual PendingTransaction* parseMultisigTxFromStr(const std::string &multisig_tx_str) = 0;
     /**
     * brief: getFeeMultiplier -
     * param: priority -
     * param: fee_algorithm -
     * return: fee multiplier
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::uint64_t getFeeMultiplier(std::uint32_t priority, int fee_algorithm) const = 0;
     /**
@@ -1383,7 +1616,7 @@ struct Wallet
     * brief: coldTxAuxImport -
     * param: ptx -
     * param: tx_device_aux -
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void coldTxAuxImport(const PendingTransaction &ptx, const std::vector<std::string> &tx_device_aux) const = 0;
     /**
@@ -1394,7 +1627,7 @@ struct Wallet
     virtual void coldSignTx(const PendingTransaction &ptx_in, PendingTransaction &exported_txs_out) const = 0;
     /**
     * brief: discardUnmixableEnotes - freeze all unmixable enotes
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void discardUnmixableEnotes() = 0;
     /**
@@ -1403,26 +1636,28 @@ struct Wallet
     * param: tx_key - secret transaction key r
     * param: additional_tx_keys -
     * param: single_destination_subaddress -
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void setTxKey(const std::string &txid, const std::string &tx_key, const std::vector<std::string> &additional_tx_keys, const std::string &single_destination_subaddress) = 0;
     /**
-    * brief: getAccountTags - get the list of registered account tags
+    * brief: getAccountTags - get tag description for each tag and tag for each account
+    *                         as map of [tag : tag_description] and list of tag per account
     * return: first.Key=(tag's name), first.Value=(tag's label), second[i]=(i-th account's tag)
     */
     virtual const std::pair<std::map<std::string, std::string>, std::vector<std::string>>& getAccountTags() const = 0;
     /**
-    * brief: setAccountTag - set a tag to a set of subaddress accounts by index
+    * brief: setAccountTag - set a tag to a set of accounts by index
+    *                        one account can have one tag, but one tag can be shared by many accounts
     * param: account_index - major index
     * param: tag -
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void setAccountTag(const std::set<std::uint32_t> &account_indices, const std::string &tag) = 0;
     /**
     * brief: setAccountTagDescription - set a description for a tag, tag must already exist
     * param: tag -
     * param: description -
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual void setAccountTagDescription(const std::string &tag, const std::string &description) = 0;
     /**
@@ -1432,14 +1667,14 @@ struct Wallet
     * param: start - offset index in enote storage, needs to be 0 for incremental mode (default: 0)
     * param: count - try to export this quantity of enotes (default: 0xffffffff)
     * return: encrypted data of exported enotes as hex string if succeeded, else empty string
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::string exportEnotesToStr(bool all = false, std::uint32_t start = 0, std::uint32_t count = 0xffffffff) const = 0;
     /**
     * brief: importEnotesFromStr - import enotes from encrypted hex string
     * param: enotes_str - enotes data as encrypted hex string
     * return: total size of enote storage
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::size_t importEnotesFromStr(const std::string &enotes_str) = 0;
     /**
@@ -1448,53 +1683,46 @@ struct Wallet
     * param: month - in range 1-12
     * param: day   - in range 1-31
     * return: blockchain height
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::uint64_t getBlockchainHeightByDate(std::uint16_t year, std::uint8_t month, std::uint8_t day) const = 0;
     /**
     * brief: estimateBacklog -
     * param: fee_levels - [ [fee per byte min, fee per byte max], ... ]
     * return: [ [number of blocks min, number of blocks max], ... ]
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::vector<std::pair<std::uint64_t, std::uint64_t>> estimateBacklog(const std::vector<std::pair<double, double>> &fee_levels) const = 0;
     /**
-    * brief: saveToFile   - save hex string to file
-    * param: path_to_file - file name
-    * param: binary       - hex string data
-    * param: is_printable - (default: false)
-    * return: true if succeeded
-    */
-    virtual bool saveToFile(const std::string &path_to_file, const std::string &binary, bool is_printable = false) const = 0;
-    /**
-    * brief: loadFromFile  - load hex string from file
-    * param: path_to_file  - file name
-    * outparam: target_str - hex string data
-    * param: max_size      - maximum size in bytes (default: 1000000000)
-    * return: true if succeeded
-    */
-    virtual bool loadFromFile(const std::string &path_to_file, std::string &target_str, std::size_t max_size = 1000000000) const = 0;
-    /**
-    * brief: hashEnotes - get hash of all enotes in local enote store up until `enote_idx`
+    * brief: hashEnotes - only needed before calling `rescanBlockChain(do_hard_rescan=false, do_keep_key_images=true, do_skip_refresh=true)`
+    *                     (with the exact settings from above, or in other words: rescan soft keep key images, skip refresh)
+    *                     get hash of all enotes in local enote store up until, but excluding, `enote_idx`
+    *                     with the information returned by this method, `finishRescanBcKeepKeyImages()` can determine if a BC reorg happened during rescan
+    *                       1. `n_hashed_enotes_pre = hashEnotes(0, hash_pre)`
+    *                       2. `rescanBlockChain(false, true, true)`
+    *                       3. `refresh(start_height, check_pool, try_incremental, max_blocks, fetched_blocks_out, received_money_out)`
+    *                       4. `finishRescanBcKeepKeyImages(n_hashed_enotes_pre, hash_pre)`
     *                     (formerly in wallet2: `uint64_t wallet2::hash_m_transfers(boost::optional<uint64_t> transfer_height, crypto::hash &hash)`)
-    * param: enote_idx - include all enotes below this index
+    * param: enote_idx - include all enotes below this index, if set to 0 it will hash all known enotes, similiar to using `getWalletState().n_enotes`
     * outparam: hash - hash as hex string
     * return: number of hashed enotes
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::uint64_t hashEnotes(std::uint64_t enote_idx, std::string &hash) const = 0;
     /**
-    * brief: finishRescanBcKeepKeyImages  -
-    * param: enote_idx -
-    * param: hash -
-    * note: sets status error on fail
+    * brief: finishRescanBcKeepKeyImages - only needed after calling `rescanBlockChain()` with `do_keep_key_images = true`
+    *                                      restores key images in m_transfers from m_key_images if no BC reorg happpened during rescan
+    *                                      more information in comment for `hashEnotes()`
+    * param: enote_idx - number of hashed enotes returned by `hashEnotes()` before rescan
+    * param: hash - hash returned as outparam by `hashEnotes()` before rescan
+    * note: sets status error on failure
     */
     virtual void finishRescanBcKeepKeyImages(std::uint64_t enote_idx, const std::string &hash) = 0;
     /**
     * brief: getPublicNodes - get a list of public notes with information when they were last seen
     * param: white_only - include gray nodes if false (default: true)
     * return: [ [ host_ip, host_rpc_port, last_seen ], ... ]
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::vector<std::tuple<std::string, std::uint16_t, std::uint64_t>> getPublicNodes(bool white_only = true) const = 0;
     /**
@@ -1505,7 +1733,7 @@ struct Wallet
     * param: n_outputs  - number of output enotes
     * param: extra_size - size of tx_extra
     * return: [estimated tx size, estimated tx weight]
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::pair<std::size_t, std::uint64_t> estimateTxSizeAndWeight(bool use_rct, int n_inputs, int ring_size, int n_outputs, std::size_t extra_size) const = 0;
     /**
@@ -1516,7 +1744,7 @@ struct Wallet
     * outparam: unspent  - total unspent amount of the wallet
     * param: check_spent -
     * return: blockchain height of last signed key image, can be 0 if height unknown
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual std::uint64_t importKeyImages(const std::vector<std::pair<std::string, std::string>> &signed_key_images, std::size_t offset, std::uint64_t &spent, std::uint64_t &unspent, bool check_spent = true) = 0;
     /**
@@ -1525,7 +1753,7 @@ struct Wallet
     * param: offset     - offset in local enote storage
     * param: selected_enotes_indices -
     * return: true if succeeded
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual bool importKeyImages(const std::vector<std::string> &key_images, std::size_t offset = 0, const std::unordered_set<std::size_t> &selected_enotes_indices = {}) = 0;
     /**
@@ -1538,12 +1766,21 @@ struct Wallet
     */
     virtual void setAllowMismatchedDaemonVersion(bool allow_mismatch) = 0;
     /**
+    * brief: getDeviceDerivationPath -
+    */
+    virtual std::string getDeviceDerivationPath() const = 0;
+    /**
+    * brief: setDeviceDerivationPath -
+    * param: device_derivation_path -
+    */
+    virtual void setDeviceDerivationPath(std::string device_derivation_path) = 0;
+    /**
     * brief: setDaemon -
     * param: daemon_address       -
     * param: daemon_username      - for daemon login (default: empty string)
     * param: daemon_password      - for daemon login (default: empty string)
     * param: trusted_daemon       - (default: false)
-    * param: ssl_support          - "disabled" | "enabled" | "autodetect" (default: "autodetect")
+    * param: ssl_support          - SSLSupport_Disabled | SSLSupport_Enabled | SSLSupport_Autodetect (default: SSLSupport_Autodetect)
     * param: ssl_private_key_path - (default: empty string)
     * param: ssl_certificate_path - (default: empty string)
     * param: ssl_ca_file_path     - (default: empty string)
@@ -1551,19 +1788,136 @@ struct Wallet
     * param: ssl_allow_any_cert   - (default: false)
     * param: proxy                - (default: empty string)
     * return: true if succeeded
-    * note: sets status error on fail
+    * note: sets status error on failure
     */
     virtual bool setDaemon(const std::string &daemon_address,
         const std::string &daemon_username = "",
         const std::string &daemon_password = "",
         bool trusted_daemon = false,
-        const std::string &ssl_support = "autodetect",
+        const SSLSupport ssl_support = Wallet::SSLSupport::SSLSupport_Autodetect,
         const std::string &ssl_private_key_path = "",
         const std::string &ssl_certificate_path = "",
         const std::string &ssl_ca_file_path = "",
         const std::vector<std::string> &ssl_allowed_fingerprints_str = {},
         bool ssl_allow_any_cert = false,
         const std::string &proxy = "") = 0;
+    /**
+    * brief: verifyPassword -
+    * param: password   - password to verify
+    * return: true if succeeded
+    * note: sets status error on failure
+    *       This function automatically locks/unlocks the keys file as needed.
+    *       When possible use this instead of WalletManager::verifyWalletPassword()
+    */
+    virtual bool verifyPassword(const std::string_view &password) = 0;
+    /**
+    * brief: encryptKeys - encrypt cached secret keys
+    * param: password    - wallet password
+    */
+    virtual void encryptKeys(const std::string_view &password) = 0;
+    /**
+    * brief: decryptKeys - decrypt cached secret keys
+    * param: password    - wallet password
+    */
+    virtual void decryptKeys(const std::string_view &password) = 0;
+    /**
+    * brief: getMinRingSize -
+    * return: minimal ring size
+    */
+    virtual std::uint64_t getMinRingSize() const = 0;
+    /**
+    * brief: getMaxRingSize -
+    * return: maximal ring size
+    */
+    virtual std::uint64_t getMaxRingSize() const = 0;
+    /**
+    * brief: adjustMixin - clamps fake_outs_count to be in range [min_ring_size, max_ring_size]
+    * param: fake_outs_count - number of decoys to be used in ring
+    * return: adjusted fake_outs_count
+    */
+    virtual std::uint64_t adjustMixin(const std::uint64_t fake_outs_count) const = 0;
+
+    /**
+    * brief: getDaemonAdjustedTime - (see comment in src/cryptonote_core/blockchain.h for get_adjusted_time() for more details about daemon adjusted time)
+    * return: daemon adjusted time
+    * note: sets status error on failure
+    */
+    virtual std::uint64_t getDaemonAdjustedTime() const = 0;
+    // return: last block reward the wallet has whitnessed
+    virtual std::uint64_t getLastBlockReward() const = 0;
+    // return: true if wallet owns enotes with unknown key images
+    virtual bool hasUnknownKeyImages() const = 0;
+
+
+    //! return: true if block height was explicitly set to 0
+    virtual bool getExplicitRefreshFromBlockHeight() const = 0;
+    virtual void setExplicitRefreshFromBlockHeight(bool do_explicit_refresh) = 0;
+
+    // Wallet Settings getter/setter
+    virtual std::string getSeedLanguage() const = 0;
+    // note: sets status error on failure
+    virtual void setSeedLanguage(const std::string &arg) = 0;
+    virtual bool getAlwaysConfirmTransfers() const = 0;
+    virtual void setAlwaysConfirmTransfers(bool do_always_confirm) = 0;
+    virtual bool getPrintRingMembers() const = 0;
+    virtual void setPrintRingMembers(bool do_print_ring_members) = 0;
+    virtual bool getStoreTxInfo() const = 0;
+    virtual void setStoreTxInfo(bool do_store_tx_info) = 0;
+    virtual bool getAutoRefresh() const = 0;
+    virtual void setAutoRefresh(bool do_auto_refresh) = 0;
+    virtual RefreshType getRefreshType() const = 0;
+    virtual void setRefreshType(RefreshType refresh_type) = 0;
+    virtual std::uint32_t getDefaultPriority() const = 0;
+    virtual void setDefaultPriority(std::uint32_t default_priority) = 0;
+    virtual AskPasswordType getAskPasswordType() const = 0;
+    virtual void setAskPasswordType(AskPasswordType ask_password_type) = 0;
+    virtual std::uint64_t getMaxReorgDepth() const = 0;
+    virtual void setMaxReorgDepth(std::uint64_t max_reorg_depth) = 0;
+    virtual std::uint32_t getMinOutputCount() const = 0;
+    virtual void setMinOutputCount(std::uint32_t min_output_count) = 0;
+    virtual std::uint64_t getMinOutputValue() const = 0;
+    virtual void setMinOutputValue(std::uint64_t min_output_value) = 0;
+    virtual bool getMergeDestinations() const = 0;
+    virtual void setMergeDestinations(bool do_merge_destinations) = 0;
+    virtual bool getConfirmBacklog() const = 0;
+    virtual void setConfirmBacklog(bool do_confirm_backlog) = 0;
+    virtual std::uint32_t getConfirmBacklogThreshold() const = 0;
+    virtual void setConfirmBacklogThreshold(std::uint32_t confirm_backlog_threshold) = 0;
+    virtual bool getConfirmExportOverwrite() const = 0;
+    virtual void setConfirmExportOverwrite(bool do_confirm_export_overwrite) = 0;
+    virtual std::uint64_t getRefreshFromBlockHeight() const = 0;
+    // note: sets status error on failure
+    virtual void setRefreshFromBlockHeight(std::uint64_t refresh_from_block_height) = 0;
+    virtual bool getAutoLowPriority() const = 0;
+    virtual void setAutoLowPriority(bool use_auto_low_priority) = 0;
+    virtual bool getSegregatePreForkOutputs() const = 0;
+    virtual void setSegregatePreForkOutputs(bool do_segregate_pre_fork_outputs) = 0;
+    virtual bool getKeyReuseMitigation2() const = 0;
+    virtual void setKeyReuseMitigation2(bool do_key_reuse_mitigation) = 0;
+    virtual std::pair<std::uint32_t, std::uint32_t> getSubaddressLookahead() const = 0;
+    virtual void setSubaddressLookahead(uint32_t major, uint32_t minor) = 0;
+    virtual std::uint64_t getSegregationHeight() const = 0;
+    virtual void setSegregationHeight(std::uint64_t segregation_height) = 0;
+    virtual bool getIgnoreFractionalOutputs() const = 0;
+    virtual void setIgnoreFractionalOutputs(bool do_ignore_fractional_outputs) = 0;
+    virtual std::uint64_t getIgnoreOutputsAbove() const = 0;
+    virtual void setIgnoreOutputsAbove(std::uint64_t ignore_outputs_above) = 0;
+    virtual std::uint64_t getIgnoreOutputsBelow() const = 0;
+    virtual void setIgnoreOutputsBelow(std::uint64_t ignore_outputs_below) = 0;
+    virtual bool getTrackUses() const = 0;
+    virtual void setTrackUses(bool do_track_uses) = 0;
+    virtual BackgroundMiningSetupType getSetupBackgroundMining() const = 0;
+    virtual void setSetupBackgroundMining(BackgroundMiningSetupType background_mining_setup) = 0;
+    virtual std::string getDeviceName() const = 0;
+    virtual void setDeviceName(const std::string &device_name) = 0;
+    virtual ExportFormat getExportFormat() const = 0;
+    virtual void setExportFormat(ExportFormat export_format) = 0;
+    virtual bool getShowWalletNameWhenLocked() const = 0;
+    virtual void setShowWalletNameWhenLocked(bool do_show_wallet_name) = 0;
+    virtual std::uint32_t getInactivityLockTimeout() const = 0;
+    virtual void setInactivityLockTimeout(std::uint32_t seconds) = 0;
+    virtual bool getEnableMultisig() const = 0;
+    virtual void setEnableMultisig(bool do_enable_multisig) = 0;
 };
 
 /**
@@ -1579,9 +1933,14 @@ struct WalletManager
      * \param  language       Language to be used to generate electrum seed mnemonic
      * \param  nettype        Network type
      * \param  kdf_rounds     Number of rounds for key derivation function
+     * \param  create_address_file - Create <wallet_name>.address.txt file (Default: false)
+     *                               NOTE: gets irgnored for stagenet and testnet and will create .address.txt file even if set to false
+     * \param  non_determinisitc - Whether to create a non-deterministic wallet, where the secret-spend-key and secret-view-key are both random and not in relation (Default: false)
+     *                             NOTE: this old way to create keys should not be used, except you have a good reason and you know what you do
+     * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                Wallet instance (Wallet::status() needs to be called to check if created successfully)
      */
-    virtual Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1) = 0;
+    virtual Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, const bool create_address_file = false, const bool non_determinisitc = false, const bool unattended = true) = 0;
     Wallet * createWallet(const std::string &path, const std::string &password, const std::string &language, bool testnet = false)      // deprecated
     {
         return createWallet(path, password, language, testnet ? TESTNET : MAINNET);
@@ -1594,9 +1953,10 @@ struct WalletManager
      * \param  nettype        Network type
      * \param  kdf_rounds     Number of rounds for key derivation function
      * \param  listener       Wallet listener to set to the wallet after creation
+     * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                Wallet instance (Wallet::status() needs to be called to check if opened successfully)
      */
-    virtual Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1, WalletListener * listener = nullptr) = 0;
+    virtual Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1, WalletListener * listener = nullptr, const bool unattended = true) = 0;
     Wallet * openWallet(const std::string &path, const std::string &password, bool testnet = false)     // deprecated
     {
         return openWallet(path, password, testnet ? TESTNET : MAINNET);
@@ -1611,11 +1971,12 @@ struct WalletManager
      * \param  restoreHeight  restore from start height
      * \param  kdf_rounds     Number of rounds for key derivation function
      * \param  seed_offset    Seed offset passphrase (optional)
+     * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
     virtual Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &mnemonic,
                                     NetworkType nettype = MAINNET, uint64_t restoreHeight = 0, uint64_t kdf_rounds = 1,
-                                    const std::string &seed_offset = {}) = 0;
+                                    const std::string &seed_offset = {}, const bool unattended = true) = 0;
     Wallet * recoveryWallet(const std::string &path, const std::string &password, const std::string &mnemonic,
                                     bool testnet = false, uint64_t restoreHeight = 0)           // deprecated
     {
@@ -1648,6 +2009,8 @@ struct WalletManager
      * \param  viewKeyString  view key
      * \param  spendKeyString spend key (optional)
      * \param  kdf_rounds     Number of rounds for key derivation function
+     * \param  create_address_file Whether to create an address file
+     * \param  unattended     Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
     virtual Wallet * createWalletFromKeys(const std::string &path,
@@ -1658,7 +2021,9 @@ struct WalletManager
                                                     const std::string &addressString,
                                                     const std::string &viewKeyString,
                                                     const std::string &spendKeyString = "",
-                                                    uint64_t kdf_rounds = 1) = 0;
+                                                    uint64_t kdf_rounds = 1,
+                                                    const bool create_address_file = false,
+                                                    const bool unattended = true) = 0;
     Wallet * createWalletFromKeys(const std::string &path,
                                   const std::string &password,
                                   const std::string &language,
@@ -1700,6 +2065,61 @@ struct WalletManager
     {
         return createWalletFromKeys(path, language, testnet ? TESTNET : MAINNET, restoreHeight, addressString, viewKeyString, spendKeyString);
     }
+    /**
+    * brief: createWalletFromJson - create a deterministic, non-deterministic or watch-only wallet from a json file
+    * json file fields:
+    *     "version"             :  <json_file_version>,       // [mandatory]    (1 (=current version at time of writing))
+    *     "filename"            : "<wallet_file_name>",       // [mandatory]
+    *     "scan_from_height"    :  <restore_height>,          // [optional]
+    *     "password"            : "<wallet_password>",        // [optional]
+    *     "viewkey"             : "<private_viewkey>",        // [optional]
+    *     "spendkey"            : "<private_spendkey>",       // [optional]
+    *     "seed"                : "<mnemonic_seed_phrase>",   // [optional]
+    *     "seed_passphrase"     : "<seed_offset_passphrase>", // [optional]
+    *     "address"             : "<wallet_main_address>",    // [optional]
+    *     "create_address_file" :  <do_create_address_file>,  // [optional]     (0 (=false) | 1 (=true))
+    *
+    * depending on what type of wallet you want to create you need to specify different combinations of fields:
+    *   "normal" (determ.)  : either `spendkey` or `seed`
+    *   non-deterministic   : `spendkey` and `viewkey`
+    *   watch-only          : `viewkey` and `address`
+    *
+    * param: json_file_path       - path to json file
+    * param: nettype              - network type
+    * outparam: pw_out            - password given by json file, this method sets an empty wallet password if no password is given
+    * param: kdf_rounds           - Number of rounds for key derivation function (Default: 1)
+    * param: unattended           - Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
+    * return:                       Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
+    */
+    virtual Wallet * createWalletFromJson(const std::string &json_file_path,
+                                          NetworkType nettype,
+                                          std::string &pw_out,
+                                          uint64_t kdf_rounds = 1,
+                                          const bool unattended = true) = 0;
+    /**
+    * \brief: createWalletFromMultisigSeed - recovers existing multisig wallet from a multisig seed and optional seed offset passphrase
+    * \param: path                - name of wallet file to be created
+    * \param: password            - password of wallet file
+    * \param: language            - mnemonic seed language
+    * \param: nettype             - network type
+    * \param: restore_height      - restore from start height
+    * \param: multisig_seed       - multisig seed
+    * \param: seed_pass           - seed offset passphrase (Default: "")
+    * \param: kdf_rounds          - Number of rounds for key derivation function (Default: 1)
+    * \param: create_address_file - Whether to create an address file (Default: false)
+    * \param: unattended          - Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
+    * \return:                      Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
+    */
+    virtual Wallet * createWalletFromMultisigSeed(const std::string &path,
+                                                  const std::string &password,
+                                                  const std::string &language,
+                                                  NetworkType nettype,
+                                                  uint64_t restore_height,
+                                                  const std::string &multisig_seed,
+                                                  const std::string seed_pass = "",
+                                                  uint64_t kdf_rounds = 1,
+                                                  const bool create_address_file = false,
+                                                  const bool unattended = true) = 0;
 
     /*!
      * \brief  creates wallet using hardware device.
@@ -1711,6 +2131,9 @@ struct WalletManager
      * \param  subaddressLookahead  Size of subaddress lookahead (empty sets to some default low value)
      * \param  kdf_rounds           Number of rounds for key derivation function
      * \param  listener             Wallet listener to set to the wallet after creation
+     * \param  device_derivation_path
+     * \param  create_address_file  Whether to create an address file
+     * \param  unattended           Whether the wallet is unattended (GUI is unattended, CLI is not unattended) (Default: true)
      * \return                      Wallet instance (Wallet::status() needs to be called to check if recovered successfully)
      */
     virtual Wallet * createWalletFromDevice(const std::string &path,
@@ -1720,14 +2143,17 @@ struct WalletManager
                                             uint64_t restoreHeight = 0,
                                             const std::string &subaddressLookahead = "",
                                             uint64_t kdf_rounds = 1,
-                                            WalletListener * listener = nullptr) = 0;
+                                            WalletListener * listener = nullptr,
+                                            const std::string device_derivation_path = "",
+                                            const bool create_address_file = false,
+                                            const bool unattended = true) = 0;
 
     /*!
      * \brief Closes wallet. In case operation succeeded, wallet object deleted. in case operation failed, wallet object not deleted
      * \param wallet        previously opened / created wallet instance
      * \return              None
      */
-    virtual bool closeWallet(Wallet *wallet, bool store = true) = 0;
+    virtual bool closeWallet(Wallet *wallet, bool store = true, bool do_delete_pointer = true) = 0;
 
     /*
      * ! checks if wallet with the given name already exists
@@ -1797,6 +2223,12 @@ struct WalletManager
     //! returns current block target
     virtual uint64_t blockTarget() = 0;
 
+    //! returns true if bootstrap mode was used by daemon or if bootstrap daemon address is set
+    virtual bool wasBootstrapEverUsed() = 0;
+
+    //! returns true iff backgound mining is enabled
+    virtual bool isBackgroundMiningEnabled() = 0;
+
     //! returns true iff mining
     virtual bool isMining() = 0;
 
@@ -1805,6 +2237,12 @@ struct WalletManager
 
     //! stops mining
     virtual bool stopMining() = 0;
+
+    //! saves the blockchain
+    virtual bool saveBlockchain() = 0;
+
+    //! daemon RPC /get_outs
+    virtual bool getOutsBin(const std::vector<std::pair<std::uint64_t, std::uint64_t>> &output_amount_index, const bool do_get_txid, std::vector<std::string> &enote_public_key_out, std::vector<std::string> &rct_key_mask_out, std::vector<bool> &unlocked_out, std::vector<std::uint64_t> &height_out, std::vector<std::string> &tx_id_out) = 0;
 
     //! resolves an OpenAlias address to a monero address
     virtual std::string resolveOpenAlias(const std::string &address, bool &dnssec_valid) const = 0;

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -37,6 +37,7 @@
 #include "common/dns_utils.h"
 #include "common/util.h"
 #include "common/updates.h"
+#include "crypto/crypto.h"
 #include "version.h"
 #include "net/http_client.h"
 #include <boost/filesystem.hpp>
@@ -73,9 +74,18 @@ Wallet *WalletManagerImpl::createWallet(const std::string &path, const std::stri
                                     const std::string &language, NetworkType nettype, uint64_t kdf_rounds,
                                     const bool create_address_file /* = false */,
                                     const bool non_deterministic /* = false */,
-                                    const bool unattended /* = true */)
+                                    const bool unattended /* = true */,
+                                    const std::string extra_entropy_file /* = "" */)
 {
     WalletImpl * wallet = new WalletImpl(nettype, kdf_rounds, unattended);
+    if (!extra_entropy_file.empty())
+    {
+        std::string data;
+        THROW_WALLET_EXCEPTION_IF(!epee::file_io_utils::load_file_to_string(extra_entropy_file, data),
+                                  tools::error::wallet_internal_error, "Failed to load extra entropy from " + extra_entropy_file);
+        crypto::add_extra_entropy_thread_safe(data.data(), data.size());
+    }
+
     wallet->create(path, password, language, create_address_file, non_deterministic);
     return wallet;
 }
@@ -118,13 +128,14 @@ Wallet *WalletManagerImpl::recoveryWallet(const std::string &path,
                                                 uint64_t restoreHeight,
                                                 uint64_t kdf_rounds,
                                                 const std::string &seed_offset/* = {}*/,
+                                                const bool create_address_file /* = false */,
                                                 const bool unattended /* = true */)
 {
     WalletImpl * wallet = new WalletImpl(nettype, kdf_rounds, unattended);
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
-    wallet->recover(path, password, mnemonic, seed_offset);
+    wallet->recover(path, password, mnemonic, seed_offset, create_address_file);
     return wallet;
 }
 
@@ -144,7 +155,7 @@ Wallet *WalletManagerImpl::createWalletFromKeys(const std::string &path,
     if(restoreHeight > 0){
         wallet->setRefreshFromBlockHeight(restoreHeight);
     }
-    wallet->recoverFromKeysWithPassword(path, password, language, addressString, viewKeyString, spendKeyString);
+    wallet->recoverFromKeysWithPassword(path, password, language, addressString, viewKeyString, spendKeyString, create_address_file);
     return wallet;
 }
 
@@ -208,7 +219,7 @@ Wallet *WalletManagerImpl::createWalletFromDevice(const std::string &path,
     {
         wallet->setSubaddressLookahead(lookahead->first, lookahead->second);
     }
-    wallet->recoverFromDevice(path, password, deviceName);
+    wallet->recoverFromDevice(path, password, deviceName, create_address_file);
     return wallet;
 }
 
@@ -287,9 +298,12 @@ std::string WalletManagerImpl::errorString() const
     return m_errorString;
 }
 
-void WalletManagerImpl::setDaemonAddress(const std::string &address)
+void WalletManagerImpl::setDaemonAddress(const std::string &address, std::pair<std::string, std::string> *daemon_username_password /* = nullptr */)
 {
-    m_http_client.set_server(address, boost::none);
+    boost::optional<epee::net_utils::http::login> daemon_login{boost::none};
+    if (daemon_username_password)
+        daemon_login.emplace(daemon_username_password->first, daemon_username_password->second);
+    m_http_client.set_server(address, daemon_login);
 }
 
 bool WalletManagerImpl::connected(uint32_t *version)
@@ -367,18 +381,6 @@ uint64_t WalletManagerImpl::blockTarget()
     if (!r)
         return 0;
     return ires.target;
-}
-
-bool WalletManagerImpl::wasBootstrapEverUsed()
-{
-    cryptonote::COMMAND_RPC_GET_INFO::request mreq;
-    cryptonote::COMMAND_RPC_GET_INFO::response mres;
-
-    bool r = epee::net_utils::invoke_http_json("/getinfo", mreq, mres, m_http_client);
-    m_errorString = interpret_rpc_response(r, mres.status);
-    if (!r)
-        return false;
-    return (mres.was_bootstrap_ever_used || !mres.bootstrap_daemon_address.empty());
 }
 
 bool WalletManagerImpl::isBackgroundMiningEnabled()

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -39,15 +39,16 @@ class WalletManagerImpl : public WalletManager
 {
 public:
     Wallet * createWallet(const std::string &path, const std::string &password,
-                          const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1) override;
-    Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1, WalletListener * listener = nullptr) override;
+                          const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, bool create_address_file = false, bool non_deterministic = false, bool unattended = true) override;
+    Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1, WalletListener * listener = nullptr, bool unattended = true) override;
     virtual Wallet * recoveryWallet(const std::string &path,
                                        const std::string &password,
                                        const std::string &mnemonic,
                                        NetworkType nettype,
                                        uint64_t restoreHeight,
                                        uint64_t kdf_rounds = 1,
-                                       const std::string &seed_offset = {}) override;
+                                       const std::string &seed_offset = {},
+                                       const bool unattended = true) override;
     virtual Wallet * createWalletFromKeys(const std::string &path,
                                              const std::string &password,
                                              const std::string &language,
@@ -56,7 +57,24 @@ public:
                                              const std::string &addressString,
                                              const std::string &viewKeyString,
                                              const std::string &spendKeyString = "",
-                                             uint64_t kdf_rounds = 1) override;
+                                             uint64_t kdf_rounds = 1,
+                                             const bool create_address_file = false,
+                                             const bool unattended = true) override;
+    Wallet * createWalletFromJson(const std::string &json_file_path,
+                                  NetworkType nettype,
+                                  std::string &pw_out,
+                                  uint64_t kdf_rounds = 1,
+                                  const bool unattended = true) override;
+    Wallet * createWalletFromMultisigSeed(const std::string &path,
+                                          const std::string &password,
+                                          const std::string &language,
+                                          NetworkType nettype,
+                                          uint64_t restoreHeight,
+                                          const std::string &multisig_seed,
+                                          const std::string seed_pass = "",
+                                          uint64_t kdf_rounds = 1,
+                                          const bool create_address_file = false,
+                                          const bool unattended = true) override;
     // next two methods are deprecated - use the above version which allow setting of a password
     virtual Wallet * recoveryWallet(const std::string &path, const std::string &mnemonic, NetworkType nettype, uint64_t restoreHeight) override;
     // deprecated: use createWalletFromKeys(..., password, ...) instead
@@ -74,8 +92,11 @@ public:
                                             uint64_t restoreHeight = 0,
                                             const std::string &subaddressLookahead = "",
                                             uint64_t kdf_rounds = 1,
-                                            WalletListener * listener = nullptr) override;
-    virtual bool closeWallet(Wallet *wallet, bool store = true) override;
+                                            WalletListener * listener = nullptr,
+                                            const std::string device_derivation_path = "",
+                                            const bool create_address_file = false,
+                                            const bool unattended = true) override;
+    virtual bool closeWallet(Wallet *wallet, bool store = true, bool do_delete_pointer = true) override;
     bool walletExists(const std::string &path) override;
     bool verifyWalletPassword(const std::string &keys_file_name, const std::string &password, bool no_spend_key, uint64_t kdf_rounds = 1) const override;
     bool queryWalletDevice(Wallet::Device& device_type, const std::string &keys_file_name, const std::string &password, uint64_t kdf_rounds = 1) const override;
@@ -88,9 +109,13 @@ public:
     uint64_t networkDifficulty() override;
     double miningHashRate() override;
     uint64_t blockTarget() override;
+    bool wasBootstrapEverUsed() override;
+    bool isBackgroundMiningEnabled() override;
     bool isMining() override;
     bool startMining(const std::string &address, uint32_t threads = 1, bool background_mining = false, bool ignore_battery = true) override;
     bool stopMining() override;
+    bool saveBlockchain() override;
+    bool getOutsBin(const std::vector<std::pair<std::uint64_t, std::uint64_t>> &output_amount_index, const bool do_get_txid, std::vector<std::string> &enote_public_key_out, std::vector<std::string> &rct_key_mask_out, std::vector<bool> &unlocked_out, std::vector<std::uint64_t> &height_out, std::vector<std::string> &tx_id_out) override;
     std::string resolveOpenAlias(const std::string &address, bool &dnssec_valid) const override;
     bool setProxy(const std::string &address) override;
 

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -39,7 +39,7 @@ class WalletManagerImpl : public WalletManager
 {
 public:
     Wallet * createWallet(const std::string &path, const std::string &password,
-                          const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, bool create_address_file = false, bool non_deterministic = false, bool unattended = true) override;
+                          const std::string &language, NetworkType nettype, uint64_t kdf_rounds = 1, bool create_address_file = false, bool non_deterministic = false, bool unattended = true, const std::string extra_entropy = "") override;
     Wallet * openWallet(const std::string &path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds = 1, WalletListener * listener = nullptr, bool unattended = true) override;
     virtual Wallet * recoveryWallet(const std::string &path,
                                        const std::string &password,
@@ -48,6 +48,7 @@ public:
                                        uint64_t restoreHeight,
                                        uint64_t kdf_rounds = 1,
                                        const std::string &seed_offset = {},
+                                       const bool create_address_file = false,
                                        const bool unattended = true) override;
     virtual Wallet * createWalletFromKeys(const std::string &path,
                                              const std::string &password,
@@ -102,14 +103,13 @@ public:
     bool queryWalletDevice(Wallet::Device& device_type, const std::string &keys_file_name, const std::string &password, uint64_t kdf_rounds = 1) const override;
     std::vector<std::string> findWallets(const std::string &path) override;
     std::string errorString() const override;
-    void setDaemonAddress(const std::string &address) override;
+    void setDaemonAddress(const std::string &address, std::pair<std::string, std::string> *daemon_username_password = nullptr) override;
     bool connected(uint32_t *version = NULL) override;
     uint64_t blockchainHeight() override;
     uint64_t blockchainTargetHeight() override;
     uint64_t networkDifficulty() override;
     double miningHashRate() override;
     uint64_t blockTarget() override;
-    bool wasBootstrapEverUsed() override;
     bool isBackgroundMiningEnabled() override;
     bool isMining() override;
     bool startMining(const std::string &address, uint32_t threads = 1, bool background_mining = false, bool ignore_battery = true) override;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1159,6 +1159,7 @@ wallet_keys_unlocker::~wallet_keys_unlocker()
     if (--lockers_per_wallet[w_ptr] > 0)
       return; // there are other unlock-ers for this wallet, do nothing for now
     lockers_per_wallet.erase(w_ptr);
+
     w.encrypt_keys(key);
   }
   catch (...)
@@ -2638,7 +2639,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
             }
 	    LOG_PRINT_L0("Received money: " << print_money(td.amount()) << ", with tx: " << txid);
 	    if (!ignore_callbacks && 0 != m_callback)
-	      m_callback->on_money_received(height, txid, tx, td.m_amount, 0, td.m_subaddr_index, payment_id, spends_one_of_ours(tx), td.m_tx.unlock_time);
+	      m_callback->on_money_received(height, txid, tx, td.m_amount, 0, td.m_subaddr_index, payment_id, spends_one_of_ours(tx), td.m_tx.unlock_time, td.get_public_key());
           }
           total_received_1 += amount;
           notify = true;
@@ -2716,7 +2717,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
 
 	    LOG_PRINT_L0("Received money: " << print_money(td.amount()) << ", with tx: " << txid);
 	    if (!ignore_callbacks && 0 != m_callback)
-	      m_callback->on_money_received(height, txid, tx, td.m_amount, burnt, td.m_subaddr_index, payment_id, spends_one_of_ours(tx), td.m_tx.unlock_time);
+	      m_callback->on_money_received(height, txid, tx, td.m_amount, burnt, td.m_subaddr_index, payment_id, spends_one_of_ours(tx), td.m_tx.unlock_time, td.get_public_key());
           }
           total_received_1 += extra_amount;
           notify = true;
@@ -2773,7 +2774,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
       if (!pool)
       {
         if (!ignore_callbacks && 0 != m_callback)
-          m_callback->on_money_spent(height, txid, tx, amount, tx, td.m_subaddr_index);
+          m_callback->on_money_spent(height, txid, tx, amount, tx, td.m_subaddr_index, td.get_public_key());
 
         if (m_background_syncing && m_background_sync_data.txs.find(txid) == m_background_sync_data.txs.end())
         {
@@ -6139,7 +6140,7 @@ std::string wallet2::get_multisig_key_exchange_booster(const epee::wipeable_stri
   CHECK_AND_ASSERT_THROW_MES(kex_messages.size() > 0, "No key exchange messages passed in.");
 
   // decrypt account keys
-  wallet_keys_unlocker unlocker(*this, &password);
+  std::optional<wallet_keys_unlocker> unlocker(std::in_place, *this, &password);
 
   // prepare multisig account
   multisig::multisig_account multisig_account;
@@ -8221,7 +8222,7 @@ bool wallet2::parse_multisig_tx_from_str(std::string multisig_tx_st, multisig_tx
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::load_multisig_tx(cryptonote::blobdata s, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func)
+bool wallet2::load_multisig_tx(cryptonote::blobdata s, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func, bool skip_callback /* = false */)
 {
   if(!parse_multisig_tx_from_str(s, exported_txs))
   {
@@ -8232,30 +8233,18 @@ bool wallet2::load_multisig_tx(cryptonote::blobdata s, multisig_tx_set &exported
   LOG_PRINT_L1("Loaded multisig tx unsigned data from binary: " << exported_txs.m_ptx.size() << " transactions");
   for (auto &ptx: exported_txs.m_ptx) LOG_PRINT_L0(cryptonote::obj_to_json_str(ptx.tx));
 
+  if (skip_callback) return true;
+
   if (accept_func && !accept_func(exported_txs))
   {
     LOG_PRINT_L1("Transactions rejected by callback");
     return false;
   }
-
-  const bool is_signed = exported_txs.m_signers.size() >= m_multisig_threshold;
-  if (is_signed)
-  {
-    for (const auto &ptx: exported_txs.m_ptx)
-    {
-      const crypto::hash txid = get_transaction_hash(ptx.tx);
-      if (store_tx_info())
-      {
-        m_tx_keys[txid] = ptx.tx_key;
-        m_additional_tx_keys[txid] = ptx.additional_tx_keys;
-      }
-    }
-  }
-
+  finish_loading_accepted_multisig_tx(exported_txs);
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::load_multisig_tx_from_file(const std::string &filename, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func)
+bool wallet2::load_multisig_tx_from_file(const std::string &filename, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func, bool skip_callback /* = false */)
 {
   std::string s;
   boost::system::error_code errcode;
@@ -8271,12 +8260,29 @@ bool wallet2::load_multisig_tx_from_file(const std::string &filename, multisig_t
     return false;
   }
 
-  if (!load_multisig_tx(s, exported_txs, accept_func))
+  if (!load_multisig_tx(s, exported_txs, accept_func, skip_callback))
   {
     LOG_PRINT_L0("Failed to parse multisig tx data from " << filename);
     return false;
   }
   return true;
+}
+//----------------------------------------------------------------------------------------------------
+void wallet2::finish_loading_accepted_multisig_tx(multisig_tx_set &exported_txs)
+{
+  const bool is_signed = exported_txs.m_signers.size() >= m_multisig_threshold;
+  if (is_signed)
+  {
+    for (const auto &ptx: exported_txs.m_ptx)
+    {
+      const crypto::hash txid = get_transaction_hash(ptx.tx);
+      if (store_tx_info())
+      {
+        m_tx_keys[txid] = ptx.tx_key;
+        m_additional_tx_keys[txid] = ptx.additional_tx_keys;
+      }
+    }
+  }
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::sign_multisig_tx(multisig_tx_set &exported_txs_inout, std::vector<crypto::hash> &txids)
@@ -13477,7 +13483,7 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
           LOG_PRINT_L0("Spent money: " << print_money(amount) << ", with tx: " << *spent_txid);
           set_spent(it->second, e.block_height);
           if (m_callback)
-            m_callback->on_money_spent(e.block_height, *spent_txid, spent_tx, amount, spent_tx, td.m_subaddr_index);
+            m_callback->on_money_spent(e.block_height, *spent_txid, spent_tx, amount, spent_tx, td.m_subaddr_index, td.get_public_key());
           if (subaddr_account != (uint32_t)-1 && subaddr_account != td.m_subaddr_index.major)
             LOG_PRINT_L0("WARNING: This tx spends outputs received by different subaddress accounts, which isn't supposed to happen");
           subaddr_account = td.m_subaddr_index.major;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2125,6 +2125,13 @@ size_t wallet2::get_transfer_details(const crypto::key_image &ki) const
   CHECK_AND_ASSERT_THROW_MES(false, "Key image not found");
 }
 //----------------------------------------------------------------------------------------------------
+size_t wallet2::get_output_index(const crypto::public_key &pk) const
+{
+  auto search = m_pub_keys.find(pk);
+  CHECK_AND_ASSERT_THROW_MES(search != m_pub_keys.end(), "Public key not found in owned outputs");
+  return search->second;
+}
+//----------------------------------------------------------------------------------------------------
 bool wallet2::frozen(const transfer_details &td) const
 {
   return td.m_frozen;
@@ -8007,7 +8014,7 @@ bool wallet2::load_tx(const std::string &signed_filename, std::vector<tools::wal
   return parse_tx_from_str(s, ptx, accept_func);
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func)
+bool wallet2::parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func, tools::wallet2::signed_tx_set *signed_txs_out /* = nullptr */, bool do_handle_key_images /* = true */)
 {
   std::string s = signed_tx_st;
   signed_tx_set signed_txs;
@@ -8064,17 +8071,29 @@ bool wallet2::parse_tx_from_str(const std::string &signed_tx_st, std::vector<too
     return false;
   }
 
-  // import key images
-  bool r = import_key_images(signed_txs.key_images);
-  if (!r) return false;
+  // `do_handle_key_images = true` was (and is) the default behavior, but for more flexibility in the Wallet API it can be turned off now
+  if (do_handle_key_images)
+  {
+    // import key images
+    bool r = import_key_images(signed_txs.key_images);
+    if (!r) return false;
 
-  // remember key images for this tx, for when we get those txes from the blockchain
-  for (const auto &e: signed_txs.tx_key_images)
-    m_cold_key_images.insert(e);
-
+    // remember key images for this tx, for when we get those txes from the blockchain
+    insert_cold_key_images(signed_txs.tx_key_images);
+  }
   ptx = signed_txs.ptx;
 
+  // Make signed_tx_set available to caller
+  if (signed_txs_out)
+      *signed_txs_out = std::move(signed_txs);
+
   return true;
+}
+//----------------------------------------------------------------------------------------------------
+void wallet2::insert_cold_key_images(std::unordered_map<crypto::public_key, crypto::key_image> &cold_key_images)
+{
+    for (const auto &ki: cold_key_images)
+      m_cold_key_images.insert(ki);
 }
 //----------------------------------------------------------------------------------------------------
 std::string wallet2::save_multisig_tx(multisig_tx_set txs)
@@ -13077,6 +13096,11 @@ crypto::public_key wallet2::get_tx_pub_key_from_received_outs(const tools::walle
 bool wallet2::export_key_images(const std::string &filename, bool all) const
 {
   PERF_TIMER(export_key_images);
+  return save_to_file(filename, export_key_images_to_str(all));
+}
+
+std::string wallet2::export_key_images_to_str(bool all /* = false */) const
+{
   std::pair<uint64_t, std::vector<std::pair<crypto::key_image, crypto::signature>>> ski = export_key_images(all);
   std::string magic(KEY_IMAGE_EXPORT_FILE_MAGIC, strlen(KEY_IMAGE_EXPORT_FILE_MAGIC));
   const cryptonote::account_public_address &keys = get_account().get_keys().m_account_address;
@@ -13100,7 +13124,7 @@ bool wallet2::export_key_images(const std::string &filename, bool all) const
   // encrypt data, keep magic plaintext
   PERF_TIMER(export_key_images_encrypt);
   std::string ciphertext = encrypt_with_view_secret_key(data);
-  return save_to_file(filename, magic + ciphertext);
+  return magic + ciphertext;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -13165,10 +13189,16 @@ uint64_t wallet2::import_key_images(const std::string &filename, uint64_t &spent
 
   THROW_WALLET_EXCEPTION_IF(!r, error::wallet_internal_error, std::string(tr("failed to read file ")) + filename);
 
+  return import_key_images_from_str(data, spent, unspent);
+}
+
+std::uint64_t wallet2::import_key_images_from_str(const std::string &key_images_str, std::uint64_t &spent, std::uint64_t &unspent)
+{
+  std::string data = key_images_str;
   const size_t magiclen = strlen(KEY_IMAGE_EXPORT_FILE_MAGIC);
   if (data.size() < magiclen || memcmp(data.data(), KEY_IMAGE_EXPORT_FILE_MAGIC, magiclen))
   {
-    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Bad key image export file magic in ") + filename);
+    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Bad key image export file magic"));
   }
 
   try
@@ -13178,11 +13208,11 @@ uint64_t wallet2::import_key_images(const std::string &filename, uint64_t &spent
   }
   catch (const std::exception &e)
   {
-    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Failed to decrypt ") + filename + ": " + e.what());
+    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Failed to decrypt: ") + e.what());
   }
 
   const size_t headerlen = 4 + 2 * sizeof(crypto::public_key);
-  THROW_WALLET_EXCEPTION_IF(data.size() < headerlen, error::wallet_internal_error, std::string("Bad data size from file ") + filename);
+  THROW_WALLET_EXCEPTION_IF(data.size() < headerlen, error::wallet_internal_error, std::string("Bad data size from file "));
   const uint32_t offset = (uint8_t)data[0] | (((uint8_t)data[1]) << 8) | (((uint8_t)data[2]) << 16) | (((uint8_t)data[3]) << 24);
   crypto::public_key public_spend_key, public_view_key;
   memcpy(&public_spend_key, &data[4], sizeof(public_spend_key));
@@ -13190,13 +13220,13 @@ uint64_t wallet2::import_key_images(const std::string &filename, uint64_t &spent
   const cryptonote::account_public_address &keys = get_account().get_keys().m_account_address;
   if (public_spend_key != keys.m_spend_public_key || public_view_key != keys.m_view_public_key)
   {
-    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string( "Key images from ") + filename + " are for a different account");
+    THROW_WALLET_EXCEPTION(error::wallet_internal_error, std::string("Key images are for a different account"));
   }
   THROW_WALLET_EXCEPTION_IF(offset > m_transfers.size(), error::wallet_internal_error, "Offset larger than known outputs");
 
   const size_t record_size = sizeof(crypto::key_image) + sizeof(crypto::signature);
   THROW_WALLET_EXCEPTION_IF((data.size() - headerlen) % record_size,
-      error::wallet_internal_error, std::string("Bad data size from file ") + filename);
+      error::wallet_internal_error, std::string("Bad data size "));
   size_t nki = (data.size() - headerlen) / record_size;
 
   std::vector<std::pair<crypto::key_image, crypto::signature>> ski;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -113,7 +113,7 @@ private:
     wallet_keys_unlocker(wallet2 &w, const epee::wipeable_string *password);
     ~wallet_keys_unlocker();
   private:
-    wallet2 &w;
+    tools::wallet2 &w;
     bool should_relock;
     crypto::chacha_key key;
     static boost::mutex lockers_lock;
@@ -126,9 +126,9 @@ private:
     // Full wallet callbacks
     virtual void on_new_block(uint64_t height, const cryptonote::block& block) {}
     virtual void on_reorg(uint64_t height, uint64_t blocks_detached, size_t transfers_detached) {}
-    virtual void on_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, uint64_t burnt, const cryptonote::subaddress_index& subaddr_index, const crypto::hash &payment_id, bool is_change, uint64_t unlock_time) {}
+    virtual void on_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, uint64_t burnt, const cryptonote::subaddress_index& subaddr_index, const crypto::hash &payment_id, bool is_change, uint64_t unlock_time, const crypto::public_key& enote_pub_key) {}
     virtual void on_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, const cryptonote::subaddress_index& subaddr_index) {}
-    virtual void on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx, uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index) {}
+    virtual void on_money_spent(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& in_tx, uint64_t amount, const cryptonote::transaction& spend_tx, const cryptonote::subaddress_index& subaddr_index, const crypto::public_key& enote_pub_key) {}
     virtual void on_skip_transaction(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx) {}
     virtual boost::optional<epee::wipeable_string> on_get_password(const char *reason) { return boost::none; }
     // Device callbacks
@@ -904,7 +904,8 @@ private:
     bool load_unsigned_tx(const std::string &unsigned_filename, unsigned_tx_set &exported_txs) const;
     bool parse_unsigned_tx_from_str(const std::string &unsigned_tx_st, unsigned_tx_set &exported_txs) const;
     bool load_tx(const std::string &signed_filename, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set&)> accept_func = NULL);
-    bool parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func);
+    bool parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func, tools::wallet2::signed_tx_set *signed_txs_out = nullptr, bool do_handle_key_images = true );
+    void insert_cold_key_images(std::unordered_map<crypto::public_key, crypto::key_image> &cold_key_images);
     std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs = {});     // pass subaddr_indices by value on purpose
     std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices);
     std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra);
@@ -915,8 +916,11 @@ private:
     uint64_t cold_key_image_sync(uint64_t &spent, uint64_t &unspent);
     void device_show_address(uint32_t account_index, uint32_t address_index, const boost::optional<crypto::hash8> &payment_id);
     bool parse_multisig_tx_from_str(std::string multisig_tx_st, multisig_tx_set &exported_txs) const;
-    bool load_multisig_tx(cryptonote::blobdata blob, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func = NULL);
-    bool load_multisig_tx_from_file(const std::string &filename, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func = NULL);
+    // skip_callback = true allows the Wallet API to use it's own confirmation mechanism
+    bool load_multisig_tx(cryptonote::blobdata blob, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func = NULL, bool skip_callback = false);
+    bool load_multisig_tx_from_file(const std::string &filename, multisig_tx_set &exported_txs, std::function<bool(const multisig_tx_set&)> accept_func = NULL, bool skip_callback = false);
+    // call this after load_multisig_tx*(..., skip_callback = true), when loading the tx was accepted
+    void finish_loading_accepted_multisig_tx(multisig_tx_set &exported_txs);
     bool sign_multisig_tx_from_file(const std::string &filename, std::vector<crypto::hash> &txids, std::function<bool(const multisig_tx_set&)> accept_func);
     bool sign_multisig_tx(multisig_tx_set &exported_txs_inout, std::vector<crypto::hash> &txids);
     bool sign_multisig_tx_to_file(multisig_tx_set &exported_txs, const std::string &filename, std::vector<crypto::hash> &txids);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1248,6 +1248,8 @@ private:
     uint64_t get_num_rct_outputs();
     size_t get_num_transfer_details() const { return m_transfers.size(); }
     const transfer_details &get_transfer_details(size_t idx) const;
+    // similar to get_transfer_details(ki) below, but uses outputs pubkey instead of key image and this method is public
+    size_t get_output_index(const crypto::public_key &pk) const;
 
     uint8_t get_current_hard_fork();
     void get_hard_fork_info(uint8_t version, uint64_t &earliest_height);
@@ -1336,8 +1338,10 @@ private:
     std::tuple<size_t, crypto::hash, std::vector<crypto::hash>> export_blockchain() const;
     void import_blockchain(const std::tuple<size_t, crypto::hash, std::vector<crypto::hash>> &bc);
     bool export_key_images(const std::string &filename, bool all = false) const;
+    std::string export_key_images_to_str(bool all = false) const;
     std::pair<uint64_t, std::vector<std::pair<crypto::key_image, crypto::signature>>> export_key_images(bool all = false) const;
     uint64_t import_key_images(const std::vector<std::pair<crypto::key_image, crypto::signature>> &signed_key_images, size_t offset, uint64_t &spent, uint64_t &unspent, bool check_spent = true);
+    std::uint64_t import_key_images_from_str(const std::string &key_images_str, std::uint64_t &spent, std::uint64_t &unspent);
     uint64_t import_key_images(const std::string &filename, uint64_t &spent, uint64_t &unspent);
     bool import_key_images(std::vector<crypto::key_image> key_images, size_t offset=0, boost::optional<std::unordered_set<size_t>> selected_transfers=boost::none);
     bool import_key_images(signed_tx_set & signed_tx, size_t offset=0, bool only_selected_transfers=false);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -46,13 +46,13 @@
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_basic/account.h"
 #include "multisig/multisig.h"
+#include "net/parse.h"
 #include "wallet_rpc_server_commands_defs.h"
 #include "string_coding.h"
 #include "string_tools.h"
 #include "crypto/hash.h"
 #include "mnemonics/electrum-words.h"
 #include "rpc/rpc_args.h"
-#include "rpc/core_rpc_server_commands_defs.h"
 #include "daemonizer/daemonizer.h"
 #include "fee_priority.h"
 
@@ -65,7 +65,7 @@
 #define CHECK_MULTISIG_ENABLED() \
   do \
   { \
-    if (m_wallet->get_multisig_status().multisig_is_active && !m_wallet->is_multisig_enabled()) \
+    if (m_wallet_impl->multisig().isMultisig && !m_wallet_impl->getEnableMultisig()) \
     { \
       er.code = WALLET_RPC_ERROR_CODE_DISABLED; \
       er.message = "This wallet is multisig, and multisig is disabled. Multisig is an experimental feature and may have bugs. Things that could go wrong include: funds sent to a multisig wallet can't be spent at all, can only be spent with the participation of a malicious group member, or can be stolen by a malicious group member. You can enable it by running this once in monero-wallet-cli: set enable-multisig-experimental 1"; \
@@ -88,14 +88,14 @@
       er.message = "Command unavailable in restricted mode."; \
       return false; \
     } \
-    if (!m_wallet) { return not_open(er); } \
-    if (m_wallet->is_background_wallet()) \
+    if (!m_wallet_impl) { return not_open(er); } \
+    if (m_wallet_impl->isBackgroundWallet()) \
     { \
       er.code = WALLET_RPC_ERROR_CODE_IS_BACKGROUND_WALLET; \
       er.message = "This command is disabled for background wallets."; \
       return false; \
     } \
-    if (m_wallet->is_background_syncing()) \
+    if (m_wallet_impl->isBackgroundSyncing()) \
     { \
       er.code = WALLET_RPC_ERROR_CODE_IS_BACKGROUND_SYNCING; \
       er.message = "This command is disabled while background syncing. Stop background syncing to use this command."; \
@@ -112,20 +112,20 @@
       er.message = "Command unavailable in restricted mode."; \
       return false; \
     } \
-    if (!m_wallet) { return not_open(er); } \
-    if (m_wallet->key_on_device()) \
+    if (!m_wallet_impl) { return not_open(er); } \
+    if (m_wallet_impl->getDeviceState().key_on_device) \
     { \
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR; \
       er.message = "Command not supported by HW wallet"; \
       return false; \
     } \
-    if (m_wallet->get_multisig_status().multisig_is_active) \
+    if (m_wallet_impl->multisig().isMultisig) \
     { \
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR; \
       er.message = "Multisig wallet cannot enable background sync"; \
       return false; \
     } \
-    if (m_wallet->watch_only()) \
+    if (m_wallet_impl->watchOnly()) \
     { \
       er.code = WALLET_RPC_ERROR_CODE_WATCH_ONLY; \
       er.message = "Watch-only wallet cannot enable background sync"; \
@@ -147,6 +147,32 @@ namespace
   const command_line::arg_descriptor<std::size_t> arg_rpc_max_connections_per_private_ip = {"rpc-max-connections-per-private-ip", "Max RPC connections per private and localhost IP permitted", DEFAULT_RPC_MAX_CONNECTIONS_PER_PRIVATE_IP};
   const command_line::arg_descriptor<std::size_t> arg_rpc_max_connections = {"rpc-max-connections", "Max RPC connections permitted", DEFAULT_RPC_MAX_CONNECTIONS};
   const command_line::arg_descriptor<std::size_t> arg_rpc_response_soft_limit = {"rpc-response-soft-limit", "Max response bytes that can be queued, enforced at next response attempt", DEFAULT_RPC_SOFT_LIMIT_SIZE};
+  const command_line::arg_descriptor<std::string> arg_daemon_address = {"daemon-address", tr("Use daemon instance at <host>:<port>"), ""};
+  const command_line::arg_descriptor<std::string> arg_daemon_host = {"daemon-host", tr("Use daemon instance at host <arg> instead of localhost"), ""};
+  const command_line::arg_descriptor<std::string> arg_proxy = {"proxy", tr("[<ip>:]<port> socks proxy to use for daemon connections"), {}, true};
+  const command_line::arg_descriptor<bool> arg_trusted_daemon = {"trusted-daemon", tr("Enable commands which rely on a trusted daemon"), false};
+  const command_line::arg_descriptor<bool> arg_untrusted_daemon = {"untrusted-daemon", tr("Disable commands which rely on a trusted daemon"), false};
+  const command_line::arg_descriptor<std::string> arg_password = {"password", tr("Wallet password (escape/quote as needed)"), "", true};
+  const command_line::arg_descriptor<std::string> arg_password_file = wallet_args::arg_password_file();
+  const command_line::arg_descriptor<int> arg_daemon_port = {"daemon-port", tr("Use daemon instance at port <arg> instead of 18081"), 0};
+  const command_line::arg_descriptor<std::string> arg_daemon_login = {"daemon-login", tr("Specify username[:password] for daemon RPC client"), "", true};
+  const command_line::arg_descriptor<std::string> arg_daemon_ssl = {"daemon-ssl", tr("Enable SSL on daemon RPC connections: enabled|disabled|autodetect"), "autodetect"};
+  const command_line::arg_descriptor<std::string> arg_daemon_ssl_private_key = {"daemon-ssl-private-key", tr("Path to a PEM format private key"), ""};
+  const command_line::arg_descriptor<std::string> arg_daemon_ssl_certificate = {"daemon-ssl-certificate", tr("Path to a PEM format certificate"), ""};
+  const command_line::arg_descriptor<std::string> arg_daemon_ssl_ca_certificates = {"daemon-ssl-ca-certificates", tr("Path to file containing concatenated PEM format certificate(s) to replace system CA(s).")};
+  const command_line::arg_descriptor<std::vector<std::string>> arg_daemon_ssl_allowed_fingerprints = {"daemon-ssl-allowed-fingerprints", tr("List of valid fingerprints of allowed RPC servers")};
+  const command_line::arg_descriptor<bool> arg_daemon_ssl_allow_any_cert = {"daemon-ssl-allow-any-cert", tr("Allow any SSL certificate from the daemon"), false};
+  const command_line::arg_descriptor<bool> arg_daemon_ssl_allow_chained = {"daemon-ssl-allow-chained", tr("Allow user (via --daemon-ssl-ca-certificates) chain certificates"), false};
+  const command_line::arg_descriptor<bool> arg_allow_mismatched_daemon_version = {"allow-mismatched-daemon-version", tr("Allow communicating with a daemon that uses a different version"), false};
+  const command_line::arg_descriptor<bool> arg_testnet = {"testnet", tr("For testnet. Daemon must also be launched with --testnet flag"), false};
+  const command_line::arg_descriptor<bool> arg_stagenet = {"stagenet", tr("For stagenet. Daemon must also be launched with --stagenet flag"), false};
+  const command_line::arg_descriptor<uint64_t> arg_kdf_rounds = {"kdf-rounds", tr("Number of rounds for the key derivation function"), 1};
+  const command_line::arg_descriptor<std::string> arg_hw_device = {"hw-device", tr("HW device to use"), ""};
+  const command_line::arg_descriptor<std::string> arg_hw_device_derivation_path = {"hw-device-deriv-path", tr("HW device wallet derivation path (e.g., SLIP-10)"), ""};
+  const command_line::arg_descriptor<std::string> arg_tx_notify = { "tx-notify" , tr("Run a program for each new incoming transaction, '%s' will be replaced by the transaction hash") , "" };
+  const command_line::arg_descriptor<bool> arg_offline = {"offline", tr("Do not connect to a daemon, nor use DNS"), false};
+  const command_line::arg_descriptor<std::string> arg_extra_entropy = {"extra-entropy", tr("File containing extra entropy to initialize the PRNG (any data, aim for 256 bits of entropy to be useful, which typically means more than 256 bits of data)")};
+
 
   constexpr const char default_rpc_username[] = "monero";
 
@@ -184,6 +210,287 @@ namespace
         entry.suggested_confirmations_threshold = std::max(entry.suggested_confirmations_threshold, (unlock_time - now + DIFFICULTY_TARGET_V2 - 1) / DIFFICULTY_TARGET_V2);
     }
   }
+  //------------------------------------------------------------------------------------------------------------------------------
+  bool get_nettype(const boost::program_options::variables_map &vm, NetworkType &nettype_out)
+  {
+    bool is_testnet = command_line::has_arg(vm, arg_testnet);
+    bool is_stagenet = command_line::has_arg(vm, arg_stagenet);
+    if (is_testnet && is_stagenet)
+    {
+      MERROR(tr("Can't specify more than one of --testnet and --stagenet"));
+      return false;
+    }
+    nettype_out = is_testnet ? NetworkType::TESTNET :
+                  is_stagenet ? NetworkType::STAGENET :
+                  NetworkType::MAINNET;
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  // get password for creating/opening a wallet file on wallet-rpc startup, from either:
+  //    --password, --password-file, or --prompt-for-password
+  epee::wipeable_string get_password(const boost::program_options::variables_map& vm, const char *prompt, bool verify)
+  {
+    epee::wipeable_string pw_out;
+    const bool is_pw_defaulted = !command_line::has_arg(vm, arg_password);
+    const bool is_pw_file_defaulted = command_line::is_arg_defaulted(vm, arg_password_file);
+    const bool prompt_for_password = command_line::get_arg(vm, arg_prompt_for_password);
+    const auto pw_arg = is_pw_defaulted ? "" : command_line::get_arg(vm, arg_password);
+    const auto password_file = command_line::get_arg(vm, arg_password_file);
+
+    if (!is_pw_defaulted + !is_pw_file_defaulted + prompt_for_password != 1)
+      THROW_WALLET_EXCEPTION(tools::error::wallet_internal_error, tools::wallet_rpc_server::tr("need to specify exactly one of --prompt-for-password, --password or --password-file"));
+
+    // --password
+    if (!is_pw_defaulted)
+      pw_out = epee::wipeable_string(pw_arg.data(), pw_arg.size());
+    // --password-file
+    else if (!is_pw_file_defaulted)
+    {
+      std::string tmp_pw;
+      bool r = epee::file_io_utils::load_file_to_string(password_file, tmp_pw);
+      THROW_WALLET_EXCEPTION_IF(!r, tools::error::file_read_error, tools::wallet_rpc_server::tr("the password file specified could not be read"));
+
+      // Remove line breaks the user might have inserted
+      boost::trim_right_if(tmp_pw, boost::is_any_of("\r\n"));
+      const epee::scope_guard tmp_pw_scope_exit_handler([&](){
+        memwipe(&tmp_pw[0], tmp_pw.size());
+      });
+      pw_out = epee::wipeable_string(tmp_pw.data(), tmp_pw.size());
+    }
+    // --prompt-for-password
+    else
+    {
+      const auto pwd_container = password_prompter(prompt, verify);
+      pw_out = pwd_container->password();
+    }
+
+    return pw_out;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  // handle command line arguments, similar to make_basic() in wallet2.cpp
+  bool get_daemon_address(const boost::program_options::variables_map &vm, std::string &daemon_address, std::string &daemon_username, std::string &daemon_password)
+  {
+    daemon_address = command_line::get_arg(vm, arg_daemon_address);
+    auto daemon_host = command_line::get_arg(vm, arg_daemon_host);
+    auto daemon_port = command_line::get_arg(vm, arg_daemon_port);
+
+    THROW_WALLET_EXCEPTION_IF(!daemon_address.empty() && !daemon_host.empty() && 0 != daemon_port,
+        tools::error::wallet_internal_error, tr("can't specify daemon host or port more than once"));
+
+    if (daemon_host.empty())
+      daemon_host = "localhost";
+
+    if (!daemon_port)
+    {
+      NetworkType nettype;
+      if (!get_nettype(vm, nettype))
+        return false;
+      daemon_port = get_config(static_cast<cryptonote::network_type>(nettype)).RPC_DEFAULT_PORT;
+    }
+
+    if (daemon_address.empty())
+      daemon_address = std::string("http://") + daemon_host + ":" + std::to_string(daemon_port);
+
+    if (command_line::has_arg(vm, arg_daemon_login))
+    {
+      std::function<boost::optional<tools::password_container>(const char *, bool)> pw_prompter = password_prompter;
+      auto parsed = tools::login::parse(
+        command_line::get_arg(vm, arg_daemon_login), false, [pw_prompter](bool verify) {
+          if (!pw_prompter)
+          {
+            MERROR("Password needed without prompt function");
+            return boost::optional<tools::password_container>();
+          }
+          return pw_prompter("Daemon client password", verify);
+        }
+      );
+      if (!parsed)
+        return false;
+
+      daemon_username = std::move(parsed->username);
+      epee::wipeable_string daemon_pw = std::move(parsed->password).password();
+      daemon_password = std::string(daemon_pw.data(), daemon_pw.size());
+    }
+
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  // handle command line arguments, similar to make_basic() in wallet2.cpp
+  bool get_daemon_init_settings(const boost::program_options::variables_map &vm,
+                                std::string &daemon_address,
+                                std::string &daemon_username,
+                                std::string &daemon_password,
+                                boost::optional<bool> &trusted_daemon,
+                                Monero::Wallet::SSLSupport &ssl_support,
+                                std::string &ssl_private_key_path,
+                                std::string &ssl_certificate_path,
+                                std::string &ssl_ca_file_path,
+                                std::vector<std::string> &ssl_allowed_fingerprints_str,
+                                bool &ssl_allow_any_cert,
+                                std::string &proxy)
+  {
+    if (!get_daemon_address(vm, daemon_address, daemon_username, daemon_password))
+      return false;
+
+    std::string ssl_support_str = command_line::get_arg(vm, arg_daemon_ssl);
+    ssl_private_key_path = command_line::get_arg(vm, arg_daemon_ssl_private_key);
+    ssl_certificate_path = command_line::get_arg(vm, arg_daemon_ssl_certificate);
+    ssl_ca_file_path     = command_line::get_arg(vm, arg_daemon_ssl_ca_certificates);
+    ssl_allowed_fingerprints_str = command_line::get_arg(vm, arg_daemon_ssl_allowed_fingerprints);
+    ssl_allow_any_cert   = command_line::get_arg(vm, arg_daemon_ssl_allow_any_cert);
+
+    const bool use_proxy = command_line::has_arg(vm, arg_proxy);
+
+    // user specified CA file or fingeprints implies enabled SSL by default
+    epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
+    if (ssl_allow_any_cert)
+      ssl_options.verification = epee::net_utils::ssl_verification_t::none;
+    else if (!ssl_ca_file_path.empty() || !ssl_allowed_fingerprints_str.empty())
+    {
+      std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints{ ssl_allowed_fingerprints_str.size() };
+      std::transform(ssl_allowed_fingerprints_str.begin(), ssl_allowed_fingerprints_str.end(), ssl_allowed_fingerprints.begin(), epee::from_hex_locale::to_vector);
+      for (const auto &fpr: ssl_allowed_fingerprints)
+      {
+        THROW_WALLET_EXCEPTION_IF(fpr.size() != SSL_FINGERPRINT_SIZE, tools::error::wallet_internal_error,
+            "SHA-256 fingerprint should be " BOOST_PP_STRINGIZE(SSL_FINGERPRINT_SIZE) " bytes long.");
+      }
+
+      ssl_options = epee::net_utils::ssl_options_t{
+        std::move(ssl_allowed_fingerprints), std::move(ssl_ca_file_path)
+      };
+
+      if (command_line::get_arg(vm, arg_daemon_ssl_allow_chained))
+        ssl_options.verification = epee::net_utils::ssl_verification_t::user_ca;
+    }
+
+    if (ssl_options.verification != epee::net_utils::ssl_verification_t::user_certificates || !command_line::is_arg_defaulted(vm, arg_daemon_ssl))
+    {
+      THROW_WALLET_EXCEPTION_IF(!epee::net_utils::ssl_support_from_string(ssl_options.support, ssl_support_str), tools::error::wallet_internal_error,
+         tr("Invalid argument for ") + std::string(arg_daemon_ssl.name));
+      ssl_support = static_cast<Wallet::SSLSupport>(ssl_options.support);
+    }
+
+    ssl_options.auth = epee::net_utils::ssl_authentication_t{
+      std::move(ssl_private_key_path), std::move(ssl_certificate_path)
+    };
+
+    {
+      const boost::string_ref real_daemon = boost::string_ref{daemon_address}.substr(0, daemon_address.rfind(':'));
+
+      // If SSL or proxy is enabled, then a specific cert, CA or fingerprint must
+      // be specified. This is specific to the wallet.
+      const bool verification_required =
+        ssl_options.verification != epee::net_utils::ssl_verification_t::none &&
+        (ssl_options.support == epee::net_utils::ssl_support_t::e_ssl_support_enabled || use_proxy);
+
+      THROW_WALLET_EXCEPTION_IF(
+        verification_required && !ssl_options.has_strong_verification(real_daemon),
+        tools::error::wallet_internal_error,
+        tr("Enabling --") + std::string{use_proxy ? arg_proxy.name : arg_daemon_ssl.name} + tr(" requires --") +
+          arg_daemon_ssl_allow_any_cert.name + tr(" or --") +
+          arg_daemon_ssl_ca_certificates.name + tr(" or --") + arg_daemon_ssl_allowed_fingerprints.name + tr(" or use of a .onion/.i2p domain")
+      );
+    }
+
+    if (use_proxy)
+    {
+      proxy = command_line::get_arg(vm, arg_proxy);
+      THROW_WALLET_EXCEPTION_IF(
+        !net::get_tcp_endpoint(proxy),
+        tools::error::wallet_internal_error,
+        std::string{"Invalid address specified for --"} + arg_proxy.name);
+    }
+
+    if (!command_line::is_arg_defaulted(vm, arg_trusted_daemon) || !command_line::is_arg_defaulted(vm, arg_untrusted_daemon))
+      trusted_daemon = command_line::get_arg(vm, arg_trusted_daemon) && !command_line::get_arg(vm, arg_untrusted_daemon);
+    THROW_WALLET_EXCEPTION_IF(!command_line::is_arg_defaulted(vm, arg_trusted_daemon) && !command_line::is_arg_defaulted(vm, arg_untrusted_daemon),
+      tools::error::wallet_internal_error, tr("--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted"));
+
+    // set --trusted-daemon if local and not overridden
+    if (!trusted_daemon)
+    {
+      try
+      {
+        trusted_daemon = false;
+        if (tools::is_local_address(daemon_address))
+        {
+          MINFO(tr("Daemon is local, assuming trusted"));
+          trusted_daemon = true;
+        }
+      }
+      catch (const std::exception &e) { }
+    }
+
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  // handle command line arguments, similar to make_basic() in wallet2.cpp
+  bool init_wallet(const boost::program_options::variables_map &vm, std::unique_ptr<Wallet> &wal, std::unique_ptr<WalletManager> &wallet_manager)
+  {
+    std::string daemon_address, daemon_username, daemon_password;
+    boost::optional<bool> is_trusted_daemon;
+    Monero::Wallet::SSLSupport ssl_support = Wallet::SSLSupport::SSLSupport_Autodetect;
+    std::string ssl_private_key_path, ssl_certificate_path, ssl_ca_file_path;
+    std::vector<std::string> ssl_allowed_fingerprints_str;
+    bool ssl_allow_any_cert = false;
+    std::string proxy;
+    try {
+      get_daemon_init_settings(vm,
+                               daemon_address,
+                               daemon_username,
+                               daemon_password,
+                               is_trusted_daemon,
+                               ssl_support,
+                               ssl_private_key_path,
+                               ssl_certificate_path,
+                               ssl_ca_file_path,
+                               ssl_allowed_fingerprints_str,
+                               ssl_allow_any_cert,
+                               proxy);
+    }
+    catch (const std::exception &e) {
+      MERROR(tr("failed to initialize wallet: ") << e.what());
+      return false;
+    }
+
+    if (command_line::get_arg(vm, arg_offline))
+      wal->setOffline(true);
+
+    const std::string tx_notify = command_line::get_arg(vm, arg_tx_notify);
+    if (!tx_notify.empty())
+      wal->setTxNotify(tx_notify);
+
+    const std::string hw_device_name = command_line::get_arg(vm, arg_hw_device);
+    if (!hw_device_name.empty())
+      wal->setDeviceName(hw_device_name);
+    const std::string device_derivation_path = command_line::get_arg(vm, arg_hw_device_derivation_path);
+    if (!device_derivation_path.empty())
+      wal->setDeviceDerivationPath(device_derivation_path);
+
+    if (command_line::get_arg(vm, arg_allow_mismatched_daemon_version))
+      wal->setAllowMismatchedDaemonVersion(true);
+
+    std::pair<std::string, std::string> daemon_login = std::make_pair(daemon_username, daemon_password);
+    wallet_manager->setDaemonAddress(daemon_address, daemon_username.empty() ? nullptr : &daemon_login);
+    wal->init(daemon_address,
+              /* upper_transaction_size_limit */ 0,
+              daemon_username,
+              daemon_password,
+              /* use_ssl */ false,
+              /* lightWallet */ false);
+
+    return wal->setDaemon(daemon_address,
+                          daemon_username,
+                          daemon_password,
+                          is_trusted_daemon ? *is_trusted_daemon : false,
+                          ssl_support,
+                          ssl_private_key_path,
+                          ssl_certificate_path,
+                          ssl_ca_file_path,
+                          ssl_allowed_fingerprints_str,
+                          ssl_allow_any_cert,
+                          proxy);
+  }
 }
 
 namespace tools
@@ -194,20 +501,15 @@ namespace tools
   }
 
   //------------------------------------------------------------------------------------------------------------------------------
-  wallet_rpc_server::wallet_rpc_server():m_wallet(NULL), rpc_login_file(), m_stop(false), m_restricted(false), m_vm(NULL)
+  wallet_rpc_server::wallet_rpc_server():rpc_login_file(), m_stop(false), m_restricted(false), m_vm(NULL)
   {
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  wallet_rpc_server::~wallet_rpc_server()
-  {
-    if (m_wallet)
-      delete m_wallet;
-  }
+  void wallet_rpc_server::set_wallet(Wallet *cr)
+  { m_wallet_impl.reset(cr); }
   //------------------------------------------------------------------------------------------------------------------------------
-  void wallet_rpc_server::set_wallet(wallet2 *cr)
-  {
-    m_wallet = cr;
-  }
+  void wallet_rpc_server::set_wallet_manager(WalletManager *wallet_manager)
+  { m_wallet_manager.reset(wallet_manager); }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::run()
   {
@@ -235,18 +537,27 @@ namespace tools
         return true;
 
       uint64_t blocks_fetched = 0;
-      bool refresh_success = false;
+      bool refresh_success = !m_wallet_impl;
       const auto start = std::chrono::steady_clock::now();
 
-      try
+      bool received_money = false;
+      if (m_wallet_impl)
       {
-        bool received_money = false;
-        if (m_wallet) m_wallet->refresh(m_wallet->is_trusted_daemon(), 0, blocks_fetched, received_money, true, true, REFRESH_INDICATIVE_BLOCK_CHUNK_SIZE);
-        refresh_success = true;
-      }
-      catch (const std::exception& ex)
-      {
-        LOG_ERROR("Exception at while refreshing, what=" << ex.what());
+        if (m_wallet_impl->refresh(/* start_height */ 0,
+            /* check_pool */ true,
+            /* try_incremental */ true,
+            REFRESH_INDICATIVE_BLOCK_CHUNK_SIZE,
+            /* skip_refresh_if_daemon_not_synced */ false,
+            &blocks_fetched,
+            &received_money))
+          refresh_success = true;
+        else
+        {
+          int error_code;
+          std::string error_msg;
+          m_wallet_impl->statusWithErrorString(error_code, error_msg);
+          LOG_ERROR("Error while refreshing, what=" << error_msg);
+        }
       }
 
       const auto end = std::chrono::steady_clock::now();
@@ -295,12 +606,18 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   void wallet_rpc_server::stop()
   {
-    if (m_wallet)
+    if (m_wallet_impl)
     {
-      m_wallet->store();
-      m_wallet->deinit();
-      delete m_wallet;
-      m_wallet = NULL;
+      m_wallet_impl->stop();
+
+      if (!m_wallet_manager->closeWallet(m_wallet_impl.get(), /* store */ true, /* do_delete_pointer */ false))
+      {
+        MERROR(tr("failed to deinitialize wallet"));
+        std::string error_msg = m_wallet_manager->errorString();
+        if (!error_msg.empty())
+          MERROR(error_msg);
+      }
+
     }
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -424,37 +741,34 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   void wallet_rpc_server::check_background_mining()
   {
-    if (!m_wallet)
+    if (!m_wallet_impl)
       return;
     // Background mining can be toggled from the main wallet
-    if (m_wallet->is_background_wallet() || m_wallet->is_background_syncing())
+    if (m_wallet_impl->isBackgroundWallet() || m_wallet_impl->isBackgroundSyncing())
       return;
 
-    tools::wallet2::BackgroundMiningSetupType setup = m_wallet->setup_background_mining();
-    if (setup == tools::wallet2::BackgroundMiningNo)
+    Wallet::BackgroundMiningSetupType setup = m_wallet_impl->getSetupBackgroundMining();
+    if (setup == Wallet::BackgroundMiningSetupType::BackgroundMining_No)
     {
       MLOG_RED(el::Level::Warning, "Background mining not enabled. Run \"set setup-background-mining 1\" in monero-wallet-cli to change.");
       return;
     }
 
-    if (!m_wallet->is_trusted_daemon())
+    if (!m_wallet_impl->trustedDaemon())
     {
       MDEBUG("Using an untrusted daemon, skipping background mining check");
       return;
     }
 
-    cryptonote::COMMAND_RPC_MINING_STATUS::request req;
-    cryptonote::COMMAND_RPC_MINING_STATUS::response res;
-    bool r = m_wallet->invoke_http_json("/mining_status", req, res);
-    if (!r || res.status != CORE_RPC_STATUS_OK)
+    if (m_wallet_manager->isMining() || m_wallet_manager->isBackgroundMiningEnabled())
+        return;
+    else if (!m_wallet_manager->errorString().empty())
     {
-      MERROR("Failed to query mining status: " << (r ? res.status : "No connection to daemon"));
+      MERROR("Failed to query mining status: " << m_wallet_manager->errorString());
       return;
     }
-    if (res.active || res.is_background_mining_enabled)
-      return;
 
-    if (setup == tools::wallet2::BackgroundMiningMaybe)
+    if (setup == Wallet::BackgroundMiningSetupType::BackgroundMining_Maybe)
     {
       MINFO("The daemon is not set up to background mine.");
       MINFO("With background mining enabled, the daemon will mine when idle and not on battery.");
@@ -463,16 +777,13 @@ namespace tools
       return;
     }
 
-    cryptonote::COMMAND_RPC_START_MINING::request req2;
-    cryptonote::COMMAND_RPC_START_MINING::response res2;
-    req2.miner_address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-    req2.threads_count = 1;
-    req2.do_background_mining = true;
-    req2.ignore_battery = false;
-    r = m_wallet->invoke_http_json("/start_mining", req2, res);
-    if (!r || res2.status != CORE_RPC_STATUS_OK)
+    if (!m_wallet_manager->startMining(m_wallet_impl->address(),
+                                       /* threads */ 1,
+                                       /* background_mining */ true,
+                                       /* ignore_battery */ false))
     {
-      MERROR("Failed to setup background mining: " << (r ? res.status : "No connection to daemon"));
+      std::string err = m_wallet_manager->errorString();
+      MERROR("Failed to setup background mining: " << (!err.empty() ? err : "No connection to daemon"));
       return;
     }
 
@@ -486,135 +797,67 @@ namespace tools
       return false;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  void wallet_rpc_server::fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const crypto::hash &txid, const crypto::hash &payment_id, const tools::wallet2::payment_details &pd) const
+  void wallet_rpc_server::fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const TransactionInfo &tx_info)
   {
-    entry.txid = string_tools::pod_to_hex(pd.m_tx_hash);
-    entry.payment_id = string_tools::pod_to_hex(payment_id);
+    entry.txid = tx_info.hash();
+    entry.payment_id = tx_info.paymentId();
     if (entry.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
       entry.payment_id = entry.payment_id.substr(0,16);
-    entry.height = pd.m_block_height;
-    entry.timestamp = pd.m_timestamp;
-    entry.amount = pd.m_amount;
-    entry.amounts = pd.m_amounts;
-    entry.unlock_time = pd.m_unlock_time;
-    entry.locked = !m_wallet->is_transfer_unlocked(pd.m_unlock_time, pd.m_block_height);
-    entry.fee = pd.m_fee;
-    entry.note = m_wallet->get_tx_note(pd.m_tx_hash);
-    entry.type = pd.m_coinbase ? "block" : "in";
-    entry.subaddr_index = pd.m_subaddr_index;
-    entry.subaddr_indices.push_back(pd.m_subaddr_index);
-    entry.address = m_wallet->get_subaddress_as_str(pd.m_subaddr_index);
-    set_confirmations(entry, m_wallet->get_blockchain_current_height(), m_wallet->get_last_block_reward(), pd.m_unlock_time);
-  }
-  //------------------------------------------------------------------------------------------------------------------------------
-  void wallet_rpc_server::fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const crypto::hash &txid, const tools::wallet2::confirmed_transfer_details &pd) const
-  {
-    entry.txid = string_tools::pod_to_hex(txid);
-    entry.payment_id = string_tools::pod_to_hex(pd.m_payment_id);
-    if (entry.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
-      entry.payment_id = entry.payment_id.substr(0,16);
-    entry.height = pd.m_block_height;
-    entry.timestamp = pd.m_timestamp;
-    entry.unlock_time = pd.m_unlock_time;
-    entry.locked = !m_wallet->is_transfer_unlocked(pd.m_unlock_time, pd.m_block_height);
-    entry.fee = pd.m_amount_in - pd.m_amount_out;
-    uint64_t change = pd.m_change == (uint64_t)-1 ? 0 : pd.m_change; // change may not be known
-    entry.amount = pd.m_amount_in - change - entry.fee;
-    entry.note = m_wallet->get_tx_note(txid);
-
-    for (const auto &d: pd.m_dests) {
-      entry.destinations.push_back(wallet_rpc::transfer_destination());
-      wallet_rpc::transfer_destination &td = entry.destinations.back();
-      td.amount = d.amount;
-      td.address = d.address(m_wallet->nettype(), pd.m_payment_id);
+    entry.height = tx_info.blockHeight();
+    entry.timestamp = tx_info.timestamp();
+    entry.amount = tx_info.amount();
+    if (tx_info.direction() == TransactionInfo::Direction_In) {
+      const auto eds = m_wallet_impl->getEnoteDetails();
+      for (const auto &ed : eds) {
+        if (ed->txId() == tx_info.hash())
+          entry.amounts.push_back(ed->amount());
+      }
+      entry.subaddr_index = { tx_info.subaddrAccount(), *tx_info.subaddrIndex().begin() };
+      entry.type = tx_info.isPending() ? "pool" : tx_info.isCoinbase() ? "block" : "in";
     }
-
-    entry.type = "out";
-    entry.subaddr_index = { pd.m_subaddr_account, 0 };
-    for (uint32_t i: pd.m_subaddr_indices)
-      entry.subaddr_indices.push_back({pd.m_subaddr_account, i});
-    entry.address = m_wallet->get_subaddress_as_str({pd.m_subaddr_account, 0});
-    set_confirmations(entry, m_wallet->get_blockchain_current_height(), m_wallet->get_last_block_reward(), pd.m_unlock_time);
-  }
-  //------------------------------------------------------------------------------------------------------------------------------
-  void wallet_rpc_server::fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const crypto::hash &txid, const tools::wallet2::unconfirmed_transfer_details &pd) const
-  {
-    bool is_failed = pd.m_state == tools::wallet2::unconfirmed_transfer_details::failed;
-    entry.txid = string_tools::pod_to_hex(txid);
-    entry.payment_id = string_tools::pod_to_hex(pd.m_payment_id);
-    if (entry.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
-      entry.payment_id = entry.payment_id.substr(0,16);
-    entry.height = 0;
-    entry.timestamp = pd.m_timestamp;
-    entry.fee = pd.m_amount_in - pd.m_amount_out;
-    entry.amount = pd.m_amount_in - pd.m_change - entry.fee;
-    entry.unlock_time = pd.m_tx.unlock_time;
-    entry.locked = true;
-    entry.note = m_wallet->get_tx_note(txid);
-
-    for (const auto &d: pd.m_dests) {
-      entry.destinations.push_back(wallet_rpc::transfer_destination());
-      wallet_rpc::transfer_destination &td = entry.destinations.back();
-      td.amount = d.amount;
-      td.address = d.address(m_wallet->nettype(), pd.m_payment_id);
+    else if (tx_info.direction() == TransactionInfo::Direction_Out) {
+      for (const auto &t: tx_info.transfers()) {
+        entry.destinations.push_back(wallet_rpc::transfer_destination());
+        wallet_rpc::transfer_destination &td = entry.destinations.back();
+        td.amount = t.amount;
+        td.address = t.address;
+      }
+      entry.type = tx_info.isPending() ? "pending" : tx_info.isFailed() ? "failed" : "out";
     }
-
-    entry.type = is_failed ? "failed" : "pending";
-    entry.subaddr_index = { pd.m_subaddr_account, 0 };
-    for (uint32_t i: pd.m_subaddr_indices)
-      entry.subaddr_indices.push_back({pd.m_subaddr_account, i});
-    entry.address = m_wallet->get_subaddress_as_str({pd.m_subaddr_account, 0});
-    set_confirmations(entry, m_wallet->get_blockchain_current_height(), m_wallet->get_last_block_reward(), pd.m_tx.unlock_time);
-  }
-  //------------------------------------------------------------------------------------------------------------------------------
-  void wallet_rpc_server::fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const crypto::hash &payment_id, const tools::wallet2::pool_payment_details &ppd) const
-  {
-    const tools::wallet2::payment_details &pd = ppd.m_pd;
-    entry.txid = string_tools::pod_to_hex(pd.m_tx_hash);
-    entry.payment_id = string_tools::pod_to_hex(payment_id);
-    if (entry.payment_id.substr(16).find_first_not_of('0') == std::string::npos)
-      entry.payment_id = entry.payment_id.substr(0,16);
-    entry.height = 0;
-    entry.timestamp = pd.m_timestamp;
-    entry.amount = pd.m_amount;
-    entry.amounts = pd.m_amounts;
-    entry.unlock_time = pd.m_unlock_time;
-    entry.locked = true;
-    entry.fee = pd.m_fee;
-    entry.note = m_wallet->get_tx_note(pd.m_tx_hash);
-    entry.double_spend_seen = ppd.m_double_spend_seen;
-    entry.type = "pool";
-    entry.subaddr_index = pd.m_subaddr_index;
-    entry.subaddr_indices.push_back(pd.m_subaddr_index);
-    entry.address = m_wallet->get_subaddress_as_str(pd.m_subaddr_index);
-    set_confirmations(entry, m_wallet->get_blockchain_current_height(), m_wallet->get_last_block_reward(), pd.m_unlock_time);
+    for (uint32_t i: tx_info.subaddrIndex())
+      entry.subaddr_indices.push_back({ tx_info.subaddrAccount(), i });
+    entry.unlock_time = tx_info.unlockTime();
+    entry.locked = !tx_info.isUnlocked();
+    entry.fee = tx_info.fee();
+    entry.note = tx_info.description();
+    entry.address = m_wallet_impl->address(tx_info.subaddrAccount(), *tx_info.subaddrIndex().begin());
+    set_confirmations(entry, m_wallet_impl->blockChainHeight(), m_wallet_impl->getLastBlockReward(), tx_info.unlockTime());
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_getbalance(const wallet_rpc::COMMAND_RPC_GET_BALANCE::request& req, wallet_rpc::COMMAND_RPC_GET_BALANCE::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     try
     {
-      res.balance = req.all_accounts ? m_wallet->balance_all(req.strict) : m_wallet->balance(req.account_index, req.strict);
-      res.unlocked_balance = req.all_accounts ? m_wallet->unlocked_balance_all(req.strict, &res.blocks_to_unlock, &res.time_to_unlock) : m_wallet->unlocked_balance(req.account_index, req.strict, &res.blocks_to_unlock, &res.time_to_unlock);
-      res.multisig_import_needed = m_wallet->get_multisig_status().multisig_is_active && m_wallet->has_multisig_partial_key_images();
+      res.balance = req.all_accounts ? m_wallet_impl->balanceAll(req.strict) : m_wallet_impl->balance(req.account_index, req.strict);
+      res.unlocked_balance = req.all_accounts ? m_wallet_impl->unlockedBalanceAll(&res.blocks_to_unlock, &res.time_to_unlock, req.strict) : m_wallet_impl->unlockedBalance(req.account_index, &res.blocks_to_unlock, &res.time_to_unlock, req.strict);
+      res.multisig_import_needed = m_wallet_impl->multisig().isMultisig && m_wallet_impl->hasMultisigPartialKeyImages();
       std::map<uint32_t, std::map<uint32_t, uint64_t>> balance_per_subaddress_per_account;
       std::map<uint32_t, std::map<uint32_t, std::pair<uint64_t, std::pair<uint64_t, uint64_t>>>> unlocked_balance_per_subaddress_per_account;
       if (req.all_accounts)
       {
-        for (uint32_t account_index = 0; account_index < m_wallet->get_num_subaddress_accounts(); ++account_index)
+        for (uint32_t account_index = 0; account_index < m_wallet_impl->numSubaddressAccounts(); ++account_index)
         {
-          balance_per_subaddress_per_account[account_index] = m_wallet->balance_per_subaddress(account_index, req.strict);
-          unlocked_balance_per_subaddress_per_account[account_index] = m_wallet->unlocked_balance_per_subaddress(account_index, req.strict);
+          balance_per_subaddress_per_account[account_index] = m_wallet_impl->balancePerSubaddress(account_index, req.strict);
+          unlocked_balance_per_subaddress_per_account[account_index] = m_wallet_impl->unlockedBalancePerSubaddress(account_index, req.strict);
         }
       }
       else
       {
-        balance_per_subaddress_per_account[req.account_index] = m_wallet->balance_per_subaddress(req.account_index, req.strict);
-        unlocked_balance_per_subaddress_per_account[req.account_index] = m_wallet->unlocked_balance_per_subaddress(req.account_index, req.strict);
+        balance_per_subaddress_per_account[req.account_index] = m_wallet_impl->balancePerSubaddress(req.account_index, req.strict);
+        unlocked_balance_per_subaddress_per_account[req.account_index] = m_wallet_impl->unlockedBalancePerSubaddress(req.account_index, req.strict);
       }
-      std::vector<tools::wallet2::transfer_details> transfers;
-      m_wallet->get_transfers(transfers);
+      std::vector<std::unique_ptr<EnoteDetails>> eds = m_wallet_impl->getEnoteDetails();
       for (const auto& p : balance_per_subaddress_per_account)
       {
         uint32_t account_index = p.first;
@@ -635,14 +878,15 @@ namespace tools
           wallet_rpc::COMMAND_RPC_GET_BALANCE::per_subaddress_info info;
           info.account_index = account_index;
           info.address_index = i;
-          cryptonote::subaddress_index index = {info.account_index, info.address_index};
-          info.address = m_wallet->get_subaddress_as_str(index);
+          info.address = m_wallet_impl->address(info.account_index, info.address_index);
           info.balance = balance_per_subaddress[i];
           info.unlocked_balance = unlocked_balance_per_subaddress[i].first;
           info.blocks_to_unlock = unlocked_balance_per_subaddress[i].second.first;
           info.time_to_unlock = unlocked_balance_per_subaddress[i].second.second;
-          info.label = m_wallet->get_subaddress_label(index);
-          info.num_unspent_outputs = std::count_if(transfers.begin(), transfers.end(), [&](const tools::wallet2::transfer_details& td) { return !td.m_spent && td.m_subaddr_index == index; });
+          info.label = m_wallet_impl->getSubaddressLabel(info.account_index, info.address_index);
+          info.num_unspent_outputs = std::count_if(eds.begin(), eds.end(), [&](const std::unique_ptr<EnoteDetails> &ed) {
+              return !ed->isSpent() && ed->subaddressIndexMajor() == info.account_index && ed->subaddressIndexMinor() && info.address_index;
+          });
           res.per_subaddress.emplace_back(std::move(info));
         }
       }
@@ -657,35 +901,33 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_getaddress(const wallet_rpc::COMMAND_RPC_GET_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_GET_ADDRESS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     try
     {
-      THROW_WALLET_EXCEPTION_IF(req.account_index >= m_wallet->get_num_subaddress_accounts(), error::account_index_outofbound);
+      THROW_WALLET_EXCEPTION_IF(req.account_index >= m_wallet_impl->numSubaddressAccounts(), error::account_index_outofbound);
       res.addresses.clear();
       std::vector<uint32_t> req_address_index;
       if (req.address_index.empty())
       {
-        for (uint32_t i = 0; i < m_wallet->get_num_subaddresses(req.account_index); ++i)
+        for (uint32_t i = 0; i < m_wallet_impl->numSubaddresses(req.account_index); ++i)
           req_address_index.push_back(i);
       }
       else
       {
         req_address_index = req.address_index;
       }
-      tools::wallet2::transfer_container transfers;
-      m_wallet->get_transfers(transfers);
+      std::vector<std::unique_ptr<EnoteDetails>> eds = m_wallet_impl->getEnoteDetails();
       for (uint32_t i : req_address_index)
       {
-        THROW_WALLET_EXCEPTION_IF(i >= m_wallet->get_num_subaddresses(req.account_index), error::address_index_outofbound);
+        THROW_WALLET_EXCEPTION_IF(i >= m_wallet_impl->numSubaddresses(req.account_index), error::address_index_outofbound);
         res.addresses.resize(res.addresses.size() + 1);
         auto& info = res.addresses.back();
-        const cryptonote::subaddress_index index = {req.account_index, i};
-        info.address = m_wallet->get_subaddress_as_str(index);
-        info.label = m_wallet->get_subaddress_label(index);
-        info.address_index = index.minor;
-        info.used = std::find_if(transfers.begin(), transfers.end(), [&](const tools::wallet2::transfer_details& td) { return td.m_subaddr_index == index; }) != transfers.end();
+        info.address = m_wallet_impl->address(req.account_index, i);
+        info.label = m_wallet_impl->getSubaddressLabel(req.account_index, i);
+        info.address_index = i;
+        info.used = std::find_if(eds.begin(), eds.end(), [&](const std::unique_ptr<EnoteDetails> &ed) { return ed->subaddressIndexMajor() == req.account_index && ed->subaddressIndexMinor() == i; }) != eds.end();
       }
-      res.address = m_wallet->get_subaddress_as_str({req.account_index, 0});
+      res.address = m_wallet_impl->address(req.account_index, 0);
     }
     catch (const std::exception& e)
     {
@@ -697,39 +939,39 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_getaddress_index(const wallet_rpc::COMMAND_RPC_GET_ADDRESS_INDEX::request& req, wallet_rpc::COMMAND_RPC_GET_ADDRESS_INDEX::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     cryptonote::address_parse_info info;
-    if(!get_account_address_from_str(info, m_wallet->nettype(), req.address))
+    if(!get_account_address_from_str(info, nettype(), req.address))
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
       er.message = "Invalid address";
       return false;
     }
-    auto index = m_wallet->get_subaddress_index(info.address);
-    if (!index)
+    int error_code;
+    std::string error_msg;
+    auto index = m_wallet_impl->getSubaddressIndex(req.address);
+    m_wallet_impl->statusWithErrorString(error_code, error_msg);
+    if (error_code != Wallet::Status::Status_Ok)
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
       er.message = "Address doesn't belong to the wallet";
       return false;
     }
-    res.index = *index;
+    res.index = {index.first, index.second};
     return true;
   }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_set_subaddr_lookahead(const wallet_rpc::COMMAND_RPC_SET_SUBADDR_LOOKAHEAD::request& req, wallet_rpc::COMMAND_RPC_SET_SUBADDR_LOOKAHEAD::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
-    const std::string wallet_file = m_wallet->get_wallet_file();
-    if (wallet_file == "" || m_wallet->verify_password(req.password))
+    const std::string wallet_file = m_wallet_impl->filename();
+    if (wallet_file == "" || m_wallet_impl->verifyPassword(req.password))
     {
-      try
-      {
-        m_wallet->set_subaddress_lookahead(req.major_idx, req.minor_idx);
-        m_wallet->rewrite(wallet_file, req.password);
-      }
-      catch (const std::exception& e) {
-        handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-        return false;
-      }
+      m_wallet_impl->setSubaddressLookahead(req.major_idx, req.minor_idx);
+      if (api_error_to_rpc_error(er)) return false;
+
+      m_wallet_impl->rewriteWalletFile(wallet_file, req.password);
+      if (api_error_to_rpc_error(er)) return false;
     }
     else
     {
@@ -750,6 +992,7 @@ namespace tools
         er.message = "Count must be between 1 and 65536.";
         return false;
       }
+      THROW_WALLET_EXCEPTION_IF(req.account_index > m_wallet_impl->numSubaddressAccounts(), error::account_index_outofbound);
 
       std::vector<std::string> addresses;
       std::vector<uint32_t>    address_indices;
@@ -758,10 +1001,12 @@ namespace tools
       address_indices.reserve(req.count);
 
       for (uint32_t i = 0; i < req.count; i++) {
-        m_wallet->add_subaddress(req.account_index, req.label);
-        uint32_t new_address_index = m_wallet->get_num_subaddresses(req.account_index) - 1;
+        m_wallet_impl->addSubaddress(req.account_index, req.label);
+        if (api_error_to_rpc_error(er)) return false;
+
+        uint32_t new_address_index = m_wallet_impl->numSubaddresses(req.account_index) - 1;
         address_indices.push_back(new_address_index);
-        addresses.push_back(m_wallet->get_subaddress_as_str({req.account_index, new_address_index}));
+        addresses.push_back(m_wallet_impl->address(req.account_index, new_address_index));
       }
 
       res.address = addresses[0];
@@ -782,7 +1027,9 @@ namespace tools
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
     try
     {
-      m_wallet->set_subaddress_label(req.index, req.label);
+      THROW_WALLET_EXCEPTION_IF(req.index.major > m_wallet_impl->numSubaddressAccounts(), error::account_index_outofbound);
+      THROW_WALLET_EXCEPTION_IF(req.index.minor > m_wallet_impl->numSubaddresses(req.index.major), error::address_index_outofbound);
+      m_wallet_impl->setSubaddressLabel(req.index.major, req.index.minor, req.label);
     }
     catch (const std::exception& e)
     {
@@ -794,20 +1041,20 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_get_accounts(const wallet_rpc::COMMAND_RPC_GET_ACCOUNTS::request& req, wallet_rpc::COMMAND_RPC_GET_ACCOUNTS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     try
     {
       res.total_balance = 0;
       res.total_unlocked_balance = 0;
       cryptonote::subaddress_index subaddr_index = {0,0};
-      const std::pair<std::map<std::string, std::string>, std::vector<std::string>> account_tags = m_wallet->get_account_tags();
+      const std::pair<std::map<std::string, std::string>, std::vector<std::string>> account_tags = m_wallet_impl->getAccountTags();
       if (!req.tag.empty() && account_tags.first.count(req.tag) == 0 && !req.regexp)
       {
         er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
         er.message = (boost::format(tr("Tag %s is unregistered.")) % req.tag).str();
         return false;
       }
-      for (; subaddr_index.major < m_wallet->get_num_subaddress_accounts(); ++subaddr_index.major)
+      for (; subaddr_index.major < m_wallet_impl->numSubaddressAccounts(); ++subaddr_index.major)
       {
         bool no_match = !req.regexp ? (!req.tag.empty() && req.tag != account_tags.second[subaddr_index.major])
           : (!req.tag.empty() && !boost::regex_match(account_tags.second[subaddr_index.major], boost::regex(req.tag)));
@@ -815,10 +1062,10 @@ namespace tools
           continue;
         wallet_rpc::COMMAND_RPC_GET_ACCOUNTS::subaddress_account_info info;
         info.account_index = subaddr_index.major;
-        info.base_address = m_wallet->get_subaddress_as_str(subaddr_index);
-        info.balance = m_wallet->balance(subaddr_index.major, req.strict_balances);
-        info.unlocked_balance = m_wallet->unlocked_balance(subaddr_index.major, req.strict_balances);
-        info.label = m_wallet->get_subaddress_label(subaddr_index);
+        info.base_address = m_wallet_impl->address(subaddr_index.major, subaddr_index.minor);
+        info.balance = m_wallet_impl->balance(subaddr_index.major, req.strict_balances);
+        info.unlocked_balance = m_wallet_impl->unlockedBalance(subaddr_index.major, /* blocks_to_unlock */ NULL, /* time_to_unlock */ NULL, req.strict_balances);
+        info.label = m_wallet_impl->getSubaddressLabel(subaddr_index.major, subaddr_index.minor);
         info.tag = account_tags.second[subaddr_index.major];
         res.subaddress_accounts.push_back(info);
         res.total_balance += info.balance;
@@ -842,17 +1089,10 @@ namespace tools
   bool wallet_rpc_server::on_create_account(const wallet_rpc::COMMAND_RPC_CREATE_ACCOUNT::request& req, wallet_rpc::COMMAND_RPC_CREATE_ACCOUNT::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
-    try
-    {
-      m_wallet->add_subaddress_account(req.label);
-      res.account_index = m_wallet->get_num_subaddress_accounts() - 1;
-      res.address = m_wallet->get_subaddress_as_str({res.account_index, 0});
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
+    m_wallet_impl->addSubaddressAccount(req.label);
+    if (api_error_to_rpc_error(er)) return false;
+    res.account_index = m_wallet_impl->numSubaddressAccounts() - 1;
+    res.address = m_wallet_impl->address(res.account_index, /* minor_idx */ 0);
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -861,7 +1101,8 @@ namespace tools
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
     try
     {
-      m_wallet->set_subaddress_label({req.account_index, 0}, req.label);
+      THROW_WALLET_EXCEPTION_IF(req.account_index > m_wallet_impl->numSubaddressAccounts(), error::account_index_outofbound);
+      m_wallet_impl->setSubaddressLabel(req.account_index, /* minor_idx */ 0, req.label);
     }
     catch (const std::exception& e)
     {
@@ -873,9 +1114,8 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_get_account_tags(const wallet_rpc::COMMAND_RPC_GET_ACCOUNT_TAGS::request& req, wallet_rpc::COMMAND_RPC_GET_ACCOUNT_TAGS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
     CHECK_IF_BACKGROUND_SYNCING();
-    const std::pair<std::map<std::string, std::string>, std::vector<std::string>> account_tags = m_wallet->get_account_tags();
+    const std::pair<std::map<std::string, std::string>, std::vector<std::string>> account_tags = m_wallet_impl->getAccountTags();
     for (const std::pair<const std::string, std::string>& p : account_tags.first)
     {
       res.account_tags.resize(res.account_tags.size() + 1);
@@ -894,54 +1134,30 @@ namespace tools
   bool wallet_rpc_server::on_tag_accounts(const wallet_rpc::COMMAND_RPC_TAG_ACCOUNTS::request& req, wallet_rpc::COMMAND_RPC_TAG_ACCOUNTS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
-    try
-    {
-      m_wallet->set_account_tag(req.accounts, req.tag);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-    return true;
+    m_wallet_impl->setAccountTag(req.accounts, req.tag);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_untag_accounts(const wallet_rpc::COMMAND_RPC_UNTAG_ACCOUNTS::request& req, wallet_rpc::COMMAND_RPC_UNTAG_ACCOUNTS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
-    try
-    {
-      m_wallet->set_account_tag(req.accounts, "");
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-    return true;
+    m_wallet_impl->setAccountTag(req.accounts, "");
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_set_account_tag_description(const wallet_rpc::COMMAND_RPC_SET_ACCOUNT_TAG_DESCRIPTION::request& req, wallet_rpc::COMMAND_RPC_SET_ACCOUNT_TAG_DESCRIPTION::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
-    try
-    {
-      m_wallet->set_account_tag_description(req.tag, req.description);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-    return true;
+    m_wallet_impl->setAccountTagDescription(req.tag, req.description);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_getheight(const wallet_rpc::COMMAND_RPC_GET_HEIGHT::request& req, wallet_rpc::COMMAND_RPC_GET_HEIGHT::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     try
     {
-      res.height = m_wallet->get_blockchain_current_height();
+      res.height = m_wallet_impl->blockChainHeight();
     }
     catch (const std::exception& e)
     {
@@ -954,100 +1170,73 @@ namespace tools
   bool wallet_rpc_server::on_freeze(const wallet_rpc::COMMAND_RPC_FREEZE::request& req, wallet_rpc::COMMAND_RPC_FREEZE::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
-    try
+    if (req.key_image.empty())
     {
-      if (req.key_image.empty())
-      {
-        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        er.message = std::string("Must specify key image to freeze");
-        return false;
-      }
-      crypto::key_image ki;
-      if (!epee::string_tools::hex_to_pod(req.key_image, ki))
-      {
-        er.code = WALLET_RPC_ERROR_CODE_WRONG_KEY_IMAGE;
-        er.message = "failed to parse key image";
-        return false;
-      }
-      m_wallet->freeze(ki);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = std::string("Must specify key image to freeze");
       return false;
     }
-    return true;
+    crypto::key_image ki;
+    if (!epee::string_tools::hex_to_pod(req.key_image, ki))
+    {
+      er.code = WALLET_RPC_ERROR_CODE_WRONG_KEY_IMAGE;
+      er.message = "failed to parse key image";
+      return false;
+    }
+    m_wallet_impl->freeze(req.key_image);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_thaw(const wallet_rpc::COMMAND_RPC_THAW::request& req, wallet_rpc::COMMAND_RPC_THAW::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
-    try
+    if (req.key_image.empty())
     {
-      if (req.key_image.empty())
-      {
-        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        er.message = std::string("Must specify key image to thaw");
-        return false;
-      }
-      crypto::key_image ki;
-      if (!epee::string_tools::hex_to_pod(req.key_image, ki))
-      {
-        er.code = WALLET_RPC_ERROR_CODE_WRONG_KEY_IMAGE;
-        er.message = "failed to parse key image";
-        return false;
-      }
-      m_wallet->thaw(ki);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = std::string("Must specify key image to thaw");
       return false;
     }
-    return true;
+    crypto::key_image ki;
+    if (!epee::string_tools::hex_to_pod(req.key_image, ki))
+    {
+      er.code = WALLET_RPC_ERROR_CODE_WRONG_KEY_IMAGE;
+      er.message = "failed to parse key image";
+      return false;
+    }
+    m_wallet_impl->thaw(req.key_image);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_frozen(const wallet_rpc::COMMAND_RPC_FROZEN::request& req, wallet_rpc::COMMAND_RPC_FROZEN::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
     CHECK_IF_BACKGROUND_SYNCING();
-    try
+    if (req.key_image.empty())
     {
-      if (req.key_image.empty())
-      {
-        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        er.message = std::string("Must specify key image to check if frozen");
-        return false;
-      }
-      crypto::key_image ki;
-      if (!epee::string_tools::hex_to_pod(req.key_image, ki))
-      {
-        er.code = WALLET_RPC_ERROR_CODE_WRONG_KEY_IMAGE;
-        er.message = "failed to parse key image";
-        return false;
-      }
-      res.frozen = m_wallet->frozen(ki);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = std::string("Must specify key image to check if frozen");
       return false;
     }
-    return true;
+    crypto::key_image ki;
+    if (!epee::string_tools::hex_to_pod(req.key_image, ki))
+    {
+      er.code = WALLET_RPC_ERROR_CODE_WRONG_KEY_IMAGE;
+      er.message = "failed to parse key image";
+      return false;
+    }
+    res.frozen = m_wallet_impl->isFrozen(req.key_image);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  bool wallet_rpc_server::validate_transfer(const std::list<wallet_rpc::transfer_destination>& destinations, const std::string& payment_id, std::vector<cryptonote::tx_destination_entry>& dsts, std::vector<uint8_t>& extra, bool at_least_one_destination, epee::json_rpc::error& er)
+  bool wallet_rpc_server::validate_transfer(const std::list<wallet_rpc::transfer_destination>& destinations, const std::string& payment_id, std::vector<std::string>& dsts, std::vector<std::uint64_t>& amounts_per_dst, bool at_least_one_destination, epee::json_rpc::error& er)
   {
     CHECK_IF_BACKGROUND_SYNCING();
 
     crypto::hash8 integrated_payment_id = crypto::null_hash8;
-    std::string extra_nonce;
     for (auto it = destinations.begin(); it != destinations.end(); it++)
     {
       cryptonote::address_parse_info info;
-      cryptonote::tx_destination_entry de;
       er.message = "";
-      if(!get_account_address_from_str_or_url(info, m_wallet->nettype(), it->address,
+      if(!get_account_address_from_str_or_url(info, nettype(), it->address,
         [&er](const std::string &url, const std::vector<std::string> &addresses, bool dnssec_valid)->std::string {
           if (!dnssec_valid)
           {
@@ -1068,12 +1257,8 @@ namespace tools
         return false;
       }
 
-      de.original = it->address;
-      de.addr = info.address;
-      de.is_subaddress = info.is_subaddress;
-      de.amount = it->amount;
-      de.is_integrated = info.has_payment_id;
-      dsts.push_back(de);
+      dsts.push_back(it->address);
+      amounts_per_dst.push_back(it->amount);
 
       if (info.has_payment_id)
       {
@@ -1084,14 +1269,6 @@ namespace tools
           return false;
         }
         integrated_payment_id = info.payment_id;
-        cryptonote::set_encrypted_payment_id_to_tx_extra_nonce(extra_nonce, integrated_payment_id);
-
-        /* Append Payment ID data into extra */
-        if (!cryptonote::add_extra_nonce_to_tx_extra(extra, extra_nonce)) {
-          er.code = WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID;
-          er.message = "Something went wrong with integrated payment_id.";
-          return false;
-        }
       }
     }
 
@@ -1109,22 +1286,6 @@ namespace tools
       return false;
     }
     return true;
-  }
-  //------------------------------------------------------------------------------------------------------------------------------
-  static std::string ptx_to_string(const tools::wallet2::pending_tx &ptx)
-  {
-    std::ostringstream oss;
-    binary_archive<true> ar(oss);
-    try
-    {
-      if (!::serialization::serialize(ar, const_cast<tools::wallet2::pending_tx&>(ptx)))
-        return "";
-    }
-    catch (...)
-    {
-      return "";
-    }
-    return epee::string_tools::buff_to_hex_nodelimer(oss.str());
   }
   //------------------------------------------------------------------------------------------------------------------------------
   template<typename T> static bool is_error_value(const T &val) { return false; }
@@ -1146,53 +1307,54 @@ namespace tools
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  static uint64_t total_amount(const tools::wallet2::pending_tx &ptx)
+  static uint64_t total_amount(const std::vector<std::uint64_t> &amounts)
   {
     uint64_t amount = 0;
-    for (const auto &dest: ptx.dests) amount += dest.amount;
+    for (const auto &amt: amounts) amount += amt;
     return amount;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  template<typename Ts, typename Tu, typename Tk, typename Ta>
-  bool wallet_rpc_server::fill_response(std::vector<tools::wallet2::pending_tx> &ptx_vector,
+template<typename Ts, typename Tu, typename Tk, typename Ta>
+  bool wallet_rpc_server::fill_response(std::unique_ptr<PendingTransaction> ptx_vector,
       bool get_tx_key, Ts& tx_key, Tu &amount, Ta &amounts_by_dest, Tu &fee, Tu &weight, std::string &multisig_txset, std::string &unsigned_txset, bool do_not_relay,
       Ts &tx_hash, bool get_tx_hex, Ts &tx_blob, bool get_tx_metadata, Ts &tx_metadata, Tk &spent_key_images, epee::json_rpc::error &er)
   {
-    for (const auto & ptx : ptx_vector)
+    const size_t tx_count = ptx_vector->txCount();
+    const std::vector<std::string> &tx_ids = ptx_vector->txid();
+    const std::vector<std::vector<std::uint64_t>> &amounts = ptx_vector->amountsPerDestination();
+    const std::vector<std::uint64_t> &fees = ptx_vector->fees();
+    const std::vector<std::uint64_t> &tx_weights = ptx_vector->txWeights();
+    const std::vector<std::string> &tx_hex_strings = ptx_vector->asHexStr();
+    const std::vector<std::string> &tx_blobs = ptx_vector->convertTxToRawBlobStr();
+    const std::vector<std::string> &tx_key_str = ptx_vector->getTxKeys();
+    const std::vector<std::vector<std::unique_ptr<EnoteDetails>>> &eds = ptx_vector->getEnoteDetailsIn();
+    for (size_t i = 0; i < tx_count; ++i)
     {
       if (get_tx_key)
       {
-        epee::wipeable_string s = epee::to_hex::wipeable_string(ptx.tx_key);
-        for (const crypto::secret_key& additional_tx_key : ptx.additional_tx_keys)
-          s += epee::to_hex::wipeable_string(additional_tx_key);
-        fill(tx_key, std::string(s.data(), s.size()));
+        fill(tx_key, tx_key_str[i]);
       }
       // Compute amount leaving wallet in tx. By convention dests does not include change outputs
-      fill(amount, total_amount(ptx));
-      fill(fee, ptx.fee);
-      fill(weight, cryptonote::get_transaction_weight(ptx.tx));
+      fill(amount, total_amount(amounts[i]));
+      fill(fee, fees[i]);
+      fill(weight, tx_weights[i]);
 
       // add amounts by destination
       tools::wallet_rpc::amounts_list abd;
-      for (const auto& dst : ptx.dests)
-        abd.amounts.push_back(dst.amount);
+      for (const auto& dst : amounts[i])
+        abd.amounts.push_back(dst);
       fill(amounts_by_dest, abd);
 
       // add spent key images
       tools::wallet_rpc::key_image_list key_image_list;
-      bool all_are_txin_to_key = std::all_of(ptx.tx.vin.begin(), ptx.tx.vin.end(), [&](const cryptonote::txin_v& s_e) -> bool
-      {
-        CHECKED_GET_SPECIFIC_VARIANT(s_e, const cryptonote::txin_to_key, in, false);
-        key_image_list.key_images.push_back(epee::string_tools::pod_to_hex(in.k_image));
-        return true;
-      });
-      THROW_WALLET_EXCEPTION_IF(!all_are_txin_to_key, error::unexpected_txin_type, ptx.tx);
+      for (const auto &ed : eds[i])
+        key_image_list.key_images.push_back(ed->keyImage());
       fill(spent_key_images, key_image_list);
     }
 
-    if (m_wallet->get_multisig_status().multisig_is_active)
+    if (m_wallet_impl->multisig().isMultisig)
     {
-      multisig_txset = epee::string_tools::buff_to_hex_nodelimer(m_wallet->save_multisig_tx(ptx_vector));
+      multisig_txset = epee::string_tools::buff_to_hex_nodelimer(m_wallet_impl->convertMultisigTxToStr(*ptx_vector));
       if (multisig_txset.empty())
       {
         er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
@@ -1202,8 +1364,8 @@ namespace tools
     }
     else
     {
-      if (m_wallet->watch_only()){
-        unsigned_txset = epee::string_tools::buff_to_hex_nodelimer(m_wallet->dump_tx_to_str(ptx_vector));
+      if (m_wallet_impl->watchOnly()){
+        unsigned_txset = epee::string_tools::buff_to_hex_nodelimer(ptx_vector->convertTxToStr());
         if (unsigned_txset.empty())
         {
           er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
@@ -1212,14 +1374,14 @@ namespace tools
         }
       }
       else if (!do_not_relay)
-        m_wallet->commit_tx(ptx_vector);
+        ptx_vector->commit();
 
       // populate response with tx hashes
-      for (auto & ptx : ptx_vector)
+      for (size_t i = 0; i < tx_count; ++i)
       {
-        bool r = fill(tx_hash, epee::string_tools::pod_to_hex(cryptonote::get_transaction_hash(ptx.tx)));
-        r = r && (!get_tx_hex || fill(tx_blob, epee::string_tools::buff_to_hex_nodelimer(tx_to_blob(ptx.tx))));
-        r = r && (!get_tx_metadata || fill(tx_metadata, ptx_to_string(ptx)));
+        bool r = fill(tx_hash, tx_ids[i]);
+        r = r && (!get_tx_hex || fill(tx_blob, epee::string_tools::buff_to_hex_nodelimer(tx_blobs[i])));
+        r = r && (!get_tx_metadata || fill(tx_metadata, tx_hex_strings[i]));
         if (!r)
         {
           er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
@@ -1234,8 +1396,8 @@ namespace tools
   bool wallet_rpc_server::on_transfer(const wallet_rpc::COMMAND_RPC_TRANSFER::request& req, wallet_rpc::COMMAND_RPC_TRANSFER::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
 
-    std::vector<cryptonote::tx_destination_entry> dsts;
-    std::vector<uint8_t> extra;
+    std::vector<std::string> dst_addr{};
+    std::vector<std::uint64_t> amt_per_dst{};
 
     LOG_PRINT_L3("on_transfer starts");
     if (m_restricted)
@@ -1244,7 +1406,7 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     else if (req.unlock_time)
     {
       er.code = WALLET_RPC_ERROR_CODE_NONZERO_UNLOCK_TIME;
@@ -1260,57 +1422,52 @@ namespace tools
 
     CHECK_MULTISIG_ENABLED();
 
-    // validate the transfer requested and populate dsts & extra
-    if (!validate_transfer(req.destinations, req.payment_id, dsts, extra, true, er))
+    // validate the transfer requested and populate dsts and amounts
+    if (!validate_transfer(req.destinations, req.payment_id, dst_addr, amt_per_dst, /* at_least_one_destination */ true, er))
     {
       return false;
     }
 
-    try
+    std::unique_ptr<PendingTransaction> ptx(
+              m_wallet_impl->createTransactionMultDest(dst_addr,
+                                                       /* [deprecated] payment_id */ "",
+                                                       amt_per_dst,
+                                                       req.ring_size ? req.ring_size - 1 : 0,
+                                                       static_cast<PendingTransaction::Priority>(req.priority),
+                                                       req.account_index,
+                                                       req.subaddr_indices,
+                                                       req.subtract_fee_from_outputs));
+    if (api_error_to_rpc_error(er)) return false;
+    if (!ptx)
     {
-      uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
-      const fee_priority priority = m_wallet->adjust_priority(fee_priority_utilities::from_integral(req.priority));
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, priority, extra, req.account_index, req.subaddr_indices, req.subtract_fee_from_outputs);
+      er.code = WALLET_RPC_ERROR_CODE_TX_NOT_POSSIBLE;
+      er.message = "No transaction created";
+      return false;
+    }
 
-      if (ptx_vector.empty())
-      {
-        er.code = WALLET_RPC_ERROR_CODE_TX_NOT_POSSIBLE;
-        er.message = "No transaction created";
-        return false;
-      }
-
-      // reject proposed transactions if there are more than one.  see on_transfer_split below.
-      if (ptx_vector.size() != 1)
-      {
-        er.code = WALLET_RPC_ERROR_CODE_TX_TOO_LARGE;
-        er.message = "Transaction would be too large.  try /transfer_split.";
-        return false;
-      }
-
-      return fill_response(ptx_vector, req.get_tx_key, res.tx_key, res.amount, res.amounts_by_dest, res.fee, res.weight, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
+    // reject proposed transactions if there are more than one.  see on_transfer_split below.
+    if (ptx->txCount() != 1)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_TX_TOO_LARGE;
+      er.message = "Transaction would be too large.  try /transfer_split.";
+      return false;
+    }
+    return fill_response(std::move(ptx), req.get_tx_key, res.tx_key, res.amount, res.amounts_by_dest, res.fee, res.weight, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
           res.tx_hash, req.get_tx_hex, res.tx_blob, req.get_tx_metadata, res.tx_metadata, res.spent_key_images, er);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR);
-      return false;
-    }
-    return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_transfer_split(const wallet_rpc::COMMAND_RPC_TRANSFER_SPLIT::request& req, wallet_rpc::COMMAND_RPC_TRANSFER_SPLIT::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
+    std::vector<std::string> dst_addr{};
+    std::vector<std::uint64_t> amt_per_dst{};
 
-    std::vector<cryptonote::tx_destination_entry> dsts;
-    std::vector<uint8_t> extra;
-
+    if (!m_wallet_impl) return not_open(er);
     if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
     else if (req.unlock_time)
     {
       er.code = WALLET_RPC_ERROR_CODE_NONZERO_UNLOCK_TIME;
@@ -1326,54 +1483,50 @@ namespace tools
 
     CHECK_MULTISIG_ENABLED();
 
-    // validate the transfer requested and populate dsts & extra; RPC_TRANSFER::request and RPC_TRANSFER_SPLIT::request are identical types.
-    if (!validate_transfer(req.destinations, req.payment_id, dsts, extra, true, er))
+    // validate the transfer requested and populate dsts; RPC_TRANSFER::request and RPC_TRANSFER_SPLIT::request are identical types.
+    if (!validate_transfer(req.destinations, req.payment_id, dst_addr, amt_per_dst, /* at_least_one_destination */ true, er))
     {
       return false;
     }
 
-    try
+    LOG_PRINT_L2("on_transfer_split calling create_transactions_2");
+    std::unique_ptr<PendingTransaction> ptx(
+            m_wallet_impl->createTransactionMultDest(dst_addr,
+                                                     /* [deprecated] payment_id */ "",
+                                                     amt_per_dst,
+                                                     req.ring_size ? req.ring_size - 1 : 0,
+                                                     static_cast<PendingTransaction::Priority>(req.priority),
+                                                     req.account_index,
+                                                     req.subaddr_indices));
+    LOG_PRINT_L2("on_transfer_split called create_transactions_2");
+    if (api_error_to_rpc_error(er)) return false;
+    if (!ptx)
     {
-      uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
-      const fee_priority priority = m_wallet->adjust_priority(fee_priority_utilities::from_integral(req.priority));
-      LOG_PRINT_L2("on_transfer_split calling create_transactions_2");
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, priority, extra, req.account_index, req.subaddr_indices);
-      LOG_PRINT_L2("on_transfer_split called create_transactions_2");
+      er.code = WALLET_RPC_ERROR_CODE_TX_NOT_POSSIBLE;
+      er.message = "No transaction created";
+      return false;
+    }
 
-      if (ptx_vector.empty())
-      {
-        er.code = WALLET_RPC_ERROR_CODE_TX_NOT_POSSIBLE;
-        er.message = "No transaction created";
-        return false;
-      }
-
-      return fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.amounts_by_dest_list, res.fee_list, res.weight_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
+    return fill_response(std::move(ptx), req.get_tx_keys, res.tx_key_list, res.amount_list, res.amounts_by_dest_list, res.fee_list, res.weight_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
           res.tx_hash_list, req.get_tx_hex, res.tx_blob_list, req.get_tx_metadata, res.tx_metadata_list, res.spent_key_images_list, er);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR);
-      return false;
-    }
-    return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_sign_transfer(const wallet_rpc::COMMAND_RPC_SIGN_TRANSFER::request& req, wallet_rpc::COMMAND_RPC_SIGN_TRANSFER::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
+    if (!m_wallet_impl) return not_open(er);
     if (m_restricted)
     {
       er.code = WALLET_RPC_ERROR_CODE_DENIED;
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    if (m_wallet->key_on_device())
+    if (m_wallet_impl->getDeviceState().key_on_device)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "command not supported by HW wallet";
       return false;
     }
-    if(m_wallet->watch_only())
+    if(m_wallet_impl->watchOnly())
     {
       er.code = WALLET_RPC_ERROR_CODE_WATCH_ONLY;
       er.message = "command not supported by watch-only wallet";
@@ -1391,51 +1544,40 @@ namespace tools
       return false;
     }
 
-    tools::wallet2::unsigned_tx_set exported_txs;
-    if(!m_wallet->parse_unsigned_tx_from_str(blob, exported_txs))
-    {
-      er.code = WALLET_RPC_ERROR_CODE_BAD_UNSIGNED_TX_DATA;
-      er.message = "cannot load unsigned_txset";
-      return false;
-    }
+    auto utx = std::unique_ptr<UnsignedTransaction>(m_wallet_impl->loadUnsignedTxFromStr(blob));
+    if (api_error_to_rpc_error(er)) return false;
 
-    std::vector<tools::wallet2::pending_tx> ptxs;
-    try
-    {
-      tools::wallet2::signed_tx_set signed_txs;
-      std::string ciphertext = m_wallet->sign_tx_dump_to_str(exported_txs, ptxs, signed_txs);
-      if (ciphertext.empty())
-      {
-        er.code = WALLET_RPC_ERROR_CODE_SIGN_UNSIGNED;
-        er.message = "Failed to sign unsigned tx";
-        return false;
-      }
-
-      res.signed_txset = epee::string_tools::buff_to_hex_nodelimer(ciphertext);
-    }
-    catch (const std::exception &e)
+    std::string ciphertext = utx->signAsString();
+    if (ciphertext.empty())
     {
       er.code = WALLET_RPC_ERROR_CODE_SIGN_UNSIGNED;
-      er.message = std::string("Failed to sign unsigned tx: ") + e.what();
+      er.message = "Failed to sign unsigned tx" + (utx->errorString().empty() ? "" : (": " + utx->errorString()));
       return false;
     }
+    res.signed_txset = epee::string_tools::buff_to_hex_nodelimer(ciphertext);
 
-    for (auto &ptx: ptxs)
+    auto ptx = m_wallet_impl->parseTxFromStr(ciphertext);
+    if (ptx->status() != PendingTransaction::Status::Status_Ok)
     {
-      res.tx_hash_list.push_back(epee::string_tools::pod_to_hex(cryptonote::get_transaction_hash(ptx.tx)));
+        er.code = WALLET_RPC_ERROR_CODE_BAD_SIGNED_TX_DATA;
+        er.message = "Failed to parse signed tx" + (ptx->errorString().empty() ? "" : (": " + ptx->errorString()));
+        return false;
+    }
+    std::vector<std::string> tx_ids = ptx->txid();
+    for (size_t i = 0; i < ptx->txCount(); ++i)
+    {
+      res.tx_hash_list.push_back(tx_ids[i]);
       if (req.get_tx_keys)
       {
-        res.tx_key_list.push_back(epee::string_tools::pod_to_hex(unwrap(unwrap(ptx.tx_key))));
-        for (const crypto::secret_key& additional_tx_key : ptx.additional_tx_keys)
-          res.tx_key_list.back() += epee::string_tools::pod_to_hex(unwrap(unwrap(additional_tx_key)));
+        res.tx_key_list.push_back(m_wallet_impl->getTxKey(tx_ids[i]));
       }
     }
 
     if (req.export_raw)
     {
-      for (auto &ptx: ptxs)
+      for (auto &raw_tx_blob_str : ptx->convertTxToRawBlobStr())
       {
-        res.tx_raw_list.push_back(epee::string_tools::buff_to_hex_nodelimer(cryptonote::tx_to_blob(ptx.tx)));
+        res.tx_raw_list.push_back(raw_tx_blob_str);
       }
     }
 
@@ -1450,14 +1592,13 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    if (m_wallet->key_on_device())
+    if (m_wallet_impl->getDeviceState().key_on_device)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "command not supported by HW wallet";
       return false;
     }
-    if(m_wallet->watch_only())
+    if(m_wallet_impl->watchOnly())
     {
       er.code = WALLET_RPC_ERROR_CODE_WATCH_ONLY;
       er.message = "command not supported by watch-only wallet";
@@ -1471,201 +1612,82 @@ namespace tools
       return false;
     }
 
-    std::vector <wallet2::tx_construction_data> tx_constructions;
+    std::unique_ptr<TransactionDescription> tx_desc{};
     if (!req.unsigned_txset.empty()) {
-      try {
-        tools::wallet2::unsigned_tx_set exported_txs;
-        cryptonote::blobdata blob;
-        if (!epee::string_tools::parse_hexstr_to_binbuff(req.unsigned_txset, blob)) {
-          er.code = WALLET_RPC_ERROR_CODE_BAD_HEX;
-          er.message = "Failed to parse hex.";
-          return false;
-        }
-        if (!m_wallet->parse_unsigned_tx_from_str(blob, exported_txs)) {
-          er.code = WALLET_RPC_ERROR_CODE_BAD_UNSIGNED_TX_DATA;
-          er.message = "cannot load unsigned_txset";
-          return false;
-        }
-        tx_constructions = exported_txs.txes;
+      cryptonote::blobdata blob;
+      if (!epee::string_tools::parse_hexstr_to_binbuff(req.unsigned_txset, blob)) {
+        er.code = WALLET_RPC_ERROR_CODE_BAD_HEX;
+        er.message = "Failed to parse hex.";
+        return false;
       }
-      catch (const std::exception &e) {
+      auto utx = std::unique_ptr<UnsignedTransaction>(m_wallet_impl->loadUnsignedTxFromStr(blob));
+      if (api_error_to_rpc_error(er)) return false;
+
+      tx_desc = utx->getTransactionDescription();
+      if (utx->status() != UnsignedTransaction::Status::Status_Ok)
+      {
         er.code = WALLET_RPC_ERROR_CODE_BAD_UNSIGNED_TX_DATA;
-        er.message = "failed to parse unsigned transfers: " + std::string(e.what());
+        er.message = utx->errorString();
         return false;
       }
     } else if (!req.multisig_txset.empty()) {
-      try {
-        tools::wallet2::multisig_tx_set exported_txs;
-        cryptonote::blobdata blob;
-        if (!epee::string_tools::parse_hexstr_to_binbuff(req.multisig_txset, blob)) {
-          er.code = WALLET_RPC_ERROR_CODE_BAD_HEX;
-          er.message = "Failed to parse hex.";
-          return false;
-        }
-        if (!m_wallet->parse_multisig_tx_from_str(blob, exported_txs)) {
-          er.code = WALLET_RPC_ERROR_CODE_BAD_MULTISIG_TX_DATA;
-          er.message = "cannot load multisig_txset";
-          return false;
-        }
-
-        for (size_t n = 0; n < exported_txs.m_ptx.size(); ++n) {
-          tx_constructions.push_back(exported_txs.m_ptx[n].construction_data);
-        }
+      cryptonote::blobdata blob;
+      if (!epee::string_tools::parse_hexstr_to_binbuff(req.multisig_txset, blob)) {
+        er.code = WALLET_RPC_ERROR_CODE_BAD_HEX;
+        er.message = "Failed to parse hex.";
+        return false;
       }
-      catch (const std::exception &e) {
+      std::shared_ptr<PendingTransaction> ptx = std::shared_ptr<PendingTransaction>(m_wallet_impl->parseMultisigTxFromStr(blob));
+      if (api_error_to_rpc_error(er)) return false;
+      if(!ptx)
+      {
         er.code = WALLET_RPC_ERROR_CODE_BAD_MULTISIG_TX_DATA;
-        er.message = "failed to parse multisig transfers: " + std::string(e.what());
+        er.message = "cannot load multisig_txset";
+        return false;
+      }
+      tx_desc = ptx->getTransactionDescription();
+      if (ptx->status() != PendingTransaction::Status::Status_Ok)
+      {
+        er.code = WALLET_RPC_ERROR_CODE_BAD_MULTISIG_TX_DATA;
+        er.message = ptx->errorString();
         return false;
       }
     }
 
-    try
+    for (const auto &cd : tx_desc->tx_descriptions)
     {
-      // gather info to ask the user
-      std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> tx_dests;
-      std::unordered_map<cryptonote::account_public_address, std::pair<std::string, uint64_t>> all_dests;
-      int first_known_non_zero_change_index = -1;
-      res.summary.amount_in = 0;
-      res.summary.amount_out = 0;
-      res.summary.change_amount = 0;
-      res.summary.fee = 0;
-      for (size_t n = 0; n < tx_constructions.size(); ++n)
-      {
-        const tools::wallet2::tx_construction_data &cd = tx_constructions[n];
-        res.desc.push_back({0, 0, std::numeric_limits<uint32_t>::max(), 0, {}, {}, "", 0, "", 0, 0, ""});
-        wallet_rpc::COMMAND_RPC_DESCRIBE_TRANSFER::transfer_description &desc = res.desc.back();
-        // Clear the recipients collection ready for this loop iteration
-        tx_dests.clear();
+      res.desc.push_back({
+          cd.amount_in,
+          cd.amount_out,
+          cd.ring_size,
+          cd.unlock_time,
+          /* sources */ {},
+          /* recipients */ {},
+          cd.payment_id,
+          cd.change_amount,
+          cd.change_address,
+          cd.fee,
+          cd.dummy_outputs,
+          cd.extra
+      });
+      for (const auto &src : cd.sources)
+          res.desc.back().sources.push_back({src.amount, src.global_index, src.rct, src.pubkey});
+      for (const auto &recipient : cd.recipients)
+          res.desc.back().recipients.push_back({recipient.address, recipient.amount});
 
-        std::vector<cryptonote::tx_extra_field> tx_extra_fields;
-        bool has_encrypted_payment_id = false;
-        crypto::hash8 payment_id8 = crypto::null_hash8;
-        if (cryptonote::parse_tx_extra(cd.extra, tx_extra_fields))
-        {
-          cryptonote::tx_extra_nonce extra_nonce;
-          if (find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
-          {
-            crypto::hash payment_id;
-            if(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id8))
-            {
-              if (payment_id8 != crypto::null_hash8)
-              {
-                desc.payment_id = epee::string_tools::pod_to_hex(payment_id8);
-                has_encrypted_payment_id = true;
-              }
-            }
-            else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
-            {
-              desc.payment_id = epee::string_tools::pod_to_hex(payment_id);
-            }
-          }
-        }
-
-        for (size_t s = 0; s < cd.sources.size(); ++s)
-        {
-          const cryptonote::tx_source_entry &src_in = cd.sources[s];
-          const cryptonote::tx_source_entry::output_entry &real_ring_member = src_in.outputs.at(src_in.real_output);
-          wallet_rpc::COMMAND_RPC_DESCRIBE_TRANSFER::source &src_out = desc.sources.emplace_back();
-          src_out.amount = src_in.amount;
-          src_out.global_index = real_ring_member.first;
-          src_out.rct = src_in.rct;
-          src_out.pubkey = epee::string_tools::pod_to_hex(real_ring_member.second);
-          desc.amount_in += src_in.amount;
-          size_t ring_size = src_in.outputs.size();
-          if (ring_size < desc.ring_size)
-            desc.ring_size = ring_size;
-        }
-        for (size_t d = 0; d < cd.splitted_dsts.size(); ++d)
-        {
-          const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
-          std::string address = cryptonote::get_account_address_as_str(m_wallet->nettype(), entry.is_subaddress, entry.addr);
-          if (has_encrypted_payment_id && !entry.is_subaddress)
-            address = cryptonote::get_account_integrated_address_as_str(m_wallet->nettype(), entry.addr, payment_id8);
-          auto i = tx_dests.find(entry.addr);
-          if (i == tx_dests.end())
-            tx_dests.insert(std::make_pair(entry.addr, std::make_pair(address, entry.amount)));
-          else
-            i->second.second += entry.amount;
-          desc.amount_out += entry.amount;
-        }
-        if (cd.change_dts.amount > 0)
-        {
-          auto it = tx_dests.find(cd.change_dts.addr);
-          if (it == tx_dests.end())
-          {
-            er.code = WALLET_RPC_ERROR_CODE_BAD_UNSIGNED_TX_DATA;
-            er.message = "Claimed change does not go to a paid address";
-            return false;
-          }
-          if (it->second.second < cd.change_dts.amount)
-          {
-            er.code = WALLET_RPC_ERROR_CODE_BAD_UNSIGNED_TX_DATA;
-            er.message = "Claimed change is larger than payment to the change address";
-            return false;
-          }
-          if (cd.change_dts.amount > 0)
-          {
-            if (first_known_non_zero_change_index == -1)
-              first_known_non_zero_change_index = n;
-            const tools::wallet2::tx_construction_data &cdn = tx_constructions[first_known_non_zero_change_index];
-            if (memcmp(&cd.change_dts.addr, &cdn.change_dts.addr, sizeof(cd.change_dts.addr)))
-            {
-              er.code = WALLET_RPC_ERROR_CODE_BAD_UNSIGNED_TX_DATA;
-              er.message = "Change goes to more than one address";
-              return false;
-            }
-          }
-          desc.change_amount += cd.change_dts.amount;
-          it->second.second -= cd.change_dts.amount;
-          if (it->second.second == 0)
-            tx_dests.erase(cd.change_dts.addr);
-        }
-
-        for (auto i = tx_dests.begin(); i != tx_dests.end(); ++i)
-        {
-          if (i->second.second > 0)
-          {
-            desc.recipients.push_back({i->second.first, i->second.second});
-            auto it_in_all = all_dests.find(i->first);
-            if (it_in_all == all_dests.end())
-              all_dests.insert(std::make_pair(i->first, i->second));
-            else
-              it_in_all->second.second += i->second.second;
-          }
-          else
-            ++desc.dummy_outputs;
-        }
-
-        if (desc.change_amount > 0)
-        {
-          const tools::wallet2::tx_construction_data &cd0 = tx_constructions[0];
-          desc.change_address = get_account_address_as_str(m_wallet->nettype(), cd0.subaddr_account > 0, cd0.change_dts.addr);
-          res.summary.change_address = desc.change_address;
-        }
-
-        desc.fee = desc.amount_in - desc.amount_out;
-        desc.unlock_time = cd.unlock_time;
-        desc.extra = epee::to_hex::string({cd.extra.data(), cd.extra.size()});
-
-        // Update summary items
-        res.summary.amount_in += desc.amount_in;
-        res.summary.amount_out += desc.amount_out;
-        res.summary.change_amount += desc.change_amount;
-        res.summary.fee += desc.fee;
-      }
-      // Populate the summary recipients list
-      for (auto i = all_dests.begin(); i != all_dests.end(); ++i)
-      {
-        res.summary.recipients.push_back({i->second.first, i->second.second});
-      }
+      // summary
+      const auto &tx_sum = tx_desc->tx_summary;
+      res.summary = wallet_rpc::COMMAND_RPC_DESCRIBE_TRANSFER::txset_summary{
+          tx_sum.amount_in,
+          tx_sum.amount_out,
+          /* recipients */ {},
+          tx_sum.change_amount,
+          tx_sum.change_address,
+          tx_sum.fee,
+      };
+      for (const auto &recipient : tx_sum.recipients)
+          res.summary.recipients.push_back({recipient.address, recipient.amount});
     }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_BAD_UNSIGNED_TX_DATA;
-      er.message = "failed to parse unsigned transfers";
-      return false;
-    }
-
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -1677,8 +1699,7 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    if (m_wallet->key_on_device())
+    if (m_wallet_impl->getDeviceState().key_on_device)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "command not supported by HW wallet";
@@ -1693,74 +1714,32 @@ namespace tools
       return false;
     }
 
-    std::vector<tools::wallet2::pending_tx> ptx_vector;
-    try
+    auto ptx = m_wallet_impl->parseTxFromStr(blob);
+    if (ptx->status() != PendingTransaction::Status::Status_Ok)
     {
-      bool r = m_wallet->parse_tx_from_str(blob, ptx_vector, NULL);
-      if (!r)
-      {
         er.code = WALLET_RPC_ERROR_CODE_BAD_SIGNED_TX_DATA;
-        er.message = "Failed to parse signed tx data.";
+        er.message = "Failed to parse signed tx data" + (ptx->errorString().empty() ? "." : (": " + ptx->errorString()));
         return false;
-      }
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_BAD_SIGNED_TX_DATA;
-      er.message = std::string("Failed to parse signed tx: ") + e.what();
-      return false;
     }
 
-    try
-    {
-      for (auto &ptx: ptx_vector)
-      {
-        m_wallet->commit_tx(ptx);
-        res.tx_hash_list.push_back(epee::string_tools::pod_to_hex(cryptonote::get_transaction_hash(ptx.tx)));
-      }
-    }
-    catch (const std::exception &e)
+    std::vector<std::string> txids = ptx->txid();
+    if (ptx->commit())
+      for (auto &txid: txids)
+        res.tx_hash_list.push_back(txid);
+    else
     {
       er.code = WALLET_RPC_ERROR_CODE_SIGNED_SUBMISSION;
-      er.message = std::string("Failed to submit signed tx: ") + e.what();
+      er.message = "Failed to submit signed tx" + (ptx->errorString().empty() ? "." : (": " + ptx->errorString()));
       return false;
     }
 
-    return true;
-  }
-  //------------------------------------------------------------------------------------------------------------------------------
-  bool wallet_rpc_server::on_sweep_dust(const wallet_rpc::COMMAND_RPC_SWEEP_DUST::request& req, wallet_rpc::COMMAND_RPC_SWEEP_DUST::response& res, epee::json_rpc::error& er, const connection_context *ctx)
-  {
-    if (m_restricted)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_DENIED;
-      er.message = "Command unavailable in restricted mode.";
-      return false;
-    }
-    if (!m_wallet) return not_open(er);
-
-    CHECK_MULTISIG_ENABLED();
-    CHECK_IF_BACKGROUND_SYNCING();
-
-    try
-    {
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_unmixable_sweep_transactions();
-
-      return fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.amounts_by_dest_list, res.fee_list, res.weight_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
-          res.tx_hash_list, req.get_tx_hex, res.tx_blob_list, req.get_tx_metadata, res.tx_metadata_list, res.spent_key_images_list, er);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR);
-      return false;
-    }
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_sweep_all(const wallet_rpc::COMMAND_RPC_SWEEP_ALL::request& req, wallet_rpc::COMMAND_RPC_SWEEP_ALL::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    std::vector<cryptonote::tx_destination_entry> dsts;
-    std::vector<uint8_t> extra;
+    std::vector<std::string> dst_addr{};
+    std::vector<std::uint64_t> amt_per_dst{};
 
     if (m_restricted)
     {
@@ -1768,7 +1747,7 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     else if (req.unlock_time)
     {
       er.code = WALLET_RPC_ERROR_CODE_NONZERO_UNLOCK_TIME;
@@ -1784,12 +1763,12 @@ namespace tools
 
     CHECK_MULTISIG_ENABLED();
 
-    // validate the transfer requested and populate dsts & extra
+    // validate the transfer requested and populate dsts
     std::list<wallet_rpc::transfer_destination> destination;
     destination.push_back(wallet_rpc::transfer_destination());
     destination.back().amount = 0;
     destination.back().address = req.address;
-    if (!validate_transfer(destination, req.payment_id, dsts, extra, true, er))
+    if (!validate_transfer(destination, req.payment_id, dst_addr, amt_per_dst, /* at_least_one_destination */ true, er))
     {
       return false;
     }
@@ -1804,7 +1783,7 @@ namespace tools
     std::set<uint32_t> subaddr_indices;
     if (req.subaddr_indices_all)
     {
-      for (uint32_t i = 0; i < m_wallet->get_num_subaddresses(req.account_index); ++i)
+      for (uint32_t i = 0; i < m_wallet_impl->numSubaddresses(req.account_index); ++i)
         subaddr_indices.insert(i);
     }
     else
@@ -1812,27 +1791,32 @@ namespace tools
       subaddr_indices= req.subaddr_indices;
     }
 
-    try
+    std::unique_ptr<PendingTransaction> ptx(
+            m_wallet_impl->createTransactionMultDest({dst_addr},
+                                                     /* [deprecated] payment_id */ "",
+                                                     /* amount */ Monero::optional<std::vector<uint64_t>>(),
+                                                     req.ring_size ? req.ring_size - 1 : 0,
+                                                     static_cast<PendingTransaction::Priority>(req.priority),
+                                                     req.account_index,
+                                                     subaddr_indices,
+                                                     /* subtract_fee_from_outputs */ {},
+                                                     /* key_image */ "",
+                                                     req.outputs,
+                                                     req.below_amount));
+    if (api_error_to_rpc_error(er)) return false;
+    if (ptx->txCount() == 0)
     {
-      uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
-      const fee_priority priority = m_wallet->adjust_priority(fee_priority_utilities::from_integral(req.priority));
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_all(req.below_amount, dsts[0].addr, dsts[0].is_subaddress, req.outputs, mixin, priority, extra, req.account_index, subaddr_indices);
+      fail_msg_writer() << tr("No outputs found, or daemon is not ready");
+      return true;
+    }
 
-      return fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.amounts_by_dest_list, res.fee_list, res.weight_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
-          res.tx_hash_list, req.get_tx_hex, res.tx_blob_list, req.get_tx_metadata, res.tx_metadata_list, res.spent_key_images_list, er);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR);
-      return false;
-    }
-    return true;
+    return fill_response(std::move(ptx), req.get_tx_keys, res.tx_key_list, res.amount_list, res.amounts_by_dest_list, res.fee_list, res.weight_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay, res.tx_hash_list, req.get_tx_hex, res.tx_blob_list, req.get_tx_metadata, res.tx_metadata_list, res.spent_key_images_list, er);
   }
 //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_sweep_single(const wallet_rpc::COMMAND_RPC_SWEEP_SINGLE::request& req, wallet_rpc::COMMAND_RPC_SWEEP_SINGLE::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    std::vector<cryptonote::tx_destination_entry> dsts;
-    std::vector<uint8_t> extra;
+    std::vector<std::string> dst_addr{};
+    std::vector<std::uint64_t> amt_per_dst{};
 
     if (m_restricted)
     {
@@ -1840,7 +1824,7 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     else if (req.unlock_time)
     {
       er.code = WALLET_RPC_ERROR_CODE_NONZERO_UNLOCK_TIME;
@@ -1863,12 +1847,12 @@ namespace tools
 
     CHECK_MULTISIG_ENABLED();
 
-    // validate the transfer requested and populate dsts & extra
+    // validate the transfer requested and populate dsts
     std::list<wallet_rpc::transfer_destination> destination;
     destination.push_back(wallet_rpc::transfer_destination());
     destination.back().amount = 0;
     destination.back().address = req.address;
-    if (!validate_transfer(destination, req.payment_id, dsts, extra, true, er))
+    if (!validate_transfer(destination, req.payment_id, dst_addr, amt_per_dst, /* at_least_one_destination */ true, er))
     {
       return false;
     }
@@ -1880,48 +1864,39 @@ namespace tools
       er.message = "failed to parse key image";
       return false;
     }
-
-    try
-    {
-      uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
-      const fee_priority priority = m_wallet->adjust_priority(fee_priority_utilities::from_integral(req.priority));
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_single(ki, dsts[0].addr, dsts[0].is_subaddress, req.outputs, mixin, priority, extra);
-
-      if (ptx_vector.empty())
-      {
-        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        er.message = "No outputs found";
-        return false;
-      }
-      if (ptx_vector.size() > 1)
-      {
-        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        er.message = "Multiple transactions are created, which is not supposed to happen";
-        return false;
-      }
-      const wallet2::pending_tx &ptx = ptx_vector[0];
-      if (ptx.selected_transfers.size() > 1)
-      {
-        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        er.message = "The transaction uses multiple inputs, which is not supposed to happen";
-        return false;
-      }
-
-      return fill_response(ptx_vector, req.get_tx_key, res.tx_key, res.amount, res.amounts_by_dest, res.fee, res.weight, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
-          res.tx_hash, req.get_tx_hex, res.tx_blob, req.get_tx_metadata, res.tx_metadata, res.spent_key_images, er);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR);
-      return false;
-    }
-    catch (...)
+    std::unique_ptr<PendingTransaction> ptx(
+            m_wallet_impl->createTransactionMultDest({dst_addr},
+                                                     /* [deprecated] payment_id */ "",
+                                                     /* amount */ Monero::optional<std::vector<uint64_t>>(),
+                                                     req.ring_size ? req.ring_size - 1 : 0,
+                                                     static_cast<PendingTransaction::Priority>(req.priority),
+                                                     /* account_index */ 0,
+                                                     /* subaddr_indices */ {},
+                                                     /* subtract_fee_from_outputs */ {},
+                                                     req.key_image,
+                                                     req.outputs,
+                                                     /* below */ 0));
+    if (api_error_to_rpc_error(er)) return false;
+    if (ptx->txCount() == 0)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = "WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR";
+      er.message = "No outputs found";
       return false;
     }
-    return true;
+    if (ptx->txCount() > 1)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = "Multiple transactions are created, which is not supposed to happen";
+      return false;
+    }
+    if (ptx->getEnoteDetailsIn()[0].size() > 1)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = "The transaction uses multiple inputs, which is not supposed to happen";
+      return false;
+    }
+
+    return fill_response(std::move(ptx), req.get_tx_key, res.tx_key, res.amount, res.amounts_by_dest, res.fee, res.weight, res.multisig_txset, res.unsigned_txset, req.do_not_relay, res.tx_hash, req.get_tx_hex, res.tx_blob, req.get_tx_metadata, res.tx_metadata, res.spent_key_images, er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_relay_tx(const wallet_rpc::COMMAND_RPC_RELAY_TX::request& req, wallet_rpc::COMMAND_RPC_RELAY_TX::response& res, epee::json_rpc::error& er, const connection_context *ctx)
@@ -1932,8 +1907,7 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
     cryptonote::blobdata blob;
     if (!epee::string_tools::parse_hexstr_to_binbuff(req.hex, blob))
@@ -1943,68 +1917,61 @@ namespace tools
       return false;
     }
 
-    bool loaded = false;
-    tools::wallet2::pending_tx ptx;
-
-    try
-    {
-      binary_archive<false> ar{epee::strspan<std::uint8_t>(blob)};
-      if (::serialization::serialize(ar, ptx))
-        loaded = true;
-    }
-    catch(...) {}
-
-    if (!loaded)
+    std::unique_ptr<PendingTransaction> ptx = m_wallet_impl->deserializePtxFromBlobStr(blob);
+    if (!ptx || ptx->status() != PendingTransaction::Status::Status_Ok)
     {
       er.code = WALLET_RPC_ERROR_CODE_BAD_TX_METADATA;
       er.message = "Failed to parse tx metadata.";
       return false;
     }
 
-    try
-    {
-      m_wallet->commit_tx(ptx);
-    }
-    catch(const std::exception &e)
+    // commit() pops ptx, that's why we pre store txid here
+    std::string tmp_txid = ptx->txid()[0];
+    if (!ptx->commit())
     {
       er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
       er.message = "Failed to commit tx.";
       return false;
     }
 
-    res.tx_hash = epee::string_tools::pod_to_hex(cryptonote::get_transaction_hash(ptx.tx));
+    res.tx_hash = tmp_txid;
 
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_make_integrated_address(const wallet_rpc::COMMAND_RPC_MAKE_INTEGRATED_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_MAKE_INTEGRATED_ADDRESS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     try
     {
       crypto::hash8 payment_id;
+      std::string payment_id_str;
       if (req.payment_id.empty())
       {
         payment_id = crypto::rand<crypto::hash8>();
+        payment_id_str = epee::string_tools::pod_to_hex(payment_id);
       }
       else
       {
-        if (!tools::wallet2::parse_short_payment_id(req.payment_id,payment_id))
+        if (!(req.payment_id.size() == 2 * sizeof(payment_id)
+            && Wallet::paymentIdValid(req.payment_id)
+            && epee::string_tools::hex_to_pod(req.payment_id, payment_id)))
         {
           er.code = WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID;
           er.message = "Invalid payment ID";
           return false;
         }
+        payment_id_str = req.payment_id;
       }
 
       if (req.standard_address.empty())
       {
-        res.integrated_address = m_wallet->get_integrated_address_as_str(payment_id);
+        res.integrated_address = m_wallet_impl->integratedAddress(payment_id_str);
       }
       else
       {
         cryptonote::address_parse_info info;
-        if(!get_account_address_from_str(info, m_wallet->nettype(), req.standard_address))
+        if(!get_account_address_from_str(info, nettype(), req.standard_address))
         {
           er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
           er.message = "Invalid address";
@@ -2022,9 +1989,9 @@ namespace tools
           er.message = "Already integrated address";
           return false;
         }
-        res.integrated_address = get_account_integrated_address_as_str(m_wallet->nettype(), info.address, payment_id);
+        res.integrated_address = get_account_integrated_address_as_str(nettype(), info.address, payment_id);
       }
-      res.payment_id = epee::string_tools::pod_to_hex(payment_id);
+      res.payment_id = payment_id_str;
       return true;
     }
     catch (const std::exception& e)
@@ -2037,12 +2004,12 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_split_integrated_address(const wallet_rpc::COMMAND_RPC_SPLIT_INTEGRATED_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_SPLIT_INTEGRATED_ADDRESS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     try
     {
       cryptonote::address_parse_info info;
 
-      if(!get_account_address_from_str(info, m_wallet->nettype(), req.integrated_address))
+      if(!get_account_address_from_str(info, nettype(), req.integrated_address))
       {
         er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
         er.message = "Invalid address";
@@ -2054,7 +2021,7 @@ namespace tools
         er.message = "Address is not an integrated address";
         return false;
       }
-      res.standard_address = get_account_address_as_str(m_wallet->nettype(), info.is_subaddress, info.address);
+      res.standard_address = get_account_address_as_str(nettype(), info.is_subaddress, info.address);
       res.payment_id = epee::string_tools::pod_to_hex(info.payment_id);
       return true;
     }
@@ -2074,64 +2041,60 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
-    try
-    {
-      m_wallet->store();
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-    return true;
+    m_wallet_impl->store(/* path */ "");
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_get_payments(const wallet_rpc::COMMAND_RPC_GET_PAYMENTS::request& req, wallet_rpc::COMMAND_RPC_GET_PAYMENTS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     crypto::hash payment_id;
     crypto::hash8 payment_id8;
-    cryptonote::blobdata payment_id_blob;
-    if(!epee::string_tools::parse_hexstr_to_binbuff(req.payment_id, payment_id_blob))
+
+    bool r;
+    if (req.payment_id.size() == 2 * sizeof(payment_id))
+    {
+      r = epee::string_tools::hex_to_pod(req.payment_id, payment_id);
+    }
+    else if (req.payment_id.size() == 2 * sizeof(payment_id8))
+    {
+      r = epee::string_tools::hex_to_pod(req.payment_id, payment_id8);
+    }
+    else
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID;
-      er.message = "Payment ID has invalid format";
+      er.message = "Payment ID has invalid size: " + req.payment_id;
       return false;
     }
 
-      if(sizeof(payment_id) == payment_id_blob.size())
-      {
-        memcpy(&payment_id, payment_id_blob.data(), sizeof(payment_id));
-      }
-      else if(sizeof(payment_id8) == payment_id_blob.size())
-      {
-        memcpy(&payment_id8, payment_id_blob.data(), sizeof(payment_id8));
-        memcpy(payment_id.data, payment_id8.data, 8);
-        memset(payment_id.data + 8, 0, 24);
-      }
-      else
-      {
-        er.code = WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID;
-        er.message = "Payment ID has invalid size: " + req.payment_id;
-        return false;
-      }
+    if(!r)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID;
+      er.message = "Payment ID has invalid format: " + req.payment_id;
+      return false;
+    }
 
     res.payments.clear();
-    std::list<wallet2::payment_details> payment_list;
-    m_wallet->get_payments(payment_id, payment_list);
-    for (auto & payment : payment_list)
+    const std::vector<TransactionInfo *> &payment_list = m_wallet_impl->history()->getAll(/* do_refresh */ true);
+    for (const auto &payment : payment_list)
     {
+      // test req.payment_id against short payment id suffixed by 48 zeros to match old behavior
+      bool tx_id_match = (payment->paymentId() == req.payment_id)
+          || ((payment->paymentId() + "000000000000000000000000000000000000000000000000") == req.payment_id);
+      if (payment->direction() != TransactionInfo::Direction::Direction_In || !tx_id_match)
+          continue;
+      cryptonote::subaddress_index subaddress_index = { payment->subaddrAccount(), *payment->subaddrIndex().begin() };
       wallet_rpc::payment_details rpc_payment;
       rpc_payment.payment_id   = req.payment_id;
-      rpc_payment.tx_hash      = epee::string_tools::pod_to_hex(payment.m_tx_hash);
-      rpc_payment.amount       = payment.m_amount;
-      rpc_payment.block_height = payment.m_block_height;
-      rpc_payment.unlock_time  = payment.m_unlock_time;
-      rpc_payment.locked       = !m_wallet->is_transfer_unlocked(payment.m_unlock_time, payment.m_block_height);
-      rpc_payment.subaddr_index = payment.m_subaddr_index;
-      rpc_payment.address      = m_wallet->get_subaddress_as_str(payment.m_subaddr_index);
+      rpc_payment.tx_hash      = payment->hash();
+      rpc_payment.amount       = payment->amount();
+      rpc_payment.block_height = payment->blockHeight();
+      rpc_payment.unlock_time  = payment->unlockTime();
+      rpc_payment.locked       = !payment->isUnlocked();
+      rpc_payment.subaddr_index = subaddress_index;
+      rpc_payment.address      = m_wallet_impl->address(subaddress_index.major, subaddress_index.minor);
       res.payments.push_back(rpc_payment);
     }
 
@@ -2141,25 +2104,26 @@ namespace tools
   bool wallet_rpc_server::on_get_bulk_payments(const wallet_rpc::COMMAND_RPC_GET_BULK_PAYMENTS::request& req, wallet_rpc::COMMAND_RPC_GET_BULK_PAYMENTS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     res.payments.clear();
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
+    const std::vector<TransactionInfo *> &payment_list = m_wallet_impl->history()->getAll(/* do_refresh */ true);
     /* If the payment ID list is empty, we get payments to any payment ID (or lack thereof) */
     if (req.payment_ids.empty())
     {
-      std::list<std::pair<crypto::hash,wallet2::payment_details>> payment_list;
-      m_wallet->get_payments(payment_list, req.min_block_height);
-
       for (auto & payment : payment_list)
       {
+        if (payment->direction() != TransactionInfo::Direction::Direction_In || payment->blockHeight() < req.min_block_height)
+          continue;
+        cryptonote::subaddress_index subaddress_index = { payment->subaddrAccount(), *payment->subaddrIndex().begin() };
         wallet_rpc::payment_details rpc_payment;
-        rpc_payment.payment_id   = epee::string_tools::pod_to_hex(payment.first);
-        rpc_payment.tx_hash      = epee::string_tools::pod_to_hex(payment.second.m_tx_hash);
-        rpc_payment.amount       = payment.second.m_amount;
-        rpc_payment.block_height = payment.second.m_block_height;
-        rpc_payment.unlock_time  = payment.second.m_unlock_time;
-        rpc_payment.subaddr_index = payment.second.m_subaddr_index;
-        rpc_payment.address      = m_wallet->get_subaddress_as_str(payment.second.m_subaddr_index);
-        rpc_payment.locked       = !m_wallet->is_transfer_unlocked(payment.second.m_unlock_time, payment.second.m_block_height);
+        rpc_payment.payment_id   = payment->paymentId().size() == 16 ? payment->paymentId() + "000000000000000000000000000000000000000000000000" : payment->paymentId();
+        rpc_payment.tx_hash      = payment->hash();
+        rpc_payment.amount       = payment->amount();
+        rpc_payment.block_height = payment->blockHeight();
+        rpc_payment.unlock_time  = payment->unlockTime();
+        rpc_payment.subaddr_index = subaddress_index;
+        rpc_payment.address      = m_wallet_impl->address(subaddress_index.major, subaddress_index.minor);
+        rpc_payment.locked       = !payment->isUnlocked();
         res.payments.push_back(std::move(rpc_payment));
       }
 
@@ -2170,9 +2134,7 @@ namespace tools
     {
       crypto::hash payment_id;
       crypto::hash8 payment_id8;
-      cryptonote::blobdata payment_id_blob;
 
-      // TODO - should the whole thing fail because of one bad id?
       bool r;
       if (payment_id_str.size() == 2 * sizeof(payment_id))
       {
@@ -2181,11 +2143,6 @@ namespace tools
       else if (payment_id_str.size() == 2 * sizeof(payment_id8))
       {
         r = epee::string_tools::hex_to_pod(payment_id_str, payment_id8);
-        if (r)
-        {
-          memcpy(payment_id.data, payment_id8.data, 8);
-          memset(payment_id.data + 8, 0, 24);
-        }
       }
       else
       {
@@ -2201,20 +2158,25 @@ namespace tools
         return false;
       }
 
-      std::list<wallet2::payment_details> payment_list;
-      m_wallet->get_payments(payment_id, payment_list, req.min_block_height);
-
       for (auto & payment : payment_list)
       {
+        // test req.payment_id against short payment id suffixed by 48 zeros to match old behavior
+        bool tx_id_match = (payment->paymentId() == payment_id_str)
+            || ((payment->paymentId() + "000000000000000000000000000000000000000000000000") == payment_id_str);
+        if (payment->direction() != TransactionInfo::Direction::Direction_In
+            || payment->blockHeight() < req.min_block_height
+            || !tx_id_match)
+          continue;
+        cryptonote::subaddress_index subaddress_index = { payment->subaddrAccount(), *payment->subaddrIndex().begin() };
         wallet_rpc::payment_details rpc_payment;
         rpc_payment.payment_id   = payment_id_str;
-        rpc_payment.tx_hash      = epee::string_tools::pod_to_hex(payment.m_tx_hash);
-        rpc_payment.amount       = payment.m_amount;
-        rpc_payment.block_height = payment.m_block_height;
-        rpc_payment.unlock_time  = payment.m_unlock_time;
-        rpc_payment.subaddr_index = payment.m_subaddr_index;
-        rpc_payment.address      = m_wallet->get_subaddress_as_str(payment.m_subaddr_index);
-        rpc_payment.locked       = !m_wallet->is_transfer_unlocked(payment.m_unlock_time, payment.m_block_height);
+        rpc_payment.tx_hash      = payment->hash();
+        rpc_payment.amount       = payment->amount();
+        rpc_payment.block_height = payment->blockHeight();
+        rpc_payment.unlock_time  = payment->unlockTime();
+        rpc_payment.subaddr_index = subaddress_index;
+        rpc_payment.address      = m_wallet_impl->address(subaddress_index.major, subaddress_index.minor);
+        rpc_payment.locked       = !payment->isUnlocked();
         res.payments.push_back(std::move(rpc_payment));
       }
     }
@@ -2224,7 +2186,7 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_incoming_transfers(const wallet_rpc::COMMAND_RPC_INCOMING_TRANSFERS::request& req, wallet_rpc::COMMAND_RPC_INCOMING_TRANSFERS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     if(req.transfer_type.compare("all") != 0 && req.transfer_type.compare("available") != 0 && req.transfer_type.compare("unavailable") != 0)
     {
       er.code = WALLET_RPC_ERROR_CODE_TRANSFER_TYPE;
@@ -2245,31 +2207,26 @@ namespace tools
       available = false;
     }
 
-    wallet2::transfer_container transfers;
-    m_wallet->get_transfers(transfers);
+    const std::vector<std::unique_ptr<EnoteDetails>> &eds = m_wallet_impl->getEnoteDetails();
 
-    for (const auto& td : transfers)
+    for (const auto& ed : eds)
     {
-      if (!filter || available != td.m_spent)
+      if (!filter || available != ed->isSpent())
       {
-        if (req.account_index != td.m_subaddr_index.major || (!req.subaddr_indices.empty() && req.subaddr_indices.count(td.m_subaddr_index.minor) == 0))
+        if (req.account_index != ed->subaddressIndexMajor() || (!req.subaddr_indices.empty() && req.subaddr_indices.count(ed->subaddressIndexMinor()) == 0))
           continue;
 
-        // wallet2::is_transfer_unlocked() needs a daemon connection to work. if it fails, assume locked
-        bool unlocked = false;
-        try { unlocked = m_wallet->is_transfer_unlocked(td); } catch (...) {}
-
         wallet_rpc::transfer_details rpc_transfers;
-        rpc_transfers.amount       = td.amount();
-        rpc_transfers.spent        = td.m_spent;
-        rpc_transfers.global_index = td.m_global_output_index;
-        rpc_transfers.tx_hash      = epee::string_tools::pod_to_hex(td.m_txid);
-        rpc_transfers.subaddr_index = {td.m_subaddr_index.major, td.m_subaddr_index.minor};
-        rpc_transfers.key_image    = td.m_key_image_known ? epee::string_tools::pod_to_hex(td.m_key_image) : "";
-        rpc_transfers.pubkey       = epee::string_tools::pod_to_hex(td.get_public_key());
-        rpc_transfers.block_height = td.m_block_height;
-        rpc_transfers.frozen       = td.m_frozen;
-        rpc_transfers.unlocked     = unlocked;
+        rpc_transfers.amount       = ed->amount();
+        rpc_transfers.spent        = ed->isSpent();
+        rpc_transfers.global_index = ed->globalEnoteIndex();
+        rpc_transfers.tx_hash      = ed->txId();
+        rpc_transfers.subaddr_index = {ed->subaddressIndexMajor(), ed->subaddressIndexMinor()};
+        rpc_transfers.key_image    = ed->isKeyImageKnown() ? ed->keyImage() : "";
+        rpc_transfers.pubkey       = ed->onetimeAddress();
+        rpc_transfers.block_height = ed->blockHeight();
+        rpc_transfers.frozen       = ed->isFrozen();
+        rpc_transfers.unlocked     = ed->isUnlocked();
         res.transfers.push_back(rpc_transfers);
       }
     }
@@ -2285,22 +2242,23 @@ namespace tools
         er.message = "Command unavailable in restricted mode.";
         return false;
       }
-      if (!m_wallet) return not_open(er);
+      if (!m_wallet_impl) return not_open(er);
 
       if (req.key_type.compare("mnemonic") == 0)
       {
         epee::wipeable_string seed;
-        const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
+        const MultisigState &ms_status{m_wallet_impl->multisig()};
 
-        if (ms_status.multisig_is_active)
+        if (ms_status.isMultisig)
         {
-          if (!ms_status.is_ready)
+          if (!ms_status.isReady)
           {
             er.code = WALLET_RPC_ERROR_CODE_NOT_MULTISIG;
             er.message = "This wallet is multisig, but not yet finalized";
             return false;
           }
-          if (!m_wallet->get_multisig_seed(seed))
+          seed = m_wallet_impl->getMultisigSeed(/* seed_offset */ "");
+          if (seed.empty())
           {
             er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
             er.message = "Failed to get multisig seed.";
@@ -2309,20 +2267,21 @@ namespace tools
         }
         else
         {
-          if (m_wallet->watch_only())
+          if (m_wallet_impl->watchOnly())
           {
             er.code = WALLET_RPC_ERROR_CODE_WATCH_ONLY;
             er.message = "The wallet is watch-only. Cannot retrieve seed.";
             return false;
           }
           CHECK_IF_BACKGROUND_SYNCING();
-          if (!m_wallet->is_deterministic())
+          if (!m_wallet_impl->isDeterministic())
           {
             er.code = WALLET_RPC_ERROR_CODE_NON_DETERMINISTIC;
             er.message = "The wallet is non-deterministic. Cannot display seed.";
             return false;
           }
-          if (!m_wallet->get_seed(seed))
+          seed = m_wallet_impl->seed(/* seed_offset */ "");
+          if (seed.empty())
           {
             er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
             er.message = "Failed to get seed.";
@@ -2333,20 +2292,18 @@ namespace tools
       }
       else if(req.key_type.compare("view_key") == 0)
       {
-          epee::wipeable_string key = epee::to_hex::wipeable_string(m_wallet->get_account().get_keys().m_view_secret_key);
-          res.key = std::string(key.data(), key.size());
+          res.key = m_wallet_impl->secretViewKey();
       }
       else if(req.key_type.compare("spend_key") == 0)
       {
-          if (m_wallet->watch_only())
+          if (m_wallet_impl->watchOnly())
           {
             er.code = WALLET_RPC_ERROR_CODE_WATCH_ONLY;
             er.message = "The wallet is watch-only. Cannot retrieve spend key.";
             return false;
           }
           CHECK_IF_BACKGROUND_SYNCING();
-          epee::wipeable_string key = epee::to_hex::wipeable_string(m_wallet->get_account().get_keys().m_spend_secret_key);
-          res.key = std::string(key.data(), key.size());
+          res.key = m_wallet_impl->secretSpendKey();
       }
       else
       {
@@ -2367,16 +2324,8 @@ namespace tools
       return false;
     }
 
-    try
-    {
-      m_wallet->rescan_blockchain(req.hard, true, req.keep_key_images);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-    return true;
+    m_wallet_impl->rescanBlockchain(req.hard, req.keep_key_images);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_setup_background_sync(const wallet_rpc::COMMAND_RPC_SETUP_BACKGROUND_SYNC::request& req, wallet_rpc::COMMAND_RPC_SETUP_BACKGROUND_SYNC::response& res, epee::json_rpc::error& er, const connection_context *ctx)
@@ -2384,11 +2333,17 @@ namespace tools
     try
     {
       PRE_VALIDATE_BACKGROUND_SYNC();
-      const tools::wallet2::BackgroundSyncType background_sync_type = tools::wallet2::background_sync_type_from_str(req.background_sync_type);
-      boost::optional<epee::wipeable_string> background_cache_password = boost::none;
-      if (background_sync_type == tools::wallet2::BackgroundSyncCustomPassword)
-        background_cache_password = boost::optional<epee::wipeable_string>(req.background_cache_password);
-      m_wallet->setup_background_sync(background_sync_type, req.wallet_password, background_cache_password);
+      Wallet::BackgroundSyncType background_sync_type;
+      if (req.background_sync_type == "off") background_sync_type = Wallet::BackgroundSyncType::BackgroundSync_Off;
+      else if (req.background_sync_type == "reuse-wallet-password") background_sync_type = Wallet::BackgroundSyncType::BackgroundSync_ReusePassword;
+      else if (req.background_sync_type == "custom-background-password") background_sync_type = Wallet::BackgroundSyncType::BackgroundSync_CustomPassword;
+      else throw std::logic_error("Unknown background sync type");
+
+      optional<std::string> background_cache_password = optional<std::string>();
+      if (background_sync_type == Wallet::BackgroundSyncType::BackgroundSync_CustomPassword)
+          background_cache_password = optional<std::string>(req.background_cache_password);
+      m_wallet_impl->setupBackgroundSync(background_sync_type, req.wallet_password, background_cache_password);
+      if (api_error_to_rpc_error(er)) return false;
     }
     catch (...)
     {
@@ -2400,75 +2355,59 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_start_background_sync(const wallet_rpc::COMMAND_RPC_START_BACKGROUND_SYNC::request& req, wallet_rpc::COMMAND_RPC_START_BACKGROUND_SYNC::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    try
-    {
-      PRE_VALIDATE_BACKGROUND_SYNC();
-      m_wallet->start_background_sync();
-    }
-    catch (...)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-    return true;
+    PRE_VALIDATE_BACKGROUND_SYNC();
+    m_wallet_impl->startBackgroundSync();
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_stop_background_sync(const wallet_rpc::COMMAND_RPC_STOP_BACKGROUND_SYNC::request& req, wallet_rpc::COMMAND_RPC_STOP_BACKGROUND_SYNC::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    try
+    PRE_VALIDATE_BACKGROUND_SYNC();
+    crypto::secret_key spend_secret_key = crypto::null_skey;
+
+    // Load the spend key from seed if seed is provided
+    if (!req.seed.empty())
     {
-      PRE_VALIDATE_BACKGROUND_SYNC();
-      crypto::secret_key spend_secret_key = crypto::null_skey;
+      crypto::secret_key recovery_key;
+      std::string language;
 
-      // Load the spend key from seed if seed is provided
-      if (!req.seed.empty())
+      if (!crypto::ElectrumWords::words_to_bytes(req.seed, recovery_key, language))
       {
-        crypto::secret_key recovery_key;
-        std::string language;
-
-        if (!crypto::ElectrumWords::words_to_bytes(req.seed, recovery_key, language))
-        {
-          er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-          er.message = "Electrum-style word list failed verification";
-          return false;
-        }
-
-        if (!req.seed_offset.empty())
-          recovery_key = cryptonote::decrypt_key(recovery_key, req.seed_offset);
-
-        // generate spend key
-        cryptonote::account_base account;
-        account.generate(recovery_key, true, false);
-        spend_secret_key = account.get_keys().m_spend_secret_key;
+        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+        er.message = "Electrum-style word list failed verification";
+        return false;
       }
 
-      m_wallet->stop_background_sync(req.wallet_password, spend_secret_key);
+      if (!req.seed_offset.empty())
+        recovery_key = cryptonote::decrypt_key(recovery_key, req.seed_offset);
+
+      // generate spend key
+      cryptonote::account_base account;
+      account.generate(recovery_key, true, false);
+      spend_secret_key = account.get_keys().m_spend_secret_key;
     }
-    catch (...)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-    return true;
+    std::string spend_secret_key_str = epee::string_tools::pod_to_hex(unwrap(unwrap(spend_secret_key)));
+
+    const epee::scope_guard ssk_scope_exit_handler([&](){
+      memwipe(&spend_secret_key_str[0], spend_secret_key_str.size());
+    });
+    std::string_view ssk{spend_secret_key_str};
+    m_wallet_impl->stopBackgroundSync(req.wallet_password, &ssk);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_sign(const wallet_rpc::COMMAND_RPC_SIGN::request& req, wallet_rpc::COMMAND_RPC_SIGN::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
 
-    tools::wallet2::message_signature_type_t signature_type = tools::wallet2::sign_with_spend_key;
-    if (req.signature_type == "spend" || req.signature_type == "")
-      signature_type = tools::wallet2::sign_with_spend_key;
-    else if (req.signature_type == "view")
-      signature_type = tools::wallet2::sign_with_view_key;
-    else
+    if (req.signature_type != "spend" && req.signature_type != "" && req.signature_type != "view")
     {
       er.code = WALLET_RPC_ERROR_CODE_INVALID_SIGNATURE_TYPE;
       er.message = "Invalid signature type requested";
       return false;
     }
-    res.signature = m_wallet->sign(req.data, signature_type, {req.account_index, req.address_index});
-    return true;
+    res.signature = m_wallet_impl->signMessage(req.data, m_wallet_impl->address(req.account_index, req.address_index), req.signature_type == "view");
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_verify(const wallet_rpc::COMMAND_RPC_VERIFY::request& req, wallet_rpc::COMMAND_RPC_VERIFY::response& res, epee::json_rpc::error& er, const connection_context *ctx)
@@ -2479,11 +2418,11 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
     cryptonote::address_parse_info info;
     er.message = "";
-    if(!get_account_address_from_str_or_url(info, m_wallet->nettype(), req.address,
+    if(!get_account_address_from_str_or_url(info, nettype(), req.address,
       [&er](const std::string &url, const std::vector<std::string> &addresses, bool dnssec_valid)->std::string {
         if (!dnssec_valid)
         {
@@ -2502,16 +2441,7 @@ namespace tools
       return false;
     }
 
-    const auto result = m_wallet->verify(req.data, info.address, req.signature);
-    res.good = result.valid;
-    res.version = result.version;
-    res.old = result.old;
-    switch (result.type)
-    {
-      case tools::wallet2::sign_with_spend_key: res.signature_type = "spend"; break;
-      case tools::wallet2::sign_with_view_key: res.signature_type = "view"; break;
-      default: res.signature_type = "invalid"; break;
-    }
+    res.good = m_wallet_impl->verifySignedMessage(req.data, req.address, req.signature, &res.old, &res.signature_type, &res.version);
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -2523,18 +2453,11 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
-    try
-    {
-      m_wallet->store();
-      m_stop.store(true, std::memory_order_relaxed);
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
+    m_wallet_impl->store(/* path */ "");
+    if (api_error_to_rpc_error(er)) return false;
+    m_stop.store(true, std::memory_order_relaxed);
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -2566,11 +2489,12 @@ namespace tools
       txids.push_back(txid);
     }
 
-    std::list<crypto::hash>::const_iterator il = txids.begin();
+    std::list<std::string>::const_iterator il = req.txids.begin();
     std::list<std::string>::const_iterator in = req.notes.begin();
-    while (il != txids.end())
+    while (il != req.txids.end())
     {
-      m_wallet->set_tx_note(*il++, *in++);
+      m_wallet_impl->setUserNote(*il++, *in++);
+      if (api_error_to_rpc_error(er)) return false;
     }
 
     return true;
@@ -2579,7 +2503,7 @@ namespace tools
   bool wallet_rpc_server::on_get_tx_notes(const wallet_rpc::COMMAND_RPC_GET_TX_NOTES::request& req, wallet_rpc::COMMAND_RPC_GET_TX_NOTES::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     res.notes.clear();
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
     std::list<crypto::hash> txids;
     std::list<std::string>::const_iterator i = req.txids.begin();
@@ -2598,10 +2522,11 @@ namespace tools
       txids.push_back(txid);
     }
 
-    std::list<crypto::hash>::const_iterator il = txids.begin();
-    while (il != txids.end())
+    std::list<std::string>::const_iterator il = req.txids.begin();
+    while (il != req.txids.end())
     {
-      res.notes.push_back(m_wallet->get_tx_note(*il++));
+      res.notes.push_back(m_wallet_impl->getUserNote(*il++));
+      if (api_error_to_rpc_error(er)) return false;
     }
     return true;
   }
@@ -2610,7 +2535,7 @@ namespace tools
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
 
-    m_wallet->set_attribute(req.key, req.value);
+    m_wallet_impl->setCacheAttribute(req.key, req.value);
 
     return true;
   }
@@ -2623,9 +2548,10 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
-    if (!m_wallet->get_attribute(req.key, res.value))
+    res.value = m_wallet_impl->getCacheAttribute(req.key);
+    if (res.value.empty())
     {
       er.code = WALLET_RPC_ERROR_CODE_ATTRIBUTE_NOT_FOUND;
       er.message = "Attribute not found.";
@@ -2633,9 +2559,9 @@ namespace tools
     }
     return true;
   }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_get_tx_key(const wallet_rpc::COMMAND_RPC_GET_TX_KEY::request& req, wallet_rpc::COMMAND_RPC_GET_TX_KEY::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
     CHECK_IF_BACKGROUND_SYNCING();
 
     crypto::hash txid;
@@ -2646,26 +2572,13 @@ namespace tools
       return false;
     }
 
-    crypto::secret_key tx_key;
-    std::vector<crypto::secret_key> additional_tx_keys;
-    if (!m_wallet->get_tx_key(txid, tx_key, additional_tx_keys))
-    {
-      er.code = WALLET_RPC_ERROR_CODE_NO_TXKEY;
-      er.message = "No tx secret key is stored for this tx";
-      return false;
-    }
-
-    epee::wipeable_string s;
-    s += epee::to_hex::wipeable_string(tx_key);
-    for (size_t i = 0; i < additional_tx_keys.size(); ++i)
-      s += epee::to_hex::wipeable_string(additional_tx_keys[i]);
-    res.tx_key = std::string(s.data(), s.size());
-    return true;
+    res.tx_key = m_wallet_impl->getTxKey(req.txid);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_check_tx_key(const wallet_rpc::COMMAND_RPC_CHECK_TX_KEY::request& req, wallet_rpc::COMMAND_RPC_CHECK_TX_KEY::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
     crypto::hash txid;
     if (!epee::string_tools::hex_to_pod(req.txid, txid))
@@ -2705,29 +2618,19 @@ namespace tools
     }
 
     cryptonote::address_parse_info info;
-    if(!get_account_address_from_str(info, m_wallet->nettype(), req.address))
+    if(!get_account_address_from_str(info, nettype(), req.address))
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
       er.message = "Invalid address";
       return false;
     }
 
-    try
-    {
-      m_wallet->check_tx_key(txid, tx_key, additional_tx_keys, info.address, res.received, res.in_pool, res.confirmations);
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = e.what();
-      return false;
-    }
-    return true;
+    m_wallet_impl->checkTxKey(req.txid, req.tx_key, req.address, res.received, res.in_pool, res.confirmations);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_get_tx_proof(const wallet_rpc::COMMAND_RPC_GET_TX_PROOF::request& req, wallet_rpc::COMMAND_RPC_GET_TX_PROOF::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
     CHECK_IF_BACKGROUND_SYNCING();
 
     crypto::hash txid;
@@ -2739,29 +2642,20 @@ namespace tools
     }
 
     cryptonote::address_parse_info info;
-    if(!get_account_address_from_str(info, m_wallet->nettype(), req.address))
+    if(!get_account_address_from_str(info, nettype(), req.address))
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
       er.message = "Invalid address";
       return false;
     }
 
-    try
-    {
-      res.signature = m_wallet->get_tx_proof(txid, info.address, info.is_subaddress, req.message);
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = e.what();
-      return false;
-    }
-    return true;
+    res.signature = m_wallet_impl->getTxProof(req.txid, req.address, req.message);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_check_tx_proof(const wallet_rpc::COMMAND_RPC_CHECK_TX_PROOF::request& req, wallet_rpc::COMMAND_RPC_CHECK_TX_PROOF::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
     crypto::hash txid;
     if (!epee::string_tools::hex_to_pod(req.txid, txid))
@@ -2772,29 +2666,19 @@ namespace tools
     }
 
     cryptonote::address_parse_info info;
-    if(!get_account_address_from_str(info, m_wallet->nettype(), req.address))
+    if(!get_account_address_from_str(info, nettype(), req.address))
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
       er.message = "Invalid address";
       return false;
     }
 
-    try
-    {
-      res.good = m_wallet->check_tx_proof(txid, info.address, info.is_subaddress, req.message, req.signature, res.received, res.in_pool, res.confirmations);
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = e.what();
-      return false;
-    }
-    return true;
+    m_wallet_impl->checkTxProof(req.txid, req.address, req.message, req.signature, res.good, res.received, res.in_pool, res.confirmations);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_get_spend_proof(const wallet_rpc::COMMAND_RPC_GET_SPEND_PROOF::request& req, wallet_rpc::COMMAND_RPC_GET_SPEND_PROOF::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
     CHECK_IF_BACKGROUND_SYNCING();
 
     crypto::hash txid;
@@ -2805,22 +2689,13 @@ namespace tools
       return false;
     }
 
-    try
-    {
-      res.signature = m_wallet->get_spend_proof(txid, req.message);
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = e.what();
-      return false;
-    }
-    return true;
+    res.signature = m_wallet_impl->getSpendProof(req.txid, req.message);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_check_spend_proof(const wallet_rpc::COMMAND_RPC_CHECK_SPEND_PROOF::request& req, wallet_rpc::COMMAND_RPC_CHECK_SPEND_PROOF::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
     crypto::hash txid;
     if (!epee::string_tools::hex_to_pod(req.txid, txid))
@@ -2830,55 +2705,34 @@ namespace tools
       return false;
     }
 
-    try
-    {
-      res.good = m_wallet->check_spend_proof(txid, req.message, req.signature);
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = e.what();
-      return false;
-    }
-    return true;
+    m_wallet_impl->checkSpendProof(req.txid, req.message, req.signature, res.good);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_get_reserve_proof(const wallet_rpc::COMMAND_RPC_GET_RESERVE_PROOF::request& req, wallet_rpc::COMMAND_RPC_GET_RESERVE_PROOF::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
     CHECK_IF_BACKGROUND_SYNCING();
 
-    boost::optional<std::pair<uint32_t, uint64_t>> account_minreserve;
     if (!req.all)
     {
-      if (req.account_index >= m_wallet->get_num_subaddress_accounts())
+      if (req.account_index >= m_wallet_impl->numSubaddressAccounts())
       {
         er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
         er.message = "Account index is out of bound";
         return false;
       }
-      account_minreserve = std::make_pair(req.account_index, req.amount);
     }
 
-    try
-    {
-      res.signature = m_wallet->get_reserve_proof(account_minreserve, req.message);
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = e.what();
-      return false;
-    }
-    return true;
+    res.signature = m_wallet_impl->getReserveProof(req.all, req.account_index, req.amount, req.message);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_check_reserve_proof(const wallet_rpc::COMMAND_RPC_CHECK_RESERVE_PROOF::request& req, wallet_rpc::COMMAND_RPC_CHECK_RESERVE_PROOF::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
     cryptonote::address_parse_info info;
-    if (!get_account_address_from_str(info, m_wallet->nettype(), req.address))
+    if (!get_account_address_from_str(info, nettype(), req.address))
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_ADDRESS;
       er.message = "Invalid address";
@@ -2891,22 +2745,13 @@ namespace tools
       return false;
     }
 
-    try
-    {
-      res.good = m_wallet->check_reserve_proof(info.address, req.message, req.signature, res.total, res.spent);
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = e.what();
-      return false;
-    }
-    return true;
+    m_wallet_impl->checkReserveProof(req.address, req.message, req.signature, res.good, res.total, res.spent);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_get_transfers(const wallet_rpc::COMMAND_RPC_GET_TRANSFERS::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSFERS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
     uint64_t min_height = 0, max_height = CRYPTONOTE_MAX_BLOCK_NUMBER;
     if (req.filter_by_height)
@@ -2923,55 +2768,50 @@ namespace tools
       subaddr_indices.clear();
     }
 
-    if (req.in)
+    const std::vector<TransactionInfo *> &txs = m_wallet_impl->history()->getAll(/* do_refresh */ true);
+    for (const auto &tx : txs)
     {
-      std::list<std::pair<crypto::hash, tools::wallet2::payment_details>> payments;
-      m_wallet->get_payments(payments, min_height, max_height, account_index, subaddr_indices);
-      for (std::list<std::pair<crypto::hash, tools::wallet2::payment_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
+      if (req.in
+       && tx->direction() == TransactionInfo::Direction_In
+       && !tx->isPending()
+       && tx->blockHeight() > min_height
+       && tx->blockHeight() <= max_height
+       && (!account_index || tx->subaddrAccount() == account_index)
+       && (subaddr_indices.empty() || *tx->subaddrIndex().begin() == *subaddr_indices.begin())) {
         res.in.push_back(wallet_rpc::transfer_entry());
-        fill_transfer_entry(res.in.back(), i->second.m_tx_hash, i->first, i->second);
+        fill_transfer_entry(res.in.back(), *tx);
+        continue;
       }
-    }
 
-    if (req.out)
-    {
-      std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>> payments;
-      m_wallet->get_payments_out(payments, min_height, max_height, account_index, subaddr_indices);
-      for (std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
+      if (req.out
+       && tx->direction() == TransactionInfo::Direction_Out
+       && !tx->isPending()
+       && tx->blockHeight() > min_height
+       && tx->blockHeight() <= max_height
+       && (!account_index || tx->subaddrAccount() == account_index)
+       && (subaddr_indices.empty() || std::count_if(tx->subaddrIndex().begin(), tx->subaddrIndex().end(), [&subaddr_indices](uint32_t index) { return subaddr_indices.count(index) == 1; }) != 0)) {
         res.out.push_back(wallet_rpc::transfer_entry());
-        fill_transfer_entry(res.out.back(), i->first, i->second);
+        fill_transfer_entry(res.out.back(), *tx);
+        continue;
       }
-    }
 
-    if (req.pending || req.failed) {
-      std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>> upayments;
-      m_wallet->get_unconfirmed_payments_out(upayments, account_index, subaddr_indices);
-      for (std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>>::const_iterator i = upayments.begin(); i != upayments.end(); ++i) {
-        const tools::wallet2::unconfirmed_transfer_details &pd = i->second;
-        bool is_failed = pd.m_state == tools::wallet2::unconfirmed_transfer_details::failed;
-        if (!((req.failed && is_failed) || (!is_failed && req.pending)))
-          continue;
-        std::list<wallet_rpc::transfer_entry> &entries = is_failed ? res.failed : res.pending;
+      if (((req.pending && tx->isPending()) || (req.failed && tx->isFailed()))
+       && tx->direction() == TransactionInfo::Direction_Out
+       && (!account_index || tx->subaddrAccount() == account_index)
+       && (subaddr_indices.empty() || std::count_if(tx->subaddrIndex().begin(), tx->subaddrIndex().end(), [&subaddr_indices](uint32_t index) { return subaddr_indices.count(index) == 1; }) != 0)) {
+        std::list<wallet_rpc::transfer_entry> &entries = tx->isFailed() ? res.failed : res.pending;
         entries.push_back(wallet_rpc::transfer_entry());
-        fill_transfer_entry(entries.back(), i->first, i->second);
-      }
-    }
-
-    if (req.pool)
-    {
-      if (!m_restricted)
-      {
-        std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> process_txs;
-        m_wallet->update_pool_state(process_txs);
-        if (!process_txs.empty())
-          m_wallet->process_pool_state(process_txs);
+        fill_transfer_entry(entries.back(), *tx);
+        continue;
       }
 
-      std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> payments;
-      m_wallet->get_unconfirmed_payments(payments, account_index, subaddr_indices);
-      for (std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
+      if (req.pool
+       && tx->direction() == TransactionInfo::Direction_In
+       && tx->isPending()
+       && (!account_index || tx->subaddrAccount() == account_index)
+       && (subaddr_indices.empty() || std::count_if(tx->subaddrIndex().begin(), tx->subaddrIndex().end(), [&subaddr_indices](uint32_t index) { return subaddr_indices.count(index) == 1; }) != 0)) {
         res.pool.push_back(wallet_rpc::transfer_entry());
-        fill_transfer_entry(res.pool.back(), i->first, i->second);
+        fill_transfer_entry(res.pool.back(), *tx);
       }
     }
 
@@ -2980,7 +2820,7 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_get_transfer_by_txid(const wallet_rpc::COMMAND_RPC_GET_TRANSFER_BY_TXID::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSFER_BY_TXID::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
     crypto::hash txid;
     cryptonote::blobdata txid_blob;
@@ -2991,70 +2831,27 @@ namespace tools
       return false;
     }
 
-    if(sizeof(txid) == txid_blob.size())
-    {
-      memcpy(&txid, txid_blob.data(), sizeof(txid));
-    }
-    else
+    if(sizeof(txid) != txid_blob.size())
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_TXID;
       er.message = "Transaction ID has invalid size: " + req.txid;
       return false;
     }
 
-    if (req.account_index >= m_wallet->get_num_subaddress_accounts())
+    if (req.account_index >= m_wallet_impl->numSubaddressAccounts())
     {
       er.code = WALLET_RPC_ERROR_CODE_ACCOUNT_INDEX_OUT_OF_BOUNDS;
       er.message = "Account index is out of bound";
       return false;
     }
 
-    std::list<std::pair<crypto::hash, tools::wallet2::payment_details>> payments;
-    m_wallet->get_payments(payments, 0, (uint64_t)-1, req.account_index);
-    for (std::list<std::pair<crypto::hash, tools::wallet2::payment_details>>::const_iterator i = payments.begin(); i != payments.end(); ++i) {
-      if (i->second.m_tx_hash == txid)
-      {
-        res.transfers.resize(res.transfers.size() + 1);
-        fill_transfer_entry(res.transfers.back(), i->second.m_tx_hash, i->first, i->second);
-      }
-    }
-
-    std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>> payments_out;
-    m_wallet->get_payments_out(payments_out, 0, (uint64_t)-1, req.account_index);
-    for (std::list<std::pair<crypto::hash, tools::wallet2::confirmed_transfer_details>>::const_iterator i = payments_out.begin(); i != payments_out.end(); ++i) {
-      if (i->first == txid)
-      {
-        res.transfers.resize(res.transfers.size() + 1);
-        fill_transfer_entry(res.transfers.back(), i->first, i->second);
-      }
-    }
-
-    std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>> upayments;
-    m_wallet->get_unconfirmed_payments_out(upayments, req.account_index);
-    for (std::list<std::pair<crypto::hash, tools::wallet2::unconfirmed_transfer_details>>::const_iterator i = upayments.begin(); i != upayments.end(); ++i) {
-      if (i->first == txid)
-      {
-        res.transfers.resize(res.transfers.size() + 1);
-        fill_transfer_entry(res.transfers.back(), i->first, i->second);
-      }
-    }
-
-    if (!m_restricted)
+    const std::vector<TransactionInfo *> &txs = m_wallet_impl->history()->getAll(/* do_refresh */ true);
+    for (const auto &tx : txs)
     {
-      std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> process_txs;
-      m_wallet->update_pool_state(process_txs);
-      if (!process_txs.empty())
-        m_wallet->process_pool_state(process_txs);
-    }
-
-    std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>> pool_payments;
-    m_wallet->get_unconfirmed_payments(pool_payments, req.account_index);
-    for (std::list<std::pair<crypto::hash, tools::wallet2::pool_payment_details>>::const_iterator i = pool_payments.begin(); i != pool_payments.end(); ++i) {
-      if (i->second.m_pd.m_tx_hash == txid)
-      {
-        res.transfers.resize(res.transfers.size() + 1);
-        fill_transfer_entry(res.transfers.back(), i->first, i->second);
-      }
+      if (req.txid != tx->hash() || req.account_index != tx->subaddrAccount())
+          continue;
+      res.transfers.resize(res.transfers.size() + 1);
+      fill_transfer_entry(res.transfers.back(), *tx);
     }
 
     if (!res.transfers.empty())
@@ -3076,8 +2873,8 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    if (m_wallet->key_on_device())
+    if (!m_wallet_impl) return not_open(er);
+    if (m_wallet_impl->getDeviceState().key_on_device)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "command not supported by HW wallet";
@@ -3085,17 +2882,8 @@ namespace tools
     }
     CHECK_IF_BACKGROUND_SYNCING();
 
-    try
-    {
-      res.outputs_data_hex = epee::string_tools::buff_to_hex_nodelimer(m_wallet->export_outputs_to_str(req.all, req.start, req.count));
-    }
-    catch (const std::exception &e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-
-    return true;
+    res.outputs_data_hex = epee::string_tools::buff_to_hex_nodelimer(m_wallet_impl->exportEnotesToStr(req.all, req.start, req.count));
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_import_outputs(const wallet_rpc::COMMAND_RPC_IMPORT_OUTPUTS::request& req, wallet_rpc::COMMAND_RPC_IMPORT_OUTPUTS::response& res, epee::json_rpc::error& er, const connection_context *ctx)
@@ -3106,8 +2894,8 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    if (m_wallet->key_on_device())
+    if (!m_wallet_impl) return not_open(er);
+    if (m_wallet_impl->getDeviceState().key_on_device)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "command not supported by HW wallet";
@@ -3123,40 +2911,24 @@ namespace tools
       return false;
     }
 
-    try
-    {
-      res.num_imported = m_wallet->import_outputs_from_str(blob);
-    }
-    catch (const std::exception &e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-
-    return true;
+    res.num_imported = m_wallet_impl->importEnotesFromStr(blob);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_export_key_images(const wallet_rpc::COMMAND_RPC_EXPORT_KEY_IMAGES::request& req, wallet_rpc::COMMAND_RPC_EXPORT_KEY_IMAGES::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
-    try
+    std::vector<std::pair<std::string, std::string>> key_images_and_signatures;
+    std::uint64_t offset;
+    m_wallet_impl->exportKeyImages(req.all, offset, key_images_and_signatures);
+    if (api_error_to_rpc_error(er)) return false;
+    res.offset = offset;
+    res.signed_key_images.resize(key_images_and_signatures.size());
+    for (size_t n = 0; n < key_images_and_signatures.size(); ++n)
     {
-      std::pair<uint64_t, std::vector<std::pair<crypto::key_image, crypto::signature>>> ski = m_wallet->export_key_images(req.all);
-      res.offset = ski.first;
-      res.signed_key_images.resize(ski.second.size());
-      for (size_t n = 0; n < ski.second.size(); ++n)
-      {
-         res.signed_key_images[n].key_image = epee::string_tools::pod_to_hex(ski.second[n].first);
-         res.signed_key_images[n].signature = epee::string_tools::pod_to_hex(ski.second[n].second);
-      }
+       res.signed_key_images[n].key_image = key_images_and_signatures[n].first;
+       res.signed_key_images[n].signature = key_images_and_signatures[n].second;
     }
-
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -3168,55 +2940,46 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    if (!m_wallet->is_trusted_daemon())
+    if (!m_wallet_impl) return not_open(er);
+    if (!m_wallet_impl->trustedDaemon())
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "This command requires a trusted daemon.";
       return false;
     }
     CHECK_IF_BACKGROUND_SYNCING();
-    try
+    std::vector<std::pair<std::string, std::string>> ski;
+    crypto::key_image tmp_ki;
+    crypto::signature tmp_sig;
+    ski.resize(req.signed_key_images.size());
+    for (size_t n = 0; n < ski.size(); ++n)
     {
-      std::vector<std::pair<crypto::key_image, crypto::signature>> ski;
-      ski.resize(req.signed_key_images.size());
-      for (size_t n = 0; n < ski.size(); ++n)
+      if (!epee::string_tools::hex_to_pod(req.signed_key_images[n].key_image, tmp_ki))
       {
-        if (!epee::string_tools::hex_to_pod(req.signed_key_images[n].key_image, ski[n].first))
-        {
-          er.code = WALLET_RPC_ERROR_CODE_WRONG_KEY_IMAGE;
-          er.message = "failed to parse key image";
-          return false;
-        }
-
-        if (!epee::string_tools::hex_to_pod(req.signed_key_images[n].signature, ski[n].second))
-        {
-          er.code = WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE;
-          er.message = "failed to parse signature";
-          return false;
-        }
+        er.code = WALLET_RPC_ERROR_CODE_WRONG_KEY_IMAGE;
+        er.message = "failed to parse key image";
+        return false;
       }
-      uint64_t spent = 0, unspent = 0;
-      uint64_t height = m_wallet->import_key_images(ski, req.offset, spent, unspent);
-      res.spent = spent;
-      res.unspent = unspent;
-      res.height = height;
+      ski[n].first = req.signed_key_images[n].key_image;
+
+      if (!epee::string_tools::hex_to_pod(req.signed_key_images[n].signature, tmp_sig))
+      {
+        er.code = WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE;
+        er.message = "failed to parse signature";
+        return false;
+      }
+      ski[n].second = req.signed_key_images[n].signature;
     }
 
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-
-    return true;
+    res.height = m_wallet_impl->importKeyImages(ski, req.offset, res.spent, res.unspent);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_make_uri(const wallet_rpc::COMMAND_RPC_MAKE_URI::request& req, wallet_rpc::COMMAND_RPC_MAKE_URI::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     std::string error;
-    std::string uri = m_wallet->make_uri(req.address, req.payment_id, req.amount, req.tx_description, req.recipient_name, error);
+    std::string uri = m_wallet_impl->make_uri(req.address, req.payment_id, req.amount, req.tx_description, req.recipient_name, error);
     if (uri.empty())
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_URI;
@@ -3230,9 +2993,9 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_parse_uri(const wallet_rpc::COMMAND_RPC_PARSE_URI::request& req, wallet_rpc::COMMAND_RPC_PARSE_URI::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     std::string error;
-    if (!m_wallet->parse_uri(req.uri, res.uri.address, res.uri.payment_id, res.uri.amount, res.uri.tx_description, res.uri.recipient_name, res.unknown_parameters, error))
+    if (!m_wallet_impl->parse_uri(req.uri, res.uri.address, res.uri.payment_id, res.uri.amount, res.uri.tx_description, res.uri.recipient_name, res.unknown_parameters, error))
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_URI;
       er.message = "Error parsing URI: " + error;
@@ -3243,20 +3006,14 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_get_address_book(const wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::request& req, wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
     CHECK_IF_BACKGROUND_SYNCING();
-    const auto ab = m_wallet->get_address_book();
+    const auto ab = m_wallet_impl->addressBook()->getAll();
     if (req.entries.empty())
     {
       uint64_t idx = 0;
       for (const auto &entry: ab)
       {
-        std::string address;
-        if (entry.m_has_payment_id)
-          address = cryptonote::get_account_integrated_address_as_str(m_wallet->nettype(), entry.m_address, entry.m_payment_id);
-        else
-          address = get_account_address_as_str(m_wallet->nettype(), entry.m_is_subaddress, entry.m_address);
-        res.entries.push_back(wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::entry{idx++, address, entry.m_description});
+        res.entries.push_back(wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::entry{idx++, entry->getAddress(), entry->getDescription()});
       }
     }
     else
@@ -3271,11 +3028,7 @@ namespace tools
         }
         const auto &entry = ab[idx];
         std::string address;
-        if (entry.m_has_payment_id)
-          address = cryptonote::get_account_integrated_address_as_str(m_wallet->nettype(), entry.m_address, entry.m_payment_id);
-        else
-          address = get_account_address_as_str(m_wallet->nettype(), entry.m_is_subaddress, entry.m_address);
-        res.entries.push_back(wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::entry{idx, address, entry.m_description});
+        res.entries.push_back(wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::entry{idx, entry->getAddress(), entry->getDescription()});
       }
     }
     return true;
@@ -3287,8 +3040,9 @@ namespace tools
 
     cryptonote::address_parse_info info;
     er.message = "";
-    if(!get_account_address_from_str_or_url(info, m_wallet->nettype(), req.address,
-      [&er](const std::string &url, const std::vector<std::string> &addresses, bool dnssec_valid)->std::string {
+    std::string address{};
+    if(!get_account_address_from_str_or_url(info, nettype(), req.address,
+      [&er, &address](const std::string &url, const std::vector<std::string> &addresses, bool dnssec_valid)->std::string {
         if (!dnssec_valid)
         {
           er.message = std::string("Invalid DNSSEC for ") + url;
@@ -3299,6 +3053,7 @@ namespace tools
           er.message = std::string("No Monero address found at ") + url;
           return {};
         }
+        address = addresses[0];
         return addresses[0];
       }))
     {
@@ -3307,13 +3062,15 @@ namespace tools
         er.message = std::string("WALLET_RPC_ERROR_CODE_WRONG_ADDRESS: ") + req.address;
       return false;
     }
-    if (!m_wallet->add_address_book_row(info.address, info.has_payment_id ? &info.payment_id : NULL, req.description, info.is_subaddress))
+    AddressBook *address_book = m_wallet_impl->addressBook();
+    address = address.empty() ? req.address : address;
+    if (!address_book->addRow(address, /* [deprecated] payment_id */ "", req.description))
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "Failed to add address book entry";
       return false;
     }
-    res.index = m_wallet->get_address_book().size() - 1;
+    res.index = address_book->getAll().size() - 1;
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -3321,22 +3078,23 @@ namespace tools
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
 
-    const auto ab = m_wallet->get_address_book();
-    if (req.index >= ab.size())
+    const auto ab = m_wallet_impl->addressBook();
+    const auto ab_entries = ab->getAll();
+    if (req.index >= ab_entries.size())
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_INDEX;
       er.message = "Index out of range: " + std::to_string(req.index);
       return false;
     }
 
-    tools::wallet2::address_book_row entry = ab[req.index];
-
+    bool success = true;
     cryptonote::address_parse_info info;
+    std::string address{};
     if (req.set_address)
     {
       er.message = "";
-      if(!get_account_address_from_str_or_url(info, m_wallet->nettype(), req.address,
-        [&er](const std::string &url, const std::vector<std::string> &addresses, bool dnssec_valid)->std::string {
+      if(!get_account_address_from_str_or_url(info, nettype(), req.address,
+        [&er, &address](const std::string &url, const std::vector<std::string> &addresses, bool dnssec_valid)->std::string {
           if (!dnssec_valid)
           {
             er.message = std::string("Invalid DNSSEC for ") + url;
@@ -3347,6 +3105,7 @@ namespace tools
             er.message = std::string("No Monero address found at ") + url;
             return {};
           }
+          address = addresses[0];
           return addresses[0];
         }))
       {
@@ -3355,16 +3114,14 @@ namespace tools
           er.message = std::string("WALLET_RPC_ERROR_CODE_WRONG_ADDRESS: ") + req.address;
         return false;
       }
-      entry.m_address = info.address;
-      entry.m_is_subaddress = info.is_subaddress;
-      entry.m_has_payment_id = info.has_payment_id;
-      entry.m_payment_id = info.has_payment_id ? info.payment_id : crypto::null_hash8;
+      address = address.empty() ? req.address : address;
+      success = ab->setAddress(req.index, address);
     }
 
-    if (req.set_description)
-      entry.m_description = req.description;
+    if (success && req.set_description)
+      success = ab->setDescription(req.index, req.description);
 
-    if (!m_wallet->set_address_book_row(req.index, entry.m_address, entry.m_has_payment_id ? &entry.m_payment_id : NULL, entry.m_description, entry.m_is_subaddress))
+    if (!success)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "Failed to edit address book entry";
@@ -3377,14 +3134,13 @@ namespace tools
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
 
-    const auto ab = m_wallet->get_address_book();
-    if (req.index >= ab.size())
+    if (req.index >= m_wallet_impl->addressBook()->getAll().size())
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_INDEX;
       er.message = "Index out of range: " + std::to_string(req.index);
       return false;
     }
-    if (!m_wallet->delete_address_book_row(req.index))
+    if (!m_wallet_impl->addressBook()->deleteRow(req.index))
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "Failed to delete address book entry";
@@ -3401,18 +3157,15 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    try
-    {
-      m_wallet->refresh(m_wallet->is_trusted_daemon(), req.start_height, res.blocks_fetched, res.received_money);
-      return true;
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-    return true;
+    if (!m_wallet_impl) return not_open(er);
+    m_wallet_impl->refresh(req.start_height,
+                             /* check_pool */ true,
+                             /* try_incremental */ true,
+                             /* max_blocks */ std::numeric_limits<std::uint64_t>::max(),
+                             /* skip_refresh_if_daemon_not_synced */ false,
+                             &res.blocks_fetched,
+                             &res.received_money);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_auto_refresh(const wallet_rpc::COMMAND_RPC_AUTO_REFRESH::request& req, wallet_rpc::COMMAND_RPC_AUTO_REFRESH::response& res, epee::json_rpc::error& er, const connection_context *ctx)
@@ -3445,56 +3198,43 @@ namespace tools
   {
       CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
 
-      std::unordered_set<crypto::hash> txids;
+      std::vector<std::string> txids;
       std::list<std::string>::const_iterator i = req.txids.begin();
       while (i != req.txids.end())
       {
           cryptonote::blobdata txid_blob;
-          if(!epee::string_tools::parse_hexstr_to_binbuff(*i++, txid_blob) || txid_blob.size() != sizeof(crypto::hash))
+          if(!epee::string_tools::parse_hexstr_to_binbuff(*i, txid_blob) || txid_blob.size() != sizeof(crypto::hash))
           {
               er.code = WALLET_RPC_ERROR_CODE_WRONG_TXID;
               er.message = "TX ID has invalid format";
               return false;
           }
 
-          crypto::hash txid;
-          memcpy(&txid, txid_blob.data(), sizeof(txid));
-          txids.insert(txid);
+          txids.push_back(*i++);
       }
 
-      try {
-          m_wallet->scan_tx(txids);
-      }  catch (const tools::error::wont_reprocess_recent_txs_via_untrusted_daemon &e) {
-          er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-          er.message = e.what() + std::string(". Either connect to a trusted daemon or rescan the chain.");
-          return false;
-      } catch (const std::exception &e) {
-          handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-          return false;
-      }
-      return true;
+    bool wont_reprocess_recent_txs_via_untrusted_daemon;
+    m_wallet_impl->scanTransactions(txids, &wont_reprocess_recent_txs_via_untrusted_daemon);
+    if (wont_reprocess_recent_txs_via_untrusted_daemon)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = std::string("The wallet has already seen 1 or more recent transactions than the scanned tx. Either connect to a trusted daemon or rescan the chain.");
+      return false;
+    }
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_rescan_spent(const wallet_rpc::COMMAND_RPC_RESCAN_SPENT::request& req, wallet_rpc::COMMAND_RPC_RESCAN_SPENT::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
-    if (!m_wallet->is_trusted_daemon())
+    if (!m_wallet_impl->trustedDaemon())
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "This command requires a trusted daemon.";
       return false;
     }
-    try
-    {
-      m_wallet->rescan_spent();
-      return true;
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-    return true;
+    m_wallet_impl->rescanSpent();
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_start_mining(const wallet_rpc::COMMAND_RPC_START_MINING::request& req, wallet_rpc::COMMAND_RPC_START_MINING::response& res, epee::json_rpc::error& er, const connection_context *ctx)
@@ -3505,8 +3245,8 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    if (!m_wallet->is_trusted_daemon())
+    if (!m_wallet_impl) return not_open(er);
+    if (!m_wallet_impl->trustedDaemon())
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "This command requires a trusted daemon.";
@@ -3521,18 +3261,14 @@ namespace tools
       return false;
     }
 
-    cryptonote::COMMAND_RPC_START_MINING::request daemon_req{};
-    daemon_req.miner_address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-    daemon_req.threads_count        = req.threads_count;
-    daemon_req.do_background_mining = req.do_background_mining;
-    daemon_req.ignore_battery       = req.ignore_battery;
-
-    cryptonote::COMMAND_RPC_START_MINING::response daemon_res;
-    bool r = m_wallet->invoke_http_json("/start_mining", daemon_req, daemon_res);
-    if (!r || daemon_res.status != CORE_RPC_STATUS_OK)
+    if (!m_wallet_manager->startMining(m_wallet_impl->address(),
+                                       req.threads_count,
+                                       req.do_background_mining,
+                                       req.ignore_battery))
     {
+      std::string err = m_wallet_manager->errorString();
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = "Couldn't start mining due to unknown error.";
+      er.message = "Couldn't start mining: " + (!err.empty() ? err : "due to unknown error.");
       return false;
     }
     return true;
@@ -3546,14 +3282,13 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    cryptonote::COMMAND_RPC_STOP_MINING::request daemon_req;
-    cryptonote::COMMAND_RPC_STOP_MINING::response daemon_res;
-    bool r = m_wallet->invoke_http_json("/stop_mining", daemon_req, daemon_res, std::chrono::seconds(60)); // this waits till stopped, and if randomx has just started initializing its dataset, it might be a while
-    if (!r || daemon_res.status != CORE_RPC_STATUS_OK)
+    if (!m_wallet_impl) return not_open(er);
+
+    if (!m_wallet_manager->stopMining())
     {
+      std::string err = m_wallet_manager->errorString();
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = "Couldn't stop mining due to unknown error.";
+      er.message = "Couldn't stop mining: " + (!err.empty() ? err : "due to unknown error.");
       return false;
     }
     return true;
@@ -3581,8 +3316,6 @@ namespace tools
       return false;
     }
 
-    namespace po = boost::program_options;
-    po::variables_map vm2;
     const char *ptr = strchr(req.filename.c_str(), '/');
 #ifdef _WIN32
     if (!ptr)
@@ -3605,63 +3338,56 @@ namespace tools
         return false;
       }
     }
+
+    int error_code, extended_error_code;
+    std::string error_msg;
+    std::unique_ptr<Wallet> wal;
+    NetworkType nettype;
+    if (!get_nettype(m_vm, nettype))
     {
-      po::options_description desc("dummy");
-      const command_line::arg_descriptor<std::string, true> arg_password = {"password", "password"};
-      const char *argv[4];
-      int argc = 3;
-      argv[0] = "wallet-rpc";
-      argv[1] = "--password";
-      argv[2] = req.password.c_str();
-      argv[3] = NULL;
-      vm2 = *m_vm;
-      command_line::add_arg(desc, arg_password);
-      po::store(po::parse_command_line(argc, argv, desc), vm2);
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = "Invalid nettype";
+      return false;
     }
-    std::unique_ptr<tools::wallet2> wal = tools::wallet2::make_new(vm2, true, nullptr).first;
+    wal.reset(
+      m_wallet_manager->createWallet(
+        wallet_file,
+        req.password,
+        req.language,
+        nettype,
+        command_line::get_arg(m_vm, arg_kdf_rounds),
+        /* create_address_file */ false,
+        /* non_deterministic */ false,
+        /* unattended */ true,
+        command_line::get_arg(m_vm, arg_extra_entropy))
+    );
     if (!wal)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "Failed to create wallet";
       return false;
     }
-    wal->set_seed_language(req.language);
-    cryptonote::COMMAND_RPC_GET_HEIGHT::request hreq;
-    cryptonote::COMMAND_RPC_GET_HEIGHT::response hres;
-    hres.height = 0;
-    bool r = wal->invoke_http_json("/getheight", hreq, hres);
-    if (r)
-      wal->set_refresh_from_block_height(hres.height);
-    crypto::secret_key dummy_key;
-    try {
-      wal->generate(wallet_file, req.password, dummy_key, false, false);
-    }
-    catch (const std::exception& e)
+    wal->statusWithErrorString(error_code, error_msg, &extended_error_code);
+    if (error_code != Wallet::Status::Status_Ok)
     {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
+      er.code = extended_error_code;
+      er.message = "Failed to create wallet: " + error_msg;
       return false;
     }
-    if (!wal)
+    if (!init_wallet(m_vm, wal, m_wallet_manager))
     {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = "Failed to generate wallet";
+      wal->statusWithErrorString(error_code, error_msg, &extended_error_code);
+      er.code = extended_error_code;
+      er.message = "Failed to initialize wallet: " + error_msg;
       return false;
     }
 
-    if (m_wallet)
+    if (m_wallet_impl)
     {
-      try
-      {
-        m_wallet->store();
-      }
-      catch (const std::exception& e)
-      {
-        handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-        return false;
-      }
-      delete m_wallet;
+      m_wallet_impl->store(/* path */ "");
+      if (api_error_to_rpc_error(er)) return false;
     }
-    m_wallet = wal.release();
+    m_wallet_impl = std::move(wal);
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -3680,8 +3406,6 @@ namespace tools
       return false;
     }
 
-    namespace po = boost::program_options;
-    po::variables_map vm2;
     const char *ptr = strchr(req.filename.c_str(), '/');
 #ifdef _WIN32
     if (!ptr)
@@ -3695,50 +3419,52 @@ namespace tools
       er.message = "Invalid filename";
       return false;
     }
-    if (m_wallet && req.autosave_current)
+    if (m_wallet_impl && req.autosave_current)
     {
-      try
-      {
-        m_wallet->store();
-      }
-      catch (const std::exception& e)
-      {
-        handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-        return false;
-      }
+      m_wallet_impl->store(/* path */ "");
+      if (api_error_to_rpc_error(er)) return false;
     }
     std::string wallet_file = m_wallet_dir + "/" + req.filename;
+
+    std::unique_ptr<Wallet> wal;
+    NetworkType nettype;
+    if (!get_nettype(m_vm, nettype))
     {
-      po::options_description desc("dummy");
-      const command_line::arg_descriptor<std::string, true> arg_password = {"password", "password"};
-      const char *argv[4];
-      int argc = 3;
-      argv[0] = "wallet-rpc";
-      argv[1] = "--password";
-      argv[2] = req.password.c_str();
-      argv[3] = NULL;
-      vm2 = *m_vm;
-      command_line::add_arg(desc, arg_password);
-      po::store(po::parse_command_line(argc, argv, desc), vm2);
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = "Invalid nettype";
+      return false;
     }
-    std::unique_ptr<tools::wallet2> wal = nullptr;
-    try {
-      wal = tools::wallet2::make_from_file(vm2, true, wallet_file, nullptr).first;
-    }
-    catch (const std::exception& e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-    }
+    wal.reset(
+      m_wallet_manager->openWallet(
+        wallet_file,
+        req.password,
+        nettype,
+        command_line::get_arg(m_vm, arg_kdf_rounds))
+    );
     if (!wal)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = "Failed to open wallet : " + (!er.message.empty() ? er.message : "Unknown.");
+      er.message = "Failed to open wallet";
+      return false;
+    }
+    int error_code, extended_error_code;
+    std::string error_msg;
+    wal->statusWithErrorString(error_code, error_msg, &extended_error_code);
+    if (error_code != Wallet::Status::Status_Ok)
+    {
+      er.code = extended_error_code;
+      er.message = "Failed to open wallet: " + error_msg;
+      return false;
+    }
+    if (!init_wallet(m_vm, wal, m_wallet_manager))
+    {
+      wal->statusWithErrorString(error_code, error_msg, &extended_error_code);
+      er.code = extended_error_code;
+      er.message = "Failed to initialize wallet: " + error_msg;
       return false;
     }
 
-    if (m_wallet)
-      delete m_wallet;
-    m_wallet = wal.release();
+    m_wallet_impl = std::move(wal);
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -3750,40 +3476,30 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
     if (req.autosave_current)
     {
-      try
-      {
-        m_wallet->store();
-      }
-      catch (const std::exception& e)
-      {
-        handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-        return false;
-      }
+      m_wallet_impl->store(/* path */ "");
+      if (api_error_to_rpc_error(er)) return false;
     }
-    delete m_wallet;
-    m_wallet = NULL;
+    if (!m_wallet_manager->closeWallet(m_wallet_impl.release(), /* store */ false))
+    {
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = "Failed to close wallet: " + m_wallet_manager->errorString();
+      return false;
+    }
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_change_wallet_password(const wallet_rpc::COMMAND_RPC_CHANGE_WALLET_PASSWORD::request& req, wallet_rpc::COMMAND_RPC_CHANGE_WALLET_PASSWORD::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
     CHECK_IF_RESTRICTED_BACKGROUND_SYNCING();
-    if (m_wallet->verify_password(req.old_password))
+    if (m_wallet_impl->verifyPassword(req.old_password))
     {
-      try
-      {
-        m_wallet->change_password(m_wallet->get_wallet_file(), req.old_password, req.new_password);
-        LOG_PRINT_L0("Wallet password changed.");
-      }
-      catch (const std::exception& e)
-      {
-        handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-        return false;
-      }
+      m_wallet_impl->setPassword(req.old_password, req.new_password);
+      if (api_error_to_rpc_error(er)) return false;
+      LOG_PRINT_L0("Wallet password changed.");
     }
     else
     {
@@ -3909,8 +3625,6 @@ namespace tools
       return false;
     }
 
-    namespace po = boost::program_options;
-    po::variables_map vm2;
     const char *ptr = strchr(req.filename.c_str(), '/');
   #ifdef _WIN32
     if (!ptr)
@@ -3941,39 +3655,23 @@ namespace tools
       }
     }
 
-    {
-      po::options_description desc("dummy");
-      const command_line::arg_descriptor<std::string, true> arg_password = {"password", "password"};
-      const char *argv[4];
-      int argc = 3;
-      argv[0] = "wallet-rpc";
-      argv[1] = "--password";
-      argv[2] = req.password.c_str();
-      argv[3] = NULL;
-      vm2 = *m_vm;
-      command_line::add_arg(desc, arg_password);
-      po::store(po::parse_command_line(argc, argv, desc), vm2);
-    }
-
-    auto rc = tools::wallet2::make_new(vm2, true, nullptr);
-    std::unique_ptr<wallet2> wal;
-    wal = std::move(rc.first);
-    if (!wal)
+    cryptonote::address_parse_info info;
+    std::unique_ptr<Wallet> wal;
+    NetworkType nettype;
+    if (!get_nettype(m_vm, nettype))
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = "Failed to create wallet";
+      er.message = "Invalid nettype";
       return false;
     }
 
-    cryptonote::address_parse_info info;
-    if(!get_account_address_from_str(info, wal->nettype(), req.address))
+    if(!get_account_address_from_str(info, static_cast<cryptonote::network_type>(nettype), req.address))
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "Failed to parse public address";
       return false;
     }
 
-    epee::wipeable_string password = rc.second.password();
     epee::wipeable_string viewkey_string = req.viewkey;
     crypto::secret_key viewkey;
     if (!viewkey_string.hex_to_pod(unwrap(unwrap(viewkey))))
@@ -3991,60 +3689,58 @@ namespace tools
       return false;
     }
 
-    if (m_wallet && req.autosave_current)
+    if (!req.spendkey.empty())
     {
-      try
+      epee::wipeable_string spendkey_string = req.spendkey;
+      crypto::secret_key spendkey;
+      if (!spendkey_string.hex_to_pod(unwrap(unwrap(spendkey))))
       {
-        if (!wallet_file.empty())
-          m_wallet->store();
+        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+        er.message = "Failed to parse spend key secret key";
+        return false;
       }
-      catch (const std::exception &e)
+
+      if (!hwdev.verify_keys(spendkey, info.address.m_spend_public_key))
       {
-        handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
+        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+        er.message = "spend secret key does not match main address";
         return false;
       }
     }
 
-    try
-    {
-      if (!req.spendkey.empty())
-      {
-        epee::wipeable_string spendkey_string = req.spendkey;
-        crypto::secret_key spendkey;
-        if (!spendkey_string.hex_to_pod(unwrap(unwrap(spendkey))))
-        {
-          er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-          er.message = "Failed to parse spend key secret key";
-          return false;
-        }
-
-        if (!hwdev.verify_keys(spendkey, info.address.m_spend_public_key))
-        {
-          er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-          er.message = "spend secret key does not match main address";
-          return false;
-        }
-
-        wal->generate(wallet_file, std::move(rc.second).password(), info.address, spendkey, viewkey, false);
-        res.info = "Wallet has been generated successfully.";
-      }
-      else
-      {
-        wal->generate(wallet_file, std::move(rc.second).password(), info.address, viewkey, false);
-        res.info = "Watch-only wallet has been generated successfully.";
-      }
-      MINFO("Wallet has been generated.\n");
-    }
-    catch (const std::exception &e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-
+    std::uint64_t kdf_rounds = command_line::get_arg(m_vm, arg_kdf_rounds);
+    // Note : we skip seed language here and apply it ourself below
+    //        recoverFromKeysWithPassword() only sets seed language for
+    //            - spend-key only, deterministic (restore by spend-key only is not allowed in the wallet-rpc)
+    //        and does not set it for
+    //            - view-key + spend-key, deterministic
+    //            - view-key + spend-key, non-deterministic (not needed, doesn't have a seed)
+    //            - view-key only (not needed, doesn't have a seed)
+    wal.reset(
+      m_wallet_manager->createWalletFromKeys(
+        wallet_file,
+        req.password,
+        /* language */ "",
+        nettype,
+        req.restore_height,
+        req.address,
+        req.viewkey,
+        req.spendkey,
+        kdf_rounds)
+    );
     if (!wal)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = "Failed to generate wallet";
+      er.message = "Failed to create wallet";
+      return false;
+    }
+    int error_code, extended_error_code;
+    std::string error_msg;
+    wal->statusWithErrorString(error_code, error_msg, &extended_error_code);
+    if (error_code != Wallet::Status::Status_Ok)
+    {
+      er.code = extended_error_code;
+      er.message = "Failed to create wallet: " + error_msg;
       return false;
     }
 
@@ -4056,25 +3752,39 @@ namespace tools
         er.message = "The specified seed language is invalid.";
         return false;
       }
-      wal->set_seed_language(req.language);
+      wal->setSeedLanguage(req.language);
     }
 
-    // set blockheight if given
-    try
+    std::string prefix = req.spendkey.empty() ? "View-only " : wal->isDeterministic() ? "" : "Non-deterministic ";
+    res.info = prefix + "Wallet has been generated successfully.";
+    MINFO(prefix + "Wallet has been generated.\n");
+
+    if (!init_wallet(m_vm, wal, m_wallet_manager))
     {
-      wal->set_refresh_from_block_height(req.restore_height);
-      wal->rewrite(wallet_file, password);
-    }
-    catch (const std::exception &e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
+      wal->statusWithErrorString(error_code, error_msg, &extended_error_code);
+      er.code = extended_error_code;
+      er.message = "Failed to initialize wallet: " + error_msg;
       return false;
     }
 
-    if (m_wallet)
-      delete m_wallet;
-    m_wallet = wal.release();
-    res.address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
+    // Store current wallet, if one was already open
+    if (m_wallet_impl && req.autosave_current)
+    {
+      if (!wallet_file.empty())
+      {
+        m_wallet_impl->store(/* path */ "");
+        if (api_error_to_rpc_error(er)) return false;
+      }
+    }
+    // Store newly generated wallet
+    m_wallet_impl = std::move(wal);
+    if (m_wallet_impl)
+    {
+      m_wallet_impl->store(/* path */ "");
+      if (api_error_to_rpc_error(er)) return false;
+    }
+
+    res.address = m_wallet_impl->address();
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -4101,8 +3811,6 @@ namespace tools
       return false;
     }
 
-    namespace po = boost::program_options;
-    po::variables_map vm2;
     const char *ptr = strchr(req.filename.c_str(), '/');
   #ifdef _WIN32
     if (!ptr)
@@ -4144,59 +3852,6 @@ namespace tools
         return false;
       }
     }
-    if (m_wallet && req.autosave_current)
-    {
-      try
-      {
-        m_wallet->store();
-      }
-      catch (const std::exception &e)
-      {
-        handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-        return false;
-      }
-    }
-
-    // process seed_offset if given
-    {
-      if (req.enable_multisig_experimental && !req.seed_offset.empty())
-      {
-        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        er.message = "Multisig seeds are not compatible with seed offsets";
-        return false;
-      }
-
-      if (!req.seed_offset.empty())
-      {
-        recovery_key = cryptonote::decrypt_key(recovery_key, req.seed_offset);
-      }
-    }
-    {
-      po::options_description desc("dummy");
-      const command_line::arg_descriptor<std::string, true> arg_password = {"password", "password"};
-      const char *argv[4];
-      int argc = 3;
-      argv[0] = "wallet-rpc";
-      argv[1] = "--password";
-      argv[2] = req.password.c_str();
-      argv[3] = NULL;
-      vm2 = *m_vm;
-      command_line::add_arg(desc, arg_password);
-      po::store(po::parse_command_line(argc, argv, desc), vm2);
-    }
-
-    auto rc = tools::wallet2::make_new(vm2, true, nullptr);
-    std::unique_ptr<wallet2> wal;
-    wal = std::move(rc.first);
-    if (!wal)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = "Failed to create wallet";
-      return false;
-    }
-
-    epee::wipeable_string password = rc.second.password();
-
     bool was_deprecated_wallet = ((old_language == crypto::ElectrumWords::old_language_name) ||
                                   crypto::ElectrumWords::get_is_old_style_seed(req.seed));
 
@@ -4224,43 +3879,104 @@ namespace tools
       mnemonic_language = req.language;
     }
 
-    wal->set_seed_language(mnemonic_language);
-
-    crypto::secret_key recovery_val;
-    try
+    // process seed_offset if given
+    if (!req.seed_offset.empty())
     {
       if (req.enable_multisig_experimental)
       {
-        // Parse multisig seed into raw multisig data
-        epee::wipeable_string multisig_data;
-        multisig_data.resize(req.seed.size() / 2);
-        if (!epee::from_hex::to_buffer(epee::to_mut_byte_span(multisig_data), req.seed))
-        {
-          er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-          er.message = "Multisig seed not represented as hexadecimal string";
-          return false;
-        }
+        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+        er.message = "Multisig seeds are not compatible with seed offsets";
+        return false;
+      }
 
-        // Generate multisig wallet
-        wal->generate(wallet_file, std::move(rc.second).password(), multisig_data, false);
-        wal->enable_multisig(true);
-      }
-      else
-      {
-        // Generate normal wallet
-        recovery_val = wal->generate(wallet_file, std::move(rc.second).password(), recovery_key, true, false, false);
-      }
-      MINFO("Wallet has been restored.\n");
+      recovery_key = cryptonote::decrypt_key(recovery_key, req.seed_offset);
     }
-    catch (const std::exception &e)
+    std::unique_ptr<Wallet> wal;
+    NetworkType nettype;
+    if (!get_nettype(m_vm, nettype))
     {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = "Invalid nettype";
+      return false;
+    }
+
+    std::uint64_t kdf_rounds = command_line::get_arg(m_vm, arg_kdf_rounds);
+    int error_code, extended_error_code;
+    std::string error_msg;
+    std::string prefix = "";
+    if (req.enable_multisig_experimental)
+    {
+      // Parse multisig seed into raw multisig data
+      epee::wipeable_string multisig_data;
+      multisig_data.resize(req.seed.size() / 2);
+      if (!epee::from_hex::to_buffer(epee::to_mut_byte_span(multisig_data), req.seed))
+      {
+        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+        er.message = "Multisig seed not represented as hexadecimal string";
+        return false;
+      }
+
+      // Generate multisig wallet
+      wal.reset(
+        m_wallet_manager->createWalletFromMultisigSeed(
+          wallet_file,
+          req.password,
+          mnemonic_language,
+          nettype,
+          req.restore_height,
+          std::string(multisig_data.data(), multisig_data.size()),
+          req.seed_offset,
+          kdf_rounds)
+      );
+      prefix = "Multisig ";
+    }
+    else
+    {
+      // Generate normal wallet
+      wal.reset(
+        m_wallet_manager->recoveryWallet(
+          wallet_file,
+          req.password,
+          req.seed,
+          nettype,
+          req.restore_height,
+          kdf_rounds,
+          req.seed_offset)
+      );
+    }
+    if (!wal)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = "Failed to create wallet";
+      return false;
+    }
+    wal->statusWithErrorString(error_code, error_msg, &extended_error_code);
+    if (error_code != Wallet::Status::Status_Ok)
+    {
+      er.code = extended_error_code;
+      er.message = "Failed to initialize wallet: " + error_msg;
+      return false;
+    }
+
+    if (req.enable_multisig_experimental)
+      wal->setEnableMultisig(true);
+
+    res.info = prefix + "Wallet has been restored successfully.";
+    res.address = wal->address();
+    MINFO(prefix + "Wallet has been restored.\n");
+    if (!init_wallet(m_vm, wal, m_wallet_manager))
+    {
+      wal->statusWithErrorString(error_code, error_msg, &extended_error_code);
+      er.code = extended_error_code;
+      er.message = "Failed to initialize wallet: " + error_msg;
       return false;
     }
 
     // // Convert the secret key back to seed
     epee::wipeable_string electrum_words;
-    if (!req.enable_multisig_experimental && !crypto::ElectrumWords::bytes_to_words(recovery_val, electrum_words, mnemonic_language))
+    crypto::secret_key secret_spend_key = crypto::null_skey;
+    epee::string_tools::hex_to_pod(wal->secretSpendKey(), secret_spend_key);
+    if (!req.enable_multisig_experimental && !crypto::ElectrumWords::bytes_to_words(secret_spend_key, electrum_words, mnemonic_language))
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "Failed to encode seed";
@@ -4268,41 +3984,33 @@ namespace tools
     }
     res.seed = std::string(electrum_words.data(), electrum_words.size());
 
-    if (!wal)
+    // Store current wallet, if one was already open
+    if (m_wallet_impl && req.autosave_current)
     {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = "Failed to generate wallet";
-      return false;
+      if (!wallet_file.empty())
+      {
+        m_wallet_impl->store(/* path */ "");
+        if (api_error_to_rpc_error(er)) return false;
+      }
     }
-
-    // set blockheight if given
-    try
+    // Store newly generated wallet
+    m_wallet_impl = std::move(wal);
+    if (m_wallet_impl)
     {
-      wal->set_refresh_from_block_height(req.restore_height);
-      wal->rewrite(wallet_file, password);
+      m_wallet_impl->store(/* path */ "");
+      if (api_error_to_rpc_error(er)) return false;
     }
-    catch (const std::exception &e)
-    {
-      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
-      return false;
-    }
-
-    if (m_wallet)
-      delete m_wallet;
-    m_wallet = wal.release();
-    res.address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-    res.info = "Wallet has been restored successfully.";
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_is_multisig(const wallet_rpc::COMMAND_RPC_IS_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_IS_MULTISIG::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
-    const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
+    if (!m_wallet_impl) return not_open(er);
+    const auto &ms_status = m_wallet_impl->multisig();
 
-    res.multisig = ms_status.multisig_is_active;
-    res.kex_is_done = ms_status.kex_is_done;
-    res.ready = ms_status.is_ready;
+    res.multisig = ms_status.isMultisig;
+    res.kex_is_done = ms_status.kexIsDone;
+    res.ready = ms_status.isReady;
     res.threshold = ms_status.threshold;
     res.total = ms_status.total;
 
@@ -4317,17 +4025,17 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    if (m_wallet->get_multisig_status().multisig_is_active)
+    if (!m_wallet_impl) return not_open(er);
+    if (m_wallet_impl->multisig().isMultisig)
     {
       er.code = WALLET_RPC_ERROR_CODE_ALREADY_MULTISIG;
       er.message = "This wallet is already multisig";
       return false;
     }
     if (req.enable_multisig_experimental)
-      m_wallet->enable_multisig(true);
+      m_wallet_impl->setEnableMultisig(true);
     CHECK_MULTISIG_ENABLED();
-    if (m_wallet->watch_only())
+    if (m_wallet_impl->watchOnly())
     {
       er.code = WALLET_RPC_ERROR_CODE_WATCH_ONLY;
       er.message = "wallet is watch-only and cannot be made multisig";
@@ -4335,7 +4043,7 @@ namespace tools
     }
     CHECK_IF_BACKGROUND_SYNCING();
 
-    res.multisig_info = m_wallet->get_multisig_first_kex_msg();
+    res.multisig_info = m_wallet_impl->getMultisigInfo();
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -4347,15 +4055,15 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    if (m_wallet->get_multisig_status().multisig_is_active)
+    if (!m_wallet_impl) return not_open(er);
+    if (m_wallet_impl->multisig().isMultisig)
     {
       er.code = WALLET_RPC_ERROR_CODE_ALREADY_MULTISIG;
       er.message = "This wallet is already multisig";
       return false;
     }
     CHECK_MULTISIG_ENABLED();
-    if (m_wallet->watch_only())
+    if (m_wallet_impl->watchOnly())
     {
       er.code = WALLET_RPC_ERROR_CODE_WATCH_ONLY;
       er.message = "wallet is watch-only and cannot be made multisig";
@@ -4363,17 +4071,9 @@ namespace tools
     }
     CHECK_IF_BACKGROUND_SYNCING();
 
-    try
-    {
-      res.multisig_info = m_wallet->make_multisig(req.password, req.multisig_info, req.threshold);
-      res.address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = e.what();
-      return false;
-    }
+    res.multisig_info = m_wallet_impl->makeMultisig(req.multisig_info, req.threshold, req.password);
+    if (api_error_to_rpc_error(er)) return false;
+    res.address = m_wallet_impl->address();
 
     return true;
   }
@@ -4386,16 +4086,16 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
+    if (!m_wallet_impl) return not_open(er);
+    const MultisigState ms_status{m_wallet_impl->multisig()};
 
-    if (!ms_status.multisig_is_active)
+    if (!ms_status.isMultisig)
     {
       er.code = WALLET_RPC_ERROR_CODE_NOT_MULTISIG;
       er.message = "This wallet is not multisig";
       return false;
     }
-    if (!ms_status.is_ready)
+    if (!ms_status.isReady)
     {
       er.code = WALLET_RPC_ERROR_CODE_NOT_MULTISIG;
       er.message = "This wallet is multisig, but not yet finalized";
@@ -4403,21 +4103,8 @@ namespace tools
     }
     CHECK_MULTISIG_ENABLED();
 
-    cryptonote::blobdata info;
-    try
-    {
-      info = m_wallet->export_multisig();
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = e.what();
-      return false;
-    }
-
-    res.info = epee::string_tools::buff_to_hex_nodelimer(info);
-
-    return true;
+    m_wallet_impl->exportMultisigImages(res.info);
+    return !api_error_to_rpc_error(er);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_import_multisig(const wallet_rpc::COMMAND_RPC_IMPORT_MULTISIG::request& req, wallet_rpc::COMMAND_RPC_IMPORT_MULTISIG::response& res, epee::json_rpc::error& er, const connection_context *ctx)
@@ -4428,16 +4115,16 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
+    if (!m_wallet_impl) return not_open(er);
+    const MultisigState ms_status{m_wallet_impl->multisig()};
 
-    if (!ms_status.multisig_is_active)
+    if (!ms_status.isMultisig)
     {
       er.code = WALLET_RPC_ERROR_CODE_NOT_MULTISIG;
       er.message = "This wallet is not multisig";
       return false;
     }
-    if (!ms_status.is_ready)
+    if (!ms_status.isReady)
     {
       er.code = WALLET_RPC_ERROR_CODE_NOT_MULTISIG;
       er.message = "This wallet is multisig, but not yet finalized";
@@ -4464,28 +4151,18 @@ namespace tools
       }
     }
 
-    try
-    {
-      res.n_outputs = m_wallet->import_multisig(info, req.refresh_after_import);
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = std::string{"Error calling import_multisig: "} + e.what();
-      return false;
-    }
+    res.n_outputs = m_wallet_impl->importMultisigImages(req.info);
+    if (api_error_to_rpc_error(er)) return false;
 
     if (req.refresh_after_import)
     {
-      if (m_wallet->is_trusted_daemon())
+      if (m_wallet_impl->trustedDaemon())
       {
-        try
+        m_wallet_impl->rescanSpent();
+        if (api_error_to_rpc_error(er))
         {
-          m_wallet->rescan_spent();
-        }
-        catch (const std::exception &e)
-        {
-          er.message = std::string("Success, but failed to update spent status after import multisig info: ") + e.what();
+          er.message = std::string("Success, but failed to update spent status after import multisig info: ") + er.message;
+          return false;
         }
       }
       else
@@ -4505,10 +4182,10 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
+    if (!m_wallet_impl) return not_open(er);
+    MultisigState ms_status{m_wallet_impl->multisig()};
 
-    if (!ms_status.multisig_is_active)
+    if (!ms_status.isMultisig)
     {
       er.code = WALLET_RPC_ERROR_CODE_NOT_MULTISIG;
       er.message = "This wallet is not multisig";
@@ -4523,20 +4200,16 @@ namespace tools
       return false;
     }
 
-    try
+    res.multisig_info = m_wallet_impl->exchangeMultisigKeys(req.multisig_info, req.password, req.force_update_use_with_caution);
+    if (api_error_to_rpc_error(er))
     {
-      res.multisig_info = m_wallet->exchange_multisig_keys(req.password, req.multisig_info, req.force_update_use_with_caution);
-      ms_status = m_wallet->get_multisig_status();
-      if (ms_status.is_ready)
-      {
-        res.address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
-      }
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = std::string("Error calling exchange_multisig_info: ") + e.what();
+      er.message = std::string("Error calling exchange_multisig_info: ") + er.message;
       return false;
+    }
+    ms_status = m_wallet_impl->multisig();
+    if (ms_status.isReady)
+    {
+      res.address = m_wallet_impl->address();
     }
     return true;
   }
@@ -4549,10 +4222,10 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
+    if (!m_wallet_impl) return not_open(er);
+    const MultisigState ms_status{m_wallet_impl->multisig()};
 
-    if (ms_status.is_ready)
+    if (ms_status.isReady)
     {
       er.code = WALLET_RPC_ERROR_CODE_ALREADY_MULTISIG;
       er.message = "This wallet is multisig, and already finalized";
@@ -4566,17 +4239,14 @@ namespace tools
       return false;
     }
 
-    try
+    res.multisig_info = m_wallet_impl->getMultisigKeyExchangeBooster(
+      req.multisig_info,
+      req.threshold,
+      req.num_signers,
+      req.password);
+    if (api_error_to_rpc_error(er))
     {
-      res.multisig_info = m_wallet->get_multisig_key_exchange_booster(req.password,
-        req.multisig_info,
-        req.threshold,
-        req.num_signers);
-    }
-    catch (const std::exception &e)
-    {
-      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-      er.message = std::string("Error calling exchange_multisig_info_booster: ") + e.what();
+      er.message = std::string("Error calling exchange_multisig_info_booster: ") + er.message;
       return false;
     }
     return true;
@@ -4590,16 +4260,16 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
+    if (!m_wallet_impl) return not_open(er);
+    const MultisigState ms_status{m_wallet_impl->multisig()};
 
-    if (!ms_status.multisig_is_active)
+    if (!ms_status.isMultisig)
     {
       er.code = WALLET_RPC_ERROR_CODE_NOT_MULTISIG;
       er.message = "This wallet is not multisig";
       return false;
     }
-    if (!ms_status.is_ready)
+    if (!ms_status.isReady)
     {
       er.code = WALLET_RPC_ERROR_CODE_NOT_MULTISIG;
       er.message = "This wallet is multisig, but not yet finalized";
@@ -4615,38 +4285,33 @@ namespace tools
       return false;
     }
 
-    tools::wallet2::multisig_tx_set txs;
-    bool r = m_wallet->load_multisig_tx(blob, txs, NULL);
-    if (!r)
+    std::vector<std::string> txids;
+    PendingTransaction *ptx;
+    ptx = m_wallet_impl->restoreMultisigTransaction(req.tx_data_hex);
+    if (api_error_to_rpc_error(er) || !ptx)
     {
       er.code = WALLET_RPC_ERROR_CODE_BAD_MULTISIG_TX_DATA;
-      er.message = "Failed to parse multisig tx data.";
+      er.message = std::string("Failed to parse multisig tx: ") + (!ptx ? er.message : "");
       return false;
     }
-
-    std::vector<crypto::hash> txids;
-    try
+    ptx->signMultisigTx(&txids);
+    bool ptx_error = ptx->status() != PendingTransaction::Status::Status_Ok;
+    if (!ptx_error)
     {
-      bool r = m_wallet->sign_multisig_tx(txs, txids);
-      if (!r)
-      {
-        er.code = WALLET_RPC_ERROR_CODE_MULTISIG_SIGNATURE;
-        er.message = "Failed to sign multisig tx";
-        return false;
-      }
+      res.tx_data_hex = ptx->multisigSignData();
+      ptx_error = ptx->status() != PendingTransaction::Status::Status_Ok;
     }
-    catch (const std::exception &e)
+    if (ptx_error)
     {
       er.code = WALLET_RPC_ERROR_CODE_MULTISIG_SIGNATURE;
-      er.message = std::string("Failed to sign multisig tx: ") + e.what();
+      er.message = "Failed to sign multisig tx: " + ptx->errorString();
       return false;
     }
 
-    res.tx_data_hex = epee::string_tools::buff_to_hex_nodelimer(m_wallet->save_multisig_tx(txs));
     if (!txids.empty())
     {
-      for (const crypto::hash &txid: txids)
-        res.tx_hash_list.push_back(epee::string_tools::pod_to_hex(txid));
+      for (const std::string &txid: txids)
+        res.tx_hash_list.push_back(txid);
     }
 
     return true;
@@ -4660,16 +4325,16 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
-    const multisig::multisig_account_status ms_status{m_wallet->get_multisig_status()};
+    if (!m_wallet_impl) return not_open(er);
+    const MultisigState ms_status{m_wallet_impl->multisig()};
 
-    if (!ms_status.multisig_is_active)
+    if (!ms_status.isMultisig)
     {
       er.code = WALLET_RPC_ERROR_CODE_NOT_MULTISIG;
       er.message = "This wallet is not multisig";
       return false;
     }
-    if (!ms_status.is_ready)
+    if (!ms_status.isReady)
     {
       er.code = WALLET_RPC_ERROR_CODE_NOT_MULTISIG;
       er.message = "This wallet is multisig, but not yet finalized";
@@ -4685,36 +4350,32 @@ namespace tools
       return false;
     }
 
-    tools::wallet2::multisig_tx_set txs;
-    bool r = m_wallet->load_multisig_tx(blob, txs, NULL);
-    if (!r)
+    PendingTransaction *ptx;
+    ptx = m_wallet_impl->restoreMultisigTransaction(req.tx_data_hex);
+    if (api_error_to_rpc_error(er) || !ptx)
     {
       er.code = WALLET_RPC_ERROR_CODE_BAD_MULTISIG_TX_DATA;
-      er.message = "Failed to parse multisig tx data.";
+      er.message = std::string("Failed to parse multisig tx: ") + (!ptx ? er.message : "");
       return false;
     }
 
-    if (txs.m_signers.size() < ms_status.threshold)
+    if (ptx->signersKeys().size() < ms_status.threshold)
     {
       er.code = WALLET_RPC_ERROR_CODE_THRESHOLD_NOT_REACHED;
       er.message = "Not enough signers signed this transaction.";
       return false;
     }
 
-    try
-    {
-      for (auto &ptx: txs.m_ptx)
-      {
-        m_wallet->commit_tx(ptx);
-        res.tx_hash_list.push_back(epee::string_tools::pod_to_hex(cryptonote::get_transaction_hash(ptx.tx)));
-      }
-    }
-    catch (const std::exception &e)
+    auto txids = ptx->txid();
+    if (!ptx->commit())
     {
       er.code = WALLET_RPC_ERROR_CODE_MULTISIG_SUBMISSION;
-      er.message = std::string("Failed to submit multisig tx: ") + e.what();
+      er.message = std::string("Failed to submit multisig tx: ") + ptx->errorString();
       return false;
     }
+
+    for (const std::string &txid : txids)
+        res.tx_hash_list.push_back(txid);
 
     return true;
   }
@@ -4727,10 +4388,10 @@ namespace tools
       { cryptonote::TESTNET, "testnet" },
       { cryptonote::STAGENET, "stagenet" },
     };
-    if (!req.any_net_type && !m_wallet) return not_open(er);
+    if (!req.any_net_type && !m_wallet_impl) return not_open(er);
     for (const auto &net_type: net_types)
     {
-      if (!req.any_net_type && (!m_wallet || net_type.type != m_wallet->nettype()))
+      if (!req.any_net_type && (!m_wallet_impl || static_cast<NetworkType>(net_type.type) != m_wallet_impl->nettype()))
         continue;
       if (req.allow_openalias)
       {
@@ -4778,9 +4439,9 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
 
-    if (m_wallet->has_proxy_option() && !req.proxy.empty())
+    if (m_wallet_impl->getWalletState().has_proxy_flag && !req.proxy.empty())
     {
       er.code = WALLET_RPC_ERROR_CODE_PROXY_ALREADY_DEFINED;
       er.message = "It is not possible to set daemon specific proxy when --proxy is defined.";
@@ -4847,7 +4508,17 @@ namespace tools
     if (!req.username.empty() || !req.password.empty())
       daemon_login.emplace(req.username, req.password);
 
-    if (!m_wallet->set_daemon(req.address, daemon_login, req.trusted, std::move(ssl_options), req.proxy))
+    if (!m_wallet_impl->setDaemon(req.address,
+                                  req.username,
+                                  req.password,
+                                  req.trusted,
+                                  static_cast<Wallet::SSLSupport>(ssl_options.support),
+                                  req.ssl_private_key_path,
+                                  req.ssl_certificate_path,
+                                  req.ssl_ca_file,
+                                  req.ssl_allowed_fingerprints,
+                                  req.ssl_allow_any_cert,
+                                  req.proxy))
     {
       er.code = WALLET_RPC_ERROR_CODE_NO_DAEMON_CONNECTION;
       er.message = std::string("Unable to set daemon");
@@ -4891,36 +4562,33 @@ namespace tools
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_estimate_tx_size_and_weight(const wallet_rpc::COMMAND_RPC_ESTIMATE_TX_SIZE_AND_WEIGHT::request& req, wallet_rpc::COMMAND_RPC_ESTIMATE_TX_SIZE_AND_WEIGHT::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
-    try
-    {
-      size_t extra_size = 34 /* pubkey */ + 10 /* encrypted payment id */; // typical makeup
-      const std::pair<size_t, uint64_t> sw = m_wallet->estimate_tx_size_and_weight(req.rct, req.n_inputs, req.ring_size, req.n_outputs, extra_size);
-      res.size = sw.first;
-      res.weight = sw.second;
-    }
-    catch (const std::exception &e)
+    if (!m_wallet_impl) return not_open(er);
+    size_t extra_size = 34 /* pubkey */ + 10 /* encrypted payment id */; // typical makeup
+    const std::pair<size_t, uint64_t> sw = m_wallet_impl->estimateTxSizeAndWeight(req.rct, req.n_inputs, req.ring_size, req.n_outputs, extra_size);
+    if (api_error_to_rpc_error(er))
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "Failed to determine size and weight";
       return false;
     }
+    res.size = sw.first;
+    res.weight = sw.second;
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_get_default_fee_priority(const wallet_rpc::COMMAND_RPC_GET_DEFAULT_FEE_PRIORITY::request& req, wallet_rpc::COMMAND_RPC_GET_DEFAULT_FEE_PRIORITY::response& res, epee::json_rpc::error& er, const connection_context *ctx)
   {
-    if (!m_wallet) return not_open(er);
+    if (!m_wallet_impl) return not_open(er);
     try
     {
-      const fee_priority priority = m_wallet->adjust_priority(fee_priority::Default);
-      if (priority == fee_priority::Default)
+      uint32_t default_priority = m_wallet_impl->getDefaultPriority();
+      res.priority = m_wallet_impl->adjustPriority(default_priority);
+      if (res.priority == default_priority)
       {
         er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
         er.message = "Failed to get adjusted fee priority";
         return false;
       }
-      res.priority = fee_priority_utilities::as_integral(priority);
     }
     catch (const std::exception& e)
     {
@@ -4938,7 +4606,42 @@ namespace tools
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-}
+  bool wallet_rpc_server::api_error_to_rpc_error(epee::json_rpc::error& er)
+  {
+    int error_code, extended_error_code;
+    std::string error_msg;
+    m_wallet_impl->statusWithErrorString(error_code, error_msg, &extended_error_code);
+    if (error_code != Wallet::Status::Status_Ok)
+    {
+      MERROR("Wallet API error: " << error_msg);
+      switch (extended_error_code) {
+        case Wallet::ExtendedStatus_Ok                      : er.code = 0;                                                  break;
+        case Wallet::ExtendedStatus_Unknown_Error           : er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;                break;
+        case Wallet::ExtendedStatus_DaemonIsBusy            : er.code = WALLET_RPC_ERROR_CODE_DAEMON_IS_BUSY;               break;
+        case Wallet::ExtendedStatus_WrongSignature          : er.code = WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE;              break;
+        case Wallet::ExtendedStatus_AccountIndexOutOfBounds : er.code = WALLET_RPC_ERROR_CODE_ACCOUNT_INDEX_OUT_OF_BOUNDS;  break;
+        case Wallet::ExtendedStatus_AddressIndexOutOfBounds : er.code = WALLET_RPC_ERROR_CODE_ADDRESS_INDEX_OUT_OF_BOUNDS;  break;
+        case Wallet::ExtendedStatus_TxNotPossible           : er.code = WALLET_RPC_ERROR_CODE_TX_NOT_POSSIBLE;              break;
+        case Wallet::ExtendedStatus_NotEnoughMoney          : er.code = WALLET_RPC_ERROR_CODE_NOT_ENOUGH_MONEY;             break;
+        case Wallet::ExtendedStatus_NotEnoughOutsToMix      : er.code = WALLET_RPC_ERROR_CODE_NOT_ENOUGH_OUTS_TO_MIX;       break;
+        case Wallet::ExtendedStatus_ZeroDestination         : er.code = WALLET_RPC_ERROR_CODE_ZERO_DESTINATION;             break;
+        case Wallet::ExtendedStatus_WalletAlreadyExists     : er.code = WALLET_RPC_ERROR_CODE_WALLET_ALREADY_EXISTS;        break;
+        case Wallet::ExtendedStatus_InvalidPassword         : er.code = WALLET_RPC_ERROR_CODE_INVALID_PASSWORD;             break;
+        case Wallet::ExtendedStatus_NotEnoughUnlockedMoney  : er.code = WALLET_RPC_ERROR_CODE_NOT_ENOUGH_UNLOCKED_MONEY;    break;
+        case Wallet::ExtendedStatus_NoDaemonConnection      : er.code = WALLET_RPC_ERROR_CODE_NO_DAEMON_CONNECTION;         break;
+        case Wallet::ExtendedStatus_ZeroAmount              : er.code = WALLET_RPC_ERROR_CODE_ZERO_AMOUNT;                  break;
+        case Wallet::ExtendedStatus_NonZeroUnlockTime       : er.code = WALLET_RPC_ERROR_CODE_NONZERO_UNLOCK_TIME;          break;
+        default:
+         MERROR((boost::format("Unknown error code: `%d`. Returning `WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR` instead.") % extended_error_code).str());
+         er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      }
+      er.message = error_msg;
+      return true;
+    }
+    return false;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+} // namespace tools
 
 class t_daemon
 {
@@ -4956,16 +4659,15 @@ public:
 
   bool run()
   {
-    std::unique_ptr<tools::wallet2> wal;
+    std::unique_ptr<Wallet> wal;
+    std::unique_ptr<WalletManager> wallet_manager;
     try
     {
-      const bool testnet = tools::wallet2::has_testnet_option(vm);
-      const bool stagenet = tools::wallet2::has_stagenet_option(vm);
-      if (testnet && stagenet)
-      {
-        MERROR(tools::wallet_rpc_server::tr("Can't specify more than one of --testnet and --stagenet"));
+      NetworkType nettype;
+      if (!get_nettype(vm, nettype))
         return false;
-      }
+
+      const auto kdf_rounds = command_line::get_arg(vm, arg_kdf_rounds);
 
       const auto arg_wallet_file = wallet_args::arg_wallet_file();
       const auto arg_from_json = wallet_args::arg_generate_from_json();
@@ -4975,9 +4677,9 @@ public:
       const auto from_json = command_line::get_arg(vm, arg_from_json);
       const auto wallet_dir = command_line::get_arg(vm, arg_wallet_dir);
       const auto password_file = command_line::get_arg(vm, arg_password_file);
-      const auto prompt_for_password = command_line::get_arg(vm, arg_prompt_for_password);
-      const auto password_prompt = prompt_for_password ? password_prompter : nullptr;
       const auto no_initial_sync = command_line::get_arg(vm, arg_no_initial_sync);
+
+      wallet_manager.reset(WalletManagerFactory::getWalletManager());
 
       if(!wallet_file.empty() && !from_json.empty())
       {
@@ -4995,7 +4697,14 @@ public:
       {
         try
         {
-          tools::wallet2::make_dummy(vm, true, password_prompt);
+          // sanity check command line args and config settings early
+          // to not get surprise errors when calling create/open/restore rpc methods and trying to apply invalid settings
+          std::string daemon_address, daemon_username, daemon_password, ssl_private_key_path, ssl_certificate_path, ssl_ca_file_path, proxy;
+          boost::optional<bool> is_trusted_daemon;
+          Monero::Wallet::SSLSupport ssl_support = Wallet::SSLSupport::SSLSupport_Autodetect;
+          std::vector<std::string> ssl_allowed_fingerprints_str;
+          bool ssl_allow_any_cert = false;
+          get_daemon_init_settings(vm, daemon_address, daemon_username, daemon_password, is_trusted_daemon, ssl_support, ssl_private_key_path, ssl_certificate_path, ssl_ca_file_path, ssl_allowed_fingerprints_str, ssl_allow_any_cert, proxy);
         }
         catch (const std::exception &e)
         {
@@ -5015,23 +4724,51 @@ public:
       LOG_PRINT_L0(tools::wallet_rpc_server::tr("Loading wallet..."));
       if(!wallet_file.empty())
       {
-        wal = tools::wallet2::make_from_file(vm, true, wallet_file, password_prompt).first;
+        epee::wipeable_string password = get_password(vm, tools::wallet_rpc_server::tr("Wallet password"), /* verify */ false);
+        std::string tmp_pw = std::string(password.data(), password.size());
+        const epee::scope_guard tmp_pw_scope_exit_handler([&](){
+          memwipe(&tmp_pw[0], tmp_pw.size());
+        });
+
+        wal.reset(
+          wallet_manager->openWallet(
+            wallet_file,
+            tmp_pw,
+            nettype,
+            kdf_rounds,
+            /* listener */ nullptr,
+            /* unattended */ true)
+        );
       }
       else
       {
-        try
-        {
-          auto rc = tools::wallet2::make_from_json(vm, true, from_json, password_prompt);
-          wal = std::move(rc.first);
-        }
-        catch (const std::exception &e)
-        {
-          MERROR("Error creating wallet: " << e.what());
-          return false;
-        }
+        std::string pw_out;
+        wal.reset(
+          wallet_manager->createWalletFromJson(
+            from_json,
+            nettype,
+            pw_out,
+            kdf_rounds)
+        );
       }
       if (!wal)
       {
+        MERROR("Failed to create wallet");
+        return false;
+      }
+      int error_code;
+      std::string error_msg;
+      wal->statusWithErrorString(error_code, error_msg);
+      if (error_code)
+      {
+        MERROR(tr("failed to load wallet: ") << error_msg);
+        return false;
+      }
+
+      if (!init_wallet(vm, wal, wallet_manager))
+      {
+        wal->statusWithErrorString(error_code, error_msg);
+        MERROR(tr("failed to initialize wallet: ") << error_msg);
         return false;
       }
 
@@ -5042,20 +4779,23 @@ public:
         wal->stop();
       });
 
-      try
+      if (!no_initial_sync)
       {
-        if (!no_initial_sync)
-          wal->refresh(wal->is_trusted_daemon());
+        if (wal->connected() != Wallet::ConnectionStatus_Connected)
+            LOG_ERROR(tools::wallet_rpc_server::tr("Initial refresh failed: no connection to daemon"));
+        if (!wal->refresh())
+        {
+            int error_code{};
+            std::string error_msg{};
+            wal->statusWithErrorString(error_code, error_msg);
+            LOG_ERROR(tools::wallet_rpc_server::tr("Initial refresh failed: ") << error_msg);
+        }
       }
-      catch (const std::exception& e)
-      {
-        LOG_ERROR(tools::wallet_rpc_server::tr("Initial refresh failed: ") << e.what());
-      }
-      // if we ^C during potentially length load/refresh, there's no server loop yet
+      // if we ^C during potentially lengthy load/refresh, there's no server loop yet
       if (quit)
       {
         MINFO(tools::wallet_rpc_server::tr("Saving wallet..."));
-        wal->store();
+        wal->store("");
         MINFO(tools::wallet_rpc_server::tr("Successfully saved"));
         return false;
       }
@@ -5068,6 +4808,7 @@ public:
     }
   just_dir:
     if (wal) wrpc->set_wallet(wal.release());
+    if (wallet_manager) wrpc->set_wallet_manager(wallet_manager.release());
     bool r = wrpc->init(&vm);
     CHECK_AND_ASSERT_MES(r, false, tools::wallet_rpc_server::tr("Failed to initialize wallet RPC server"));
     tools::signal_handler::install([this](int) {
@@ -5145,7 +4886,6 @@ int main(int argc, char** argv) {
   po::options_description hidden_options("Hidden");
 
   po::options_description desc_params(wallet_args::tr("Wallet options"));
-  tools::wallet2::init_options(desc_params);
   command_line::add_arg(desc_params, arg_rpc_bind_port);
   command_line::add_arg(desc_params, arg_disable_rpc_login);
   command_line::add_arg(desc_params, arg_restricted);
@@ -5160,6 +4900,32 @@ int main(int argc, char** argv) {
   command_line::add_arg(desc_params, arg_rpc_max_connections);
   command_line::add_arg(desc_params, arg_rpc_response_soft_limit);
   command_line::add_arg(hidden_options, daemonizer::arg_non_interactive);
+  command_line::add_arg(desc_params, arg_daemon_address );
+  command_line::add_arg(desc_params, arg_daemon_host );
+  command_line::add_arg(desc_params, arg_proxy );
+  command_line::add_arg(desc_params, arg_trusted_daemon );
+  command_line::add_arg(desc_params, arg_untrusted_daemon );
+  command_line::add_arg(desc_params, arg_password );
+  command_line::add_arg(desc_params, arg_password_file );
+  command_line::add_arg(desc_params, arg_daemon_port );
+  command_line::add_arg(desc_params, arg_daemon_login );
+  command_line::add_arg(desc_params, arg_daemon_ssl );
+  command_line::add_arg(desc_params, arg_daemon_ssl_private_key );
+  command_line::add_arg(desc_params, arg_daemon_ssl_certificate );
+  command_line::add_arg(desc_params, arg_daemon_ssl_ca_certificates );
+  command_line::add_arg(desc_params, arg_daemon_ssl_allowed_fingerprints );
+  command_line::add_arg(desc_params, arg_daemon_ssl_allow_any_cert );
+  command_line::add_arg(desc_params, arg_daemon_ssl_allow_chained );
+
+  command_line::add_arg(desc_params, arg_allow_mismatched_daemon_version );
+  command_line::add_arg(desc_params, arg_testnet );
+  command_line::add_arg(desc_params, arg_stagenet );
+  command_line::add_arg(desc_params, arg_kdf_rounds );
+  command_line::add_arg(desc_params, arg_hw_device );
+  command_line::add_arg(desc_params, arg_hw_device_derivation_path );
+  command_line::add_arg(desc_params, arg_tx_notify );
+  command_line::add_arg(desc_params, arg_offline );
+  command_line::add_arg(desc_params, arg_extra_entropy );
 
   daemonizer::init_options(hidden_options, desc_params);
   desc_params.add(hidden_options);

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -36,8 +36,11 @@
 #include <chrono>
 #include "common/util.h"
 #include "net/http_server_impl_base.h"
+#include "wallet/api/wallet2_api.h"
+#include "wallet/api/pending_transaction.h"
 #include "wallet_rpc_server_commands_defs.h"
-#include "wallet2.h"
+
+using namespace Monero;
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "wallet.rpc"
@@ -53,14 +56,15 @@ namespace tools
     typedef epee::net_utils::connection_context_base connection_context;
 
     static const char* tr(const char* str);
+    cryptonote::network_type nettype() { return static_cast<cryptonote::network_type>(m_wallet_impl->nettype()); }
 
     wallet_rpc_server();
-    ~wallet_rpc_server();
 
     bool init(const boost::program_options::variables_map *vm);
     bool run();
     void stop();
-    void set_wallet(wallet2 *cr);
+    void set_wallet(Wallet *cr);
+    void set_wallet_manager(WalletManager *wallet_manager);
 
   private:
 
@@ -93,8 +97,6 @@ namespace tools
         MAP_JON_RPC_WE("sign_transfer",      on_sign_transfer,      wallet_rpc::COMMAND_RPC_SIGN_TRANSFER)
         MAP_JON_RPC_WE("describe_transfer",  on_describe_transfer,  wallet_rpc::COMMAND_RPC_DESCRIBE_TRANSFER)
         MAP_JON_RPC_WE("submit_transfer",    on_submit_transfer,    wallet_rpc::COMMAND_RPC_SUBMIT_TRANSFER)
-        MAP_JON_RPC_WE("sweep_dust",         on_sweep_dust,         wallet_rpc::COMMAND_RPC_SWEEP_DUST)
-        MAP_JON_RPC_WE("sweep_unmixable",    on_sweep_dust,         wallet_rpc::COMMAND_RPC_SWEEP_DUST)
         MAP_JON_RPC_WE("sweep_all",          on_sweep_all,          wallet_rpc::COMMAND_RPC_SWEEP_ALL)
         MAP_JON_RPC_WE("sweep_single",       on_sweep_single,       wallet_rpc::COMMAND_RPC_SWEEP_SINGLE)
         MAP_JON_RPC_WE("relay_tx",           on_relay_tx,           wallet_rpc::COMMAND_RPC_RELAY_TX)
@@ -191,7 +193,7 @@ namespace tools
       bool on_sign_transfer(const wallet_rpc::COMMAND_RPC_SIGN_TRANSFER::request& req, wallet_rpc::COMMAND_RPC_SIGN_TRANSFER::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_describe_transfer(const wallet_rpc::COMMAND_RPC_DESCRIBE_TRANSFER::request& req, wallet_rpc::COMMAND_RPC_DESCRIBE_TRANSFER::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_submit_transfer(const wallet_rpc::COMMAND_RPC_SUBMIT_TRANSFER::request& req, wallet_rpc::COMMAND_RPC_SUBMIT_TRANSFER::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
-      bool on_sweep_dust(const wallet_rpc::COMMAND_RPC_SWEEP_DUST::request& req, wallet_rpc::COMMAND_RPC_SWEEP_DUST::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
+      // removed: sweep_dust/sweep_unmixable; reason: not needed anymore after FCMP++ fork, discussed in "Monero Tech Meeting #140" https://github.com/monero-project/meta/issues/1277
       bool on_sweep_all(const wallet_rpc::COMMAND_RPC_SWEEP_ALL::request& req, wallet_rpc::COMMAND_RPC_SWEEP_ALL::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_sweep_single(const wallet_rpc::COMMAND_RPC_SWEEP_SINGLE::request& req, wallet_rpc::COMMAND_RPC_SWEEP_SINGLE::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_relay_tx(const wallet_rpc::COMMAND_RPC_RELAY_TX::request& req, wallet_rpc::COMMAND_RPC_RELAY_TX::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
@@ -266,23 +268,23 @@ namespace tools
       bool on_query_key(const wallet_rpc::COMMAND_RPC_QUERY_KEY::request& req, wallet_rpc::COMMAND_RPC_QUERY_KEY::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
 
       // helpers
-      void fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const crypto::hash &txid, const crypto::hash &payment_id, const tools::wallet2::payment_details &pd) const;
-      void fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const crypto::hash &txid, const tools::wallet2::confirmed_transfer_details &pd) const;
-      void fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const crypto::hash &txid, const tools::wallet2::unconfirmed_transfer_details &pd) const;
-      void fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const crypto::hash &payment_id, const tools::wallet2::pool_payment_details &pd) const;
+      void fill_transfer_entry(tools::wallet_rpc::transfer_entry &entry, const TransactionInfo &tx_info);
       bool not_open(epee::json_rpc::error& er);
       void handle_rpc_exception(const std::exception_ptr& e, epee::json_rpc::error& er, int default_error_code);
+      // return false if no error occured
+      bool api_error_to_rpc_error(epee::json_rpc::error& er);
 
       template<typename Ts, typename Tu, typename Tk, typename Ta>
-      bool fill_response(std::vector<tools::wallet2::pending_tx> &ptx_vector,
+      bool fill_response(std::unique_ptr<PendingTransaction> ptx_vector,
           bool get_tx_key, Ts& tx_key, Tu &amount, Ta &amounts_by_dest, Tu &fee, Tu &weight, std::string &multisig_txset, std::string &unsigned_txset, bool do_not_relay,
           Ts &tx_hash, bool get_tx_hex, Ts &tx_blob, bool get_tx_metadata, Ts &tx_metadata, Tk &spent_key_images, epee::json_rpc::error &er);
 
-      bool validate_transfer(const std::list<wallet_rpc::transfer_destination>& destinations, const std::string& payment_id, std::vector<cryptonote::tx_destination_entry>& dsts, std::vector<uint8_t>& extra, bool at_least_one_destination, epee::json_rpc::error& er);
+      bool validate_transfer(const std::list<wallet_rpc::transfer_destination>& destinations, const std::string& payment_id, std::vector<std::string>& dsts, std::vector<std::uint64_t>& amounts_per_dst, bool at_least_one_destination, epee::json_rpc::error& er);
 
       void check_background_mining();
 
-      wallet2 *m_wallet;
+      std::unique_ptr<Wallet> m_wallet_impl;
+      std::unique_ptr<WalletManager> m_wallet_manager;
       std::string m_wallet_dir;
       tools::private_file rpc_login_file;
       std::atomic<bool> m_stop;

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -47,7 +47,7 @@
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define WALLET_RPC_VERSION_MAJOR 1
-#define WALLET_RPC_VERSION_MINOR 31
+#define WALLET_RPC_VERSION_MINOR 32
 #define MAKE_WALLET_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define WALLET_RPC_VERSION MAKE_WALLET_RPC_VERSION(WALLET_RPC_VERSION_MAJOR, WALLET_RPC_VERSION_MINOR)
 namespace tools

--- a/tests/functional_tests/functional_tests_rpc.py
+++ b/tests/functional_tests/functional_tests_rpc.py
@@ -9,6 +9,8 @@ import string
 import os
 import time
 
+import util_resources
+
 USAGE = 'usage: functional_tests_rpc.py <python> <srcdir> <builddir> [<tests-to-run> | all]'
 DEFAULT_TESTS = [
   'address_book', 'bans', 'blockchain', 'cold_signing', 'daemon_info', 'get_output_distribution',
@@ -45,11 +47,28 @@ N_MONERODS = 5
 # 4 wallets connected to the main offline monerod
 # 1 wallet connected to the first local online monerod
 # 1 offline wallet
-N_WALLETS = 7
+# 1 generate-from-json wallet (no wallet-dir)
+# 1 restricted-rpc wallet
+N_WALLETS = 9
 
 WALLET_DIRECTORY = builddir + "/functional-tests-directory"
 FUNCTIONAL_TESTS_DIRECTORY = builddir + "/tests/functional_tests"
+TMP_WALLET_FILE = WALLET_DIRECTORY + "/tmp_wallet"
+JSON_WALLET_FILE = TMP_WALLET_FILE + ".json"
 DIFFICULTY = 10
+
+# Init: generate json file for --generate-from-json
+if not os.path.exists(WALLET_DIRECTORY):
+    os.mkdir(WALLET_DIRECTORY)
+with open(JSON_WALLET_FILE, "w") as f:
+  file_content = f'''{{
+    "version": 1,
+    "filename": "{TMP_WALLET_FILE}",
+    "password": "",
+    "seed": "velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted"
+}}
+'''
+  f.write(file_content)
 
 monerod_base = [builddir + "/bin/monerod", "--regtest", "--fixed-difficulty", str(DIFFICULTY), "--p2p-bind-port", "monerod_p2p_port", "--rpc-bind-port", "monerod_rpc_port", "--zmq-rpc-bind-port", "monerod_zmq_port", "--zmq-pub", "monerod_zmq_pub", "--non-interactive", "--disable-dns-checkpoints", "--check-updates", "disabled", "--rpc-ssl", "disabled", "--data-dir", "monerod_data_dir", "--log-level", "1", "--rpc-max-connections-per-private-ip", "100", "--rpc-max-connections", "100"]
 
@@ -60,15 +79,17 @@ monerod_extra = [
   ["--add-exclusive-node", "127.0.0.1:18282"],
   ["--rpc-login", "md5_lover:Z1ON0101", "--offline"],
 ]
-wallet_base = [builddir + "/bin/monero-wallet-rpc", "--wallet-dir", WALLET_DIRECTORY, "--rpc-bind-port", "wallet_port", "--rpc-ssl", "disabled", "--daemon-ssl", "disabled", "--log-level", "1", "--allow-mismatched-daemon-version"]
+wallet_base = [builddir + "/bin/monero-wallet-rpc", "--rpc-bind-port", "wallet_port", "--rpc-ssl", "disabled", "--daemon-ssl", "disabled", "--log-level", "1", "--allow-mismatched-daemon-version"]
 wallet_extra = [
-  ["--daemon-port", "18180", "--disable-rpc-login"],
-  ["--daemon-port", "18180", "--disable-rpc-login"],
-  ["--daemon-port", "18180", "--disable-rpc-login"],
-  ["--daemon-port", "18180", "--disable-rpc-login"],
-  ["--daemon-port", "18182", "--disable-rpc-login"],
-  ["--offline", "--disable-rpc-login"],
-  ["--daemon-port", "18184", "--daemon-login", "md5_lover:Z1ON0101", "--rpc-login", "kyle:reveille"],
+  ["--daemon-port", "18180", "--disable-rpc-login", "--wallet-dir", WALLET_DIRECTORY],
+  ["--daemon-port", "18180", "--disable-rpc-login", "--wallet-dir", WALLET_DIRECTORY],
+  ["--daemon-port", "18180", "--disable-rpc-login", "--wallet-dir", WALLET_DIRECTORY],
+  ["--daemon-port", "18180", "--disable-rpc-login", "--wallet-dir", WALLET_DIRECTORY],
+  ["--daemon-port", "18182", "--disable-rpc-login", "--wallet-dir", WALLET_DIRECTORY],
+  ["--offline", "--disable-rpc-login", "--wallet-dir", WALLET_DIRECTORY],
+  ["--daemon-port", "18184", "--daemon-login", "md5_lover:Z1ON0101", "--rpc-login", "kyle:reveille", "--wallet-dir", WALLET_DIRECTORY],
+  ["--daemon-port", "18180", "--disable-rpc-login", "--generate-from-json", JSON_WALLET_FILE],
+  ["--daemon-port", "18180", "--disable-rpc-login", "--wallet-dir", WALLET_DIRECTORY, "--restricted-rpc"],
 ]
 
 command_lines = []
@@ -108,6 +129,10 @@ try:
   if not 'MINING_SILENT' in os.environ:
     os.environ['MINING_SILENT'] = "1"
 
+  # Clean up tmp_wallet file from previous run
+  if os.path.exists(TMP_WALLET_FILE):
+    util_resources.remove_wallet_files(TMP_WALLET_FILE.split("/")[-1])
+
   for i in range(len(command_lines)):
     #print('Running: ' + str(command_lines[i]))
     processes.append(subprocess.Popen(command_lines[i], stdout = outputs[i]))
@@ -121,7 +146,7 @@ def kill():
     except: pass
 
 # wait for error/startup
-startup_timeout = 10
+startup_timeout = 15
 deadline = time.monotonic() + startup_timeout
 for port in ports:
   addr = ('127.0.0.1', port)

--- a/tests/functional_tests/integrated_address.py
+++ b/tests/functional_tests/integrated_address.py
@@ -36,9 +36,15 @@ Test the following RPCs:
 
 """
 
+import ast
+
 from framework.wallet import Wallet
 
 class IntegratedAddressTest():
+    error_codes = {
+        -2:"WALLET_RPC_ERROR_CODE_WRONG_ADDRESS",
+        -5:"WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID",
+    }
     def run_test(self):
       self.create()
       self.check()
@@ -76,7 +82,10 @@ class IntegratedAddressTest():
         print('Checking bad payment id')
         fails = 0
         try: wallet.make_integrated_address(standard_address = '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK', payment_id = '11223344556677880')
-        except: fails += 1
+        except Exception as e:
+            res_dict = ast.literal_eval(str(e))
+            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID"
+            fails += 1
         try: wallet.make_integrated_address(standard_address = '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK', payment_id = '112233445566778')
         except: fails += 1
         try: wallet.make_integrated_address(standard_address = '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerK', payment_id = '112233445566778g')
@@ -88,7 +97,10 @@ class IntegratedAddressTest():
         print('Checking bad standard address')
         fails = 0
         try: wallet.make_integrated_address(standard_address = '46r4nYSevkfBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCLGwTerr', payment_id = '1122334455667788')
-        except: fails += 1
+        except Exception as e:
+            res_dict = ast.literal_eval(str(e))
+            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_WRONG_ADDRESS"
+            fails += 1
         try: wallet.make_integrated_address(standard_address = '4GYjoMG9Y2BBUMhuykdK3gQ98XDqDTYW1hNLaXNvjpsJaSbNtdXh1sKMsdVgqkaihChAzEy29zEDPMR3NHQvGoZCVSs1ZojwrDCGS5rUuo', payment_id = '1122334455667788')
         except: fails += 1
         assert fails == 2

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -78,7 +78,6 @@ class TransferTest():
         self.check_get_bulk_payments()
         self.check_get_payments()
         self.check_double_spend_detection()
-        self.sweep_dust()
         self.sweep_single()
         self.check_destinations()
         self.check_tx_notes()
@@ -546,6 +545,8 @@ class TransferTest():
         self.wallet[0].refresh()
         res = self.wallet[0].get_bulk_payments()
         assert len(res.payments) >= 83 # at least 83 coinbases
+        res = self.wallet[0].get_bulk_payments(payment_ids = ['0'*16])
+        assert len(res.payments) >= 83 # at least 83 with dummy encrypted payment id
         res = self.wallet[0].get_bulk_payments(payment_ids = ['1234500000012345abcde00000abcdeff1234500000012345abcde00000abcde'])
         assert 'payments' not in res or len(res.payments) == 0
         res = self.wallet[0].get_bulk_payments(min_block_height = height)
@@ -591,7 +592,11 @@ class TransferTest():
         res = self.wallet[1].get_payments('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
         assert 'payments' not in res or len(res.payments) == 0
 
+        res = self.wallet[1].get_payments(payment_id = '0'*16)
+        assert len(res.payments) >= 1 # one tx with dummy payment id
         res = self.wallet[1].get_payments(payment_id = '1111111122222222' + '0'*48)
+        assert len(res.payments) >= 1 # one tx to integrated address
+        res = self.wallet[1].get_payments(payment_id = '1111111122222222')
         assert len(res.payments) >= 1 # one tx to integrated address
 
     def check_double_spend_detection(self):
@@ -652,12 +657,7 @@ class TransferTest():
         assert tx.in_pool
         assert tx.double_spend_seen
 
-    def sweep_dust(self):
-        print("Sweeping dust")
-        daemon = Daemon()
-        self.wallet[0].refresh()
-        res = self.wallet[0].sweep_dust()
-        assert not 'tx_hash_list' in res or len(res.tx_hash_list) == 0 # there's just one, but it cannot meet the fee
+    # removed: sweep_dust/sweep_unmixable; reason: not needed anymore after FCMP++ fork, discussed in "Monero Tech Meeting #140" https://github.com/monero-project/meta/issues/1277
 
     def sweep_single(self):
         daemon = Daemon()

--- a/tests/functional_tests/wallet.py
+++ b/tests/functional_tests/wallet.py
@@ -32,6 +32,7 @@
 """Test basic wallet functionality
 """
 
+import ast
 import sys
 import util_resources
 
@@ -39,9 +40,36 @@ from framework.wallet import Wallet
 from framework.daemon import Daemon
 
 class WalletTest():
+    seed = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted'
+    address = '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+    ssk = '148d78d2aba7dbca5cd8f6abcfb0b3c009ffbdbea1ff373d50ed94d78286640e'
+    svk = '49774391fa5e8d249fc2c5b45dadef13534bf2483dede880dac88f061e809100'
+    address_non_deterministic = '4591SBcZXAMQaGfPDgRppX6N1FyyLoYXscRohnAd2MXMhG76o7r2PvYNKvdJdpAZzs4GS4J4bqYuPcfAG479hNrQF2qM6Lr'
+    ssk_non_deterministic = 'e4810cd6432e9c59ad1b1e640957960f33d3bbc85f56f0f7631495b7c08a1409'
+    svk_non_determinisitc = '10f67f0ecfff7860d978cf88d966f8012ec447799ba36a1da94bd44e314d1206'
+    # non-deterministic wallet
+    wal_nd = None
+    # deterministic wallet from spend-key
+    wal_sk = None
+    # view-only wallet
+    wal_vo = None
+    error_codes = {
+        -1:"WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR",
+        -7:"WALLET_RPC_ERROR_CODE_DENIED",
+        -21:"WALLET_RPC_ERROR_CODE_WALLET_ALREADY_EXISTS",
+        -22:"WALLET_RPC_ERROR_CODE_INVALID_PASSWORD",
+        -23:"WALLET_RPC_ERROR_CODE_NO_WALLET_DIR",
+        -29:"WALLET_RPC_ERROR_CODE_WATCH_ONLY",
+        -43:"WALLET_RPC_ERROR_CODE_NON_DETERMINISTIC",
+        -45:"WALLET_RPC_ERROR_CODE_ATTRIBUTE_NOT_FOUND",
+    }
+
     def run_test(self):
       self.reset()
+      self.create_fail()
       self.create()
+      self.generate_from_keys()
+      self.restore_deterministic()
       self.check_main_address()
       self.check_keys()
       self.create_subaddresses()
@@ -60,22 +88,119 @@ class WalletTest():
         daemon.pop_blocks(res.height - 1)
         daemon.flush_txpool()
 
+    def create_fail(self):
+        print('Fail creating wallet')
+        wallet_file_name = "tmp_wallet"
+
+        # with --restricted-rpc
+        wallet = Wallet(idx=8)
+        try:
+            res = wallet.create_wallet(filename=wallet_file_name)
+        except AssertionError as e:
+            res_dict = ast.literal_eval(str(e))
+            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_DENIED"
+
+        # without --wallet-dir
+        wallet = Wallet(idx=7)
+        try:
+            res = wallet.create_wallet(filename=wallet_file_name)
+        except AssertionError as e:
+            res_dict = ast.literal_eval(str(e))
+            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_NO_WALLET_DIR"
+
+        # attempt to create already existing tmp_wallet
+        wallet = Wallet()
+        try:
+            res = wallet.create_wallet(filename=wallet_file_name)
+        except AssertionError as e:
+            res_dict = ast.literal_eval(str(e))
+            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR"
+            # QUESTION : actually there is a specific error code for this case, should I change it to this?
+#            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_WALLET_ALREADY_EXISTS"
+            assert res_dict["error"]["message"] == "Failed to create wallet: attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting."
+
+        # invalid filename
+        try:
+            res = wallet.create_wallet(filename="/invalid/filename")
+        except AssertionError as e:
+            res_dict = ast.literal_eval(str(e))
+            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR"
+            assert res_dict["error"]["message"] == "Invalid filename"
+
+        # invalid seed language
+        language = "Newspeak"
+        try:
+            res = wallet.create_wallet(language=language)
+        except AssertionError as e:
+            res_dict = ast.literal_eval(str(e))
+            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR"
+            assert res_dict["error"]["message"] == "Unknown language: " + language
+
     def create(self):
         print('Creating wallet')
         wallet = Wallet()
         # close the wallet if any, will throw if none is loaded
         try: wallet.close_wallet()
         except: pass
-        seed = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted'
-        res = wallet.restore_deterministic_wallet(seed = seed)
-        assert res.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
-        assert res.seed == seed
+        res = wallet.create_wallet()
+        assert res == {}
+
+    def generate_from_keys(self):
+        print('Generating wallet from keys')
+        # view-key + spend-key (determinisitc)
+        wallet = Wallet()
+        try: wallet.close_wallet()
+        except: pass
+        res = wallet.generate_from_keys(address = self.address, spendkey = self.ssk, viewkey = self.svk)
+        assert res.address == self.address
+        assert res.info == "Wallet has been generated successfully."
+        assert wallet.query_key("mnemonic")["key"] == self.seed
+
+        # view-key + spend-key (non-determinisitc)
+        self.wal_nd = Wallet(idx=1)
+        try: wallet.close_wallet()
+        except: pass
+        res = self.wal_nd.generate_from_keys(address = self.address_non_deterministic, spendkey = self.ssk_non_deterministic, viewkey = self.svk_non_determinisitc)
+        assert res.address == self.address_non_deterministic
+        assert res.info == "Non-deterministic Wallet has been generated successfully."
+
+        # fail spend-key only (deterministic)
+        self.wal_sk = Wallet(idx=2)
+        try: self.wal_sk.close_wallet()
+        except: pass
+        try:
+            res = wallet.generate_from_keys(address = self.address, spendkey = self.ssk)
+        except Exception as e:
+            res_dict = ast.literal_eval(str(e))
+            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR"
+            assert res_dict["error"]["message"] == "field 'viewkey' is mandatory. Please provide a view key you want to restore from."
+
+        # view-only
+        self.wal_vo = Wallet(idx=3)
+        try: self.wal_vo.close_wallet()
+        except: pass
+        res = self.wal_vo.generate_from_keys(address = self.address, viewkey = self.svk)
+        assert res.address == self.address
+        assert res.info == "View-only Wallet has been generated successfully."
+
+    def restore_deterministic(self):
+        print('Restoring deterministic wallet')
+        wallet = Wallet()
+        util_resources.remove_wallet_files("tmp_wallet_copy")
+        # close the wallet if any, will throw if none is loaded
+        try: wallet.close_wallet()
+        except: pass
+        res = wallet.restore_deterministic_wallet(filename = "tmp_wallet_copy", seed = self.seed)
+        assert res.address == self.address
+        assert res.seed == self.seed
+
+        # Note : restoring multisig is covered in multisig.py
 
     def check_main_address(self):
         print('Getting address')
         wallet = Wallet()
         res = wallet.get_address()
-        assert res.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', res
+        assert res.address == self.address, res
         assert len(res.addresses) == 1
         assert res.addresses[0].address == res.address
         assert res.addresses[0].address_index == 0
@@ -85,11 +210,39 @@ class WalletTest():
         print('Checking keys')
         wallet = Wallet()
         res = wallet.query_key('view_key')
-        assert res.key == '49774391fa5e8d249fc2c5b45dadef13534bf2483dede880dac88f061e809100'
+        assert res.key == self.svk
         res = wallet.query_key('spend_key')
-        assert res.key == '148d78d2aba7dbca5cd8f6abcfb0b3c009ffbdbea1ff373d50ed94d78286640e'
+        assert res.key == self.ssk
         res = wallet.query_key('mnemonic')
-        assert res.key == 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted'
+        assert res.key == self.seed
+
+        # non-deterministic
+        res = self.wal_nd.query_key('view_key')
+        assert res.key == self.svk_non_determinisitc
+        res = self.wal_nd.query_key('spend_key')
+        assert res.key == self.ssk_non_deterministic
+        try:
+            self.wal_nd.query_key('mnemonic')
+        except Exception as e:
+            res_dict = ast.literal_eval(str(e))
+            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_NON_DETERMINISTIC"
+            assert res_dict["error"]["message"] == "The wallet is non-deterministic. Cannot display seed."
+
+        # view-only
+        res = self.wal_vo.query_key('view_key')
+        assert res.key == self.svk
+        try:
+            self.wal_vo.query_key('spend_key')
+        except Exception as e:
+            res_dict = ast.literal_eval(str(e))
+            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_WATCH_ONLY"
+            assert res_dict["error"]["message"] == "The wallet is watch-only. Cannot retrieve spend key."
+        try:
+            self.wal_vo.query_key("mnemonic")
+        except Exception as e:
+            res_dict = ast.literal_eval(str(e))
+            assert self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_WATCH_ONLY"
+            assert res_dict["error"]["message"] == "The wallet is watch-only. Cannot retrieve seed."
 
     def create_subaddresses(self):
         print('Creating subaddresses')
@@ -102,7 +255,7 @@ class WalletTest():
         assert res.address == '8Bdb75y2MhvbkvaBnG7vYP6DCNneLWcXqNmfPmyyDkavAUUgrHQEAhTNK3jEq69kGPDrd3i5inPivCwTvvA12eQ4SJk9iyy', res
 
         res = wallet.get_address(0, 0)
-        assert res.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', res
+        assert res.address == self.address, res
         assert len(res.addresses) == 1
         assert res.addresses[0].address_index == 0, res
         res = wallet.get_address(1, 0)
@@ -155,7 +308,7 @@ class WalletTest():
 
         res = wallet.get_address_index('87KfgTZ8ER5D3Frefqnrqif11TjVsTPaTcp37kqqKMrdDRUhpJRczeR7KiBmSHF32UJLP3HHhKUDmEQyJrv2mV8yFDCq8eB')
         assert res.index == {'major': 1, 'minor': 2}
-        res = wallet.get_address_index('42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm')
+        res = wallet.get_address_index(self.address)
         assert res.index == {'major': 0, 'minor': 0}
         res = wallet.get_address_index('84QRUYawRNrU3NN1VpFRndSukeyEb3Xpv8qZjjsoJZnTYpDYceuUTpog13D7qPxpviS7J29bSgSkR11hFFoXWk2yNdsR9WF')
         assert res.index == {'major': 0, 'minor': 1}
@@ -249,7 +402,7 @@ class WalletTest():
             assert x.balance == 0
             assert x.unlocked_balance == 0
             subaddress_accounts.append((x.account_index, x.base_address, x.label))
-        assert sorted(subaddress_accounts) == [(0, '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm', 'main'), (1, '82pP87g1Vkd3LUMssBCumk3MfyEsFqLAaGDf6oxddu61EgSFzt8gCwUD4tr3kp9TUfdPs2CnpD7xLZzyC1Ei9UsW3oyCWDf', 'idx1_new')]
+        assert sorted(subaddress_accounts) == [(0, self.address, 'main'), (1, '82pP87g1Vkd3LUMssBCumk3MfyEsFqLAaGDf6oxddu61EgSFzt8gCwUD4tr3kp9TUfdPs2CnpD7xLZzyC1Ei9UsW3oyCWDf', 'idx1_new')]
 
     def attributes(self):
         print('Testing attributes')
@@ -267,7 +420,9 @@ class WalletTest():
         assert res.value == u'いっしゅん'
         ok = False
         try: res = wallet.get_attribute('いちりゅう')
-        except: ok = True
+        except Exception as e:
+            res_dict = ast.literal_eval(str(e))
+            ok = self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_ATTRIBUTE_NOT_FOUND"
         assert ok
         res = wallet.set_attribute('いちりゅう', 'いっぽう')
         res = wallet.get_attribute('いちりゅう')
@@ -278,7 +433,7 @@ class WalletTest():
         wallet = Wallet()
 
         res = wallet.get_address()
-        assert res.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        assert res.address == self.address
 
         wallet.close_wallet()
         ok = False
@@ -296,9 +451,9 @@ class WalletTest():
         except: ok = True
         assert ok
 
-        wallet.restore_deterministic_wallet(seed = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted')
+        wallet.open_wallet(filename = "tmp_wallet_copy")
         res = wallet.get_address()
-        assert res.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        assert res.address == self.address
 
     def languages(self):
         print('Testing languages')
@@ -330,27 +485,36 @@ class WalletTest():
 
         util_resources.remove_wallet_files('test1')
 
-        seed = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted'
-        res = wallet.restore_deterministic_wallet(seed = seed, filename = 'test1')
-        assert res.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
-        assert res.seed == seed
+        res = wallet.restore_deterministic_wallet(seed = self.seed, filename = 'test1')
+        assert res.address == self.address
+        assert res.seed == self.seed
 
         wallet.close_wallet()
         res = wallet.open_wallet('test1', password = '')
         res = wallet.get_address()
-        assert res.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        assert res.address == self.address
+
+        # invalid old password
+        ok = False
+        try:
+            wallet.change_wallet_password(old_password = 'foo', new_password = 'foo')
+        except Exception as e:
+            res_dict = ast.literal_eval(str(e))
+            ok = self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_INVALID_PASSWORD" and res_dict["error"]["message"] == "Invalid original password."
+        assert ok
 
         res = wallet.change_wallet_password(old_password = '', new_password = 'foo')
         wallet.close_wallet()
 
-        ok = False
         try: res = wallet.open_wallet('test1', password = '')
-        except: ok = True
+        except Exception as e:
+            res_dict = ast.literal_eval(str(e))
+            ok = self.error_codes[res_dict["error"]["code"]] == "WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR" and res_dict["error"]["message"] == "Failed to open wallet: invalid password"
         assert ok
 
         res = wallet.open_wallet('test1', password = 'foo')
         res = wallet.get_address()
-        assert res.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        assert res.address == self.address
 
         wallet.close_wallet()
 
@@ -366,10 +530,9 @@ class WalletTest():
 
         util_resources.remove_wallet_files('test1')
 
-        seed = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted'
-        res = wallet.restore_deterministic_wallet(seed = seed, filename = 'test1')
-        assert res.address == '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
-        assert res.seed == seed
+        res = wallet.restore_deterministic_wallet(seed = self.seed, filename = 'test1')
+        assert res.address == self.address
+        assert res.seed == self.seed
 
         util_resources.remove_file('test1')
         assert util_resources.file_exists('test1.keys')

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -102,7 +102,7 @@ static void configure_wallet(Monero::Wallet *wallet)
 {
     if (!wallet)
         return;
-    wallet->allowMismatchedDaemonVersion(true);
+    wallet->setAllowMismatchedDaemonVersion(true);
     wallet->setRefreshFromBlockHeight(1);
     if (!RING_DATABASE_DIR.empty())
         wallet->setRingDatabase(RING_DATABASE_DIR);

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -1033,7 +1033,7 @@ struct MyWalletListener : public Monero::WalletListener
         send_triggered = receive_triggered = newblock_triggered = update_triggered = refresh_triggered = false;
     }
 
-    virtual void moneySpent(const string &txId, uint64_t amount)
+    virtual void moneySpent(const string &txId, uint64_t amount, const string &enote_pub_key, std::pair<uint32_t, uint32_t> subaddr_index /* = {} */)
     {
         std::cerr << "wallet: " << wallet->mainAddress() << "**** just spent money ("
                   << txId  << ", " << wallet->displayAmount(amount) << ")" << std::endl;
@@ -1042,7 +1042,7 @@ struct MyWalletListener : public Monero::WalletListener
         cv_send.notify_one();
     }
 
-    virtual void moneyReceived(const string &txId, uint64_t amount)
+    virtual void moneyReceived(const string &txId, uint64_t amount, const uint64_t burnt, const string &enote_pub_key, const bool is_change /* = false */, const bool is_coinbase /* = false */)
     {
         std::cout << "wallet: " << wallet->mainAddress() << "**** just received money ("
                   << txId  << ", " << wallet->displayAmount(amount) << ")" << std::endl;
@@ -1087,6 +1087,11 @@ struct MyWalletListener : public Monero::WalletListener
         cv_refresh.notify_one();
     }
 
+    void onReorg(uint64_t height, uint64_t blocks_detached, size_t transfers_detached) override {}
+
+    optional<std::string> onGetPassword(const char *reason) override { return {}; }
+
+    void onPoolTxRemoved(const string &txid) override {}
 };
 
 

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -397,7 +397,7 @@ TEST_F(WalletManagerTest, WalletManagerMovesWallet)
             (boost::filesystem::temp_directory_path() / (std::string(WALLET_NAME) + ".moved")).string();
     Utils::deleteWallet(WALLET_NAME_MOVED);
     std::string seed1 = wallet1->seed();
-    ASSERT_TRUE(wallet1->store(WALLET_NAME_MOVED));
+    ASSERT_TRUE(wallet1->store(WALLET_NAME_MOVED, WALLET_PASS));
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
     Monero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME_MOVED, WALLET_PASS, WALLET_NETWORK_TYPE);
@@ -413,7 +413,7 @@ TEST_F(WalletManagerTest, WalletManagerChangesPassword)
 {
     Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG, WALLET_NETWORK_TYPE);
     std::string seed1 = wallet1->seed();
-    ASSERT_TRUE(wallet1->setPassword(WALLET_PASS2));
+    ASSERT_TRUE(wallet1->setPassword(WALLET_PASS, WALLET_PASS2));
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
     Monero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME, WALLET_PASS2, WALLET_NETWORK_TYPE);
     ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
@@ -451,7 +451,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresPasswordOfWalletRecoveredFromSeed)
     Monero::Wallet * wallet2 = wmgr->recoveryWallet(WALLET_NAME, WALLET_PASS, seed1, Monero::NetworkType::MAINNET, 0);
     ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet2->mainAddress() == address1);
-    ASSERT_TRUE(wallet2->store(WALLET_NAME_COPY));
+    ASSERT_TRUE(wallet2->store(WALLET_NAME_COPY, WALLET_PASS));
     ASSERT_TRUE(wmgr->closeWallet(wallet2));
     Monero::Wallet * wallet3 = wmgr->openWallet(WALLET_NAME_COPY, WALLET_PASS, Monero::NetworkType::MAINNET);
     ASSERT_TRUE(wallet3->status() == Monero::Wallet::Status_Ok);
@@ -470,7 +470,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresPasswordOfWalletRecoveredFromKeys)
     Monero::Wallet * wallet2 = wmgr->createWalletFromKeys(WALLET_NAME, WALLET_PASS, WALLET_LANG, Monero::NetworkType::MAINNET, 0, address1, viewkey1, spendkey1);
     ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
     ASSERT_TRUE(wallet2->mainAddress() == address1);
-    ASSERT_TRUE(wallet2->store(WALLET_NAME_COPY));
+    ASSERT_TRUE(wallet2->store(WALLET_NAME_COPY, WALLET_PASS));
     ASSERT_TRUE(wmgr->closeWallet(wallet2));
     Monero::Wallet * wallet3 = wmgr->openWallet(WALLET_NAME_COPY, WALLET_PASS, Monero::NetworkType::MAINNET);
     ASSERT_TRUE(wallet3->status() == Monero::Wallet::Status_Ok);
@@ -486,7 +486,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet1)
     std::string address1 = wallet1->mainAddress();
 
     ASSERT_TRUE(wallet1->store(""));
-    ASSERT_TRUE(wallet1->store(WALLET_NAME_COPY));
+    ASSERT_TRUE(wallet1->store(WALLET_NAME_COPY, WALLET_PASS));
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
     Monero::Wallet * wallet2 = wmgr->openWallet(WALLET_NAME_COPY, WALLET_PASS, WALLET_NETWORK_TYPE);
     ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
@@ -502,7 +502,7 @@ TEST_F(WalletManagerTest, WalletManagerStoresWallet2)
     std::string seed1 = wallet1->seed();
     std::string address1 = wallet1->mainAddress();
 
-    ASSERT_TRUE(wallet1->store(WALLET_NAME_WITH_DIR));
+    ASSERT_TRUE(wallet1->store(WALLET_NAME_WITH_DIR, WALLET_PASS));
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 
     wallet1 = wmgr->openWallet(WALLET_NAME_WITH_DIR, WALLET_PASS, WALLET_NETWORK_TYPE);

--- a/utils/python-rpc/framework/wallet.py
+++ b/utils/python-rpc/framework/wallet.py
@@ -317,7 +317,7 @@ class Wallet(object):
         }
         return self.rpc.send_json_rpc_request(restore_deterministic_wallet)
 
-    def generate_from_keys(self, restore_height = 0, filename = "", password = "", address = "", spendkey = "", viewkey = "", autosave_current = True):
+    def generate_from_keys(self, restore_height = 0, filename = "", password = "", address = "", spendkey = "", viewkey = "", language = "English", autosave_current = True):
         generate_from_keys = {
             'method': 'generate_from_keys',
             'params' : {
@@ -327,6 +327,7 @@ class Wallet(object):
                 'spendkey': spendkey,
                 'viewkey': viewkey,
                 'password': password,
+                'language': language,
                 'autosave_current': autosave_current,
             },
             'jsonrpc': '2.0', 
@@ -399,10 +400,11 @@ class Wallet(object):
         }
         return self.rpc.send_json_rpc_request(stop_wallet)
 
-    def refresh(self):
+    def refresh(self, start_height = 0):
         refresh = {
             'method': 'refresh',
             'params' : {
+                "start_height": start_height,
             },
             'jsonrpc': '2.0', 
             'id': '0'
@@ -923,12 +925,13 @@ class Wallet(object):
         }
         return self.rpc.send_json_rpc_request(set_account_tag_description)
 
-    def rescan_blockchain(self, hard = False):
+    def rescan_blockchain(self, hard = False, keep_key_images = False):
         rescan_blockchain = {
             'method': 'rescan_blockchain',
             'jsonrpc': '2.0',
             'params': {
                 'hard': hard,
+                'keep_key_images': keep_key_images,
             },
             'id': '0'
         }


### PR DESCRIPTION
## Context

This change was proposed by @j-berman in Step 2 [here](https://github.com/seraphis-migration/wallet3/issues/64).
(And the first part, replacing `wallet2` with the Wallet API in `monero-wallet-cli`, is waiting for reviews/testers here: #10233)

All the relevant changes for this PR can be found in the fifth commit.
Other commits have their own PRs:
1-3: add functions to Wallet API - #9464 (where the first commit was the initial round, before working on wallet-cli or wallet-rpc, second commit were changes that came up during work on the wallet-cli #10233, third commit started out as all changes that were explicitly introduced during work on the wallet-rpc, but all the recent changes (even for wallet-cli fixes) have been squashed into the latest commit, so maybe at this point I can just squash all three commits of that PR?)
4: remove cached password in Wallet API - #10232


(Will eventually make some edits to this PR description, but for now I didn't want to further delay this PR.)