### PR TITLE
wallet2: remove unused pool tx removed callback

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3596,8 +3596,6 @@ void wallet2::remove_obsolete_pool_txs(const std::vector<crypto::hash> &tx_hashe
     {
       MDEBUG("Removing " << txid << " from unconfirmed payments");
       m_unconfirmed_payments.erase(pit);
-      if (0 != m_callback)
-        m_callback->on_pool_tx_removed(txid);
     }
   }
 }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -136,8 +136,6 @@ private:
     virtual boost::optional<epee::wipeable_string> on_device_pin_request() { return boost::none; }
     virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool & on_device) { on_device = true; return boost::none; }
     virtual void on_device_progress(const hw::device_progress& event) {};
-    // Common callbacks
-    virtual void on_pool_tx_removed(const crypto::hash &txid) {}
     virtual ~i_wallet2_callback() {}
   };
 


### PR DESCRIPTION
`on_pool_tx_removed` has no implementation beyond the empty default callback and is not wired through the wallet API layer.

The only call site passed `txid` after erasing the payment entry that owned it, leaving a dangling reference.