### PR TITLE
Fix typos

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -295,7 +295,7 @@ MARKDOWN_SUPPORT       = YES
 
 # When enabled doxygen tries to link words that correspond to documented
 # classes, or namespaces to their corresponding documentation. Such a link can
-# be prevented in individual cases by by putting a % sign in front of the word
+# be prevented in individual cases by putting a % sign in front of the word
 # or globally by setting AUTOLINK_SUPPORT to NO.
 # The default value is: YES.
 
@@ -2068,7 +2068,7 @@ HAVE_DOT               = $(HAVE_DOT)
 
 DOT_NUM_THREADS        = 0
 
-# When you want a differently looking font n the dot files that doxygen
+# When you want a differently looking font in the dot files that doxygen
 # generates you can specify the font name using DOT_FONTNAME. You need to make
 # sure dot is able to find the font, which can be done by putting it in a
 # standard location or by setting the DOTFONTPATH environment variable or by

--- a/cmake/SetClangTidy.cmake
+++ b/cmake/SetClangTidy.cmake
@@ -51,7 +51,7 @@ macro (monero_clang_tidy LANGUAGE)
 			    # An example of selectively enabling checks:
 			    #-checks=bugprone-*,cppcoreguidelines-avoid-goto # Have to be in one line :(
 			)
-			# Current list of checks is avaibale under:
+			# Current list of checks is available under:
 			# https://clang.llvm.org/extra/clang-tidy/
 			if (${LANGUAGE} STREQUAL "C")
 				set(CMAKE_C_CLANG_TIDY

--- a/contrib/epee/include/net/http_protocol_handler.inl
+++ b/contrib/epee/include/net/http_protocol_handler.inl
@@ -160,7 +160,7 @@ namespace net_utils
 					pos = body.find(boundary, std::distance(body.begin(), it_begin));
 					if(std::string::npos == pos)
 					{
-						MERROR("Error: Filed to match closing multipart tag");
+						MERROR("Error: Failed to match closing multipart tag");
 						it_end = body.end();
 					}else
 					{

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -108,7 +108,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 - A patch MUST adhere to the code style guidelines of the project if these are defined.
 - A patch MUST adhere to the "Evolution of Public Contracts" guidelines defined below.
 - A patch MUST NOT include non-trivial code from other projects unless the Contributor is the original author of that code.
-- A patch MUST compile cleanly and pass project self-tests on at least the principle target platform.
+- A patch MUST compile cleanly and pass project self-tests on at least the principal target platform.
 - A patch commit message SHOULD consist of a single short (less than 50 character) line summarizing the change, optionally followed by a blank line and then a more thorough description.
 - A "Correct Patch" is one that satisfies the above requirements.
 

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2568,7 +2568,7 @@ std::vector<uint64_t> BlockchainLMDB::get_block_cumulative_rct_outputs(const std
   {
     if (height >= range_begin && height < range_end)
     {
-      // nohting to do
+      // nothing to do
     }
     else
     {

--- a/src/common/stack_trace.cpp
+++ b/src/common/stack_trace.cpp
@@ -67,7 +67,7 @@
 // from https://stackoverflow.com/questions/11665829/how-can-i-print-stack-trace-for-caught-exceptions-in-c-code-injection-in-c
 
 // The decl of __cxa_throw in /usr/include/.../cxxabi.h uses
-// 'std::type_info *', but GCC's built-in protype uses 'void *'.
+// 'std::type_info *', but GCC's built-in prototype uses 'void *'.
 #ifdef __clang__
 #define CXA_THROW_INFO_T std::type_info
 #else // !__clang__

--- a/src/crypto/crypto_ops_builder/ref10CommentedCombined/MakeCryptoOps.py
+++ b/src/crypto/crypto_ops_builder/ref10CommentedCombined/MakeCryptoOps.py
@@ -1,4 +1,4 @@
-#assumes you have gnu sed, osx sed might need slight syntax changeo
+#assumes you have gnu sed, osx sed might need slight syntax changes
 #c.f. https://unix.stackexchange.com/questions/112023/how-can-i-replace-a-string-in-a-files
 
 #written by shen-noether monero research labs

--- a/src/crypto/generic-ops.h
+++ b/src/crypto/generic-ops.h
@@ -49,7 +49,7 @@ namespace crypto { \
 #define CRYPTO_MAKE_COMPARABLE_CONSTANT_TIME(type) \
 namespace crypto { \
   inline bool operator==(const type &_v1, const type &_v2) { \
-    static_assert(sizeof(_v1) == 32, "constant time comparison is only implenmted for 32 bytes"); \
+    static_assert(sizeof(_v1) == 32, "constant time comparison is only implemented for 32 bytes"); \
     return crypto_verify_32((const unsigned char*)&_v1, (const unsigned char*)&_v2) == 0; \
   } \
   inline bool operator!=(const type &_v1, const type &_v2) { \

--- a/src/crypto/jh.c
+++ b/src/crypto/jh.c
@@ -215,7 +215,7 @@ static void F8(hashState *state)
 {
       uint64_t* x = (uint64_t*)state->x;
 
-      /*xor the 512-bit message with the fist half of the 1024-bit hash state*/
+      /*xor the 512-bit message with the first half of the 1024-bit hash state*/
       for (int i = 0; i < 8; ++i) {
             uint64 b;
             memcpy(&b, &state->buffer[i << 3], sizeof(b));

--- a/src/crypto/slow-hash.c
+++ b/src/crypto/slow-hash.c
@@ -1458,7 +1458,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int variant, int 
 }
 #else /* aarch64 && crypto */
 
-// ND: Some minor optimizations for ARMv7 (raspberrry pi 2), effect seems to be ~40-50% faster.
+// ND: Some minor optimizations for ARMv7 (raspberry pi 2), effect seems to be ~40-50% faster.
 //     Needs more work.
 
 #ifdef NO_OPTIMIZED_MULTIPLY_ON_ARM

--- a/src/cryptonote_basic/connection_context.h
+++ b/src/cryptonote_basic/connection_context.h
@@ -57,8 +57,8 @@ namespace cryptonote
 
     /*
       This class was originally from the EPEE module. It is identical in function to std::atomic<uint32_t> except
-      that it has copy-construction and copy-assignment defined, which means that earliers devs didn't have to write
-      custom copy-contructors and copy-assingment operators for the outer class, cryptonote_connection_context.
+      that it has copy-construction and copy-assignment defined, which means that earlier devs didn't have to write
+      custom copy-constructors and copy-assignment operators for the outer class, cryptonote_connection_context.
       cryptonote_connection_context should probably be refactored because it is both trying to be POD-like while
       also (very loosely) controlling access to its atomic members.
     */

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -140,7 +140,7 @@
 #define P2P_LOCAL_GRAY_PEERLIST_LIMIT                   5000
 
 #define P2P_DEFAULT_CONNECTIONS_COUNT                   12
-#define P2P_DEFAULT_HANDSHAKE_INTERVAL                  60           //secondes
+#define P2P_DEFAULT_HANDSHAKE_INTERVAL                  60           //seconds
 #define P2P_DEFAULT_PACKET_MAX_SIZE                     50000000     //50000000 bytes maximum packet size
 #define P2P_DEFAULT_PEERS_IN_HANDSHAKE                  250
 #define P2P_MAX_PEERS_IN_HANDSHAKE                      250

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -643,7 +643,7 @@ block Blockchain::pop_block_from_blockchain(bool keep_txs)
 
       // At time of popping, we know all of the referenced mix ring data for popped transactions,
       // and since they are already in the chain, and not pruned, we assume that the ring signature
-      // input verification succeeded for these transactions. We can deference each each mix ring,
+      // input verification succeeded for these transactions. We can dereference each mix ring,
       // calculate the verification ID for that (tx, ring) pair, then add to the mempool with that
       // input verification ID. This speeds up re-org handling by allowing to skip verifying ring
       // signatures which were previously verified.
@@ -1528,7 +1528,7 @@ uint64_t Blockchain::get_current_cumulative_block_weight_median() const
 //
 // FIXME: this codebase references #if defined(DEBUG_CREATE_BLOCK_TEMPLATE)
 // in a lot of places.  That flag is not referenced in any of the code
-// nor any of the makefiles, howeve.  Need to look into whether or not it's
+// nor any of the makefiles, however.  Need to look into whether or not it's
 // necessary at all.
 bool Blockchain::create_block_template(block& b, const crypto::hash *from_block, const account_public_address& miner_address, difficulty_type& diffic, uint64_t& height, uint64_t& expected_reward, uint64_t& cumulative_weight, const blobdata& ex_nonce, uint64_t &seed_height, crypto::hash &seed_hash)
 {

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1035,7 +1035,7 @@ namespace cryptonote
      bool check_block_rate();
 
      /**
-      * @brief recalculate difficulties after the last difficulty checklpoint to circumvent the annoying 'difficulty drift' bug
+      * @brief recalculate difficulties after the last difficulty checkpoint to circumvent the annoying 'difficulty drift' bug
       *
       * @return true
       */

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1007,7 +1007,7 @@ namespace cryptonote
       LOG_PRINT_L2("Giving back the whole pool");
 
     // If incremental, handle removed TXIDs first since it's important that txs are removed
-    // from synchronizers' pools, and we need need to estimate how much space we have left to
+    // from synchronizers' pools, and we need to estimate how much space we have left to
     // request full-bodied txs
     if (incremental)
     {

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -687,7 +687,7 @@ private:
     std::multimap<time_t, removed_tx_info> m_removed_txs_by_time;
 
     // Info how far back in time the list of removed tx ids currently reaches
-    // (it gets shorted periodically to prevent overflow)
+    // (it gets shortened periodically to prevent overflow)
     time_t m_removed_txs_start_time;
 
     /**

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1990,7 +1990,7 @@ skip:
     const uint32_t local_stripe = tools::get_pruning_stripe(m_core.get_blockchain_pruning_seed());
     if (local_stripe == 0)
       return false;
-    // don't request pre-bulletprooof pruned blocks, we can't reconstruct their weight (yet)
+    // don't request pre-bulletproof pruned blocks, we can't reconstruct their weight (yet)
     static const uint64_t bp_fork_height = m_core.get_earliest_ideal_height_for_version(HF_VERSION_SMALLER_BP + 1);
     if (first_block_height < bp_fork_height)
       return false;

--- a/src/cryptonote_protocol/levin_notify.cpp
+++ b/src/cryptonote_protocol/levin_notify.cpp
@@ -187,7 +187,7 @@ namespace levin
         epee::byte_slice arg_buff;
         epee::serialization::store_t_to_binary(request, arg_buff);
 
-        // we probably lowballed the payload size a bit, so added a but too much. Fix this now.
+        // we probably lowballed the payload size a bit, so added a bit too much. Fix this now.
         size_t remove = arg_buff.size() % granularity;
         if (remove > request._.size())
           request._.clear();
@@ -325,7 +325,7 @@ namespace levin
         : zone_(source.zone_), message_(source.message_.clone()), destination_(source.destination_)
       {}
 
-      //! \pre Called within `zone_->channels[destionation_].strand`.
+      //! \pre Called within `zone_->channels[destination_].strand`.
       void operator()()
       {
         if (!zone_)

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -636,7 +636,7 @@ namespace hw {
         memset(vkey.data, 0x00, 32);
         memset(skey.data, 0xFF, 32);
 
-        //spcialkey, normal conf handled in decrypt
+        //special key, normal conf handled in decrypt
         send_simple(INS_GET_KEY, 0x02);
 
         //View key is retrieved, if allowed, to speed up blockchain parsing
@@ -2190,7 +2190,7 @@ namespace hw {
           offset += 1;
           //xx
           this->send_secret(xx[j].bytes, offset);
-          //alpa
+          //alpha
           this->send_secret(alpha[j].bytes, offset);
 
           this->buffer_send[4] = offset-5;
@@ -2336,7 +2336,7 @@ namespace hw {
         int offset = set_command_header_noopt(INS_CLSAG, 0x03);
 
         //c
-        //discard, unse internal one
+        //discard, use internal one
         //a
         this->send_secret(a.bytes, offset);
         //p

--- a/src/device_trezor/device_trezor_base.cpp
+++ b/src/device_trezor/device_trezor_base.cpp
@@ -470,7 +470,7 @@ namespace trezor {
     void device_trezor_base::on_passphrase_request(GenericMessage & resp, const messages::common::PassphraseRequest * msg)
     {
       CHECK_AND_ASSERT_THROW_MES(msg, "Empty message");
-      MDEBUG("on_passhprase_request");
+      MDEBUG("on_passphrase_request");
 
       m_seen_passphrase_entry_message = true;
       bool on_device = false;

--- a/src/net/parse.h
+++ b/src/net/parse.h
@@ -126,7 +126,7 @@ namespace net
         get_network_address(boost::string_ref address, std::uint16_t default_port);
 
     /*!
-      Identifies an IPv4 subnet in CIDR notatioa and returns it as a generic
+      Identifies an IPv4 subnet in CIDR notation and returns it as a generic
       `network_address`. If the type is unsupported, it might be a hostname,
       and `error() == net::error::kUnsupportedAddress` is returned.
 

--- a/src/ringct/rctOps.cpp
+++ b/src/ringct/rctOps.cpp
@@ -673,7 +673,7 @@ namespace rct {
         }
     }
 
-    //Elliptic Curve Diffie Helman: encodes and decodes the amount b and mask a
+    //Elliptic Curve Diffie-Hellman: encodes and decodes the amount b and mask a
     // where C= aG + bH
     key genAmountEncodingFactor(const key &k)
     {

--- a/src/ringct/rctOps.h
+++ b/src/ringct/rctOps.h
@@ -172,7 +172,7 @@ namespace rct {
     //sums a vector of curve points (for scalars use sc_add)
     void sumKeys(key & Csum, const key &Cis);
 
-    //Elliptic Curve Diffie Helman: encodes and decodes the amount b and mask a
+    //Elliptic Curve Diffie-Hellman: encodes and decodes the amount b and mask a
     // where C= aG + bH
     key genAmountEncodingFactor(const key &k);
     key genCommitmentMask(const key &sk);

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -1040,12 +1040,12 @@ namespace rct {
     //   columns that are claimed as inputs, and that the sum of inputs  = sum of outputs.
     //   Also contains masked "amount" and "mask" so the receiver can see how much they received
     //verRct:
-    //   verifies that all signatures (rangeProogs, MG sig, sum inputs = outputs) are correct
+    //   verifies that all signatures (rangeProofs, MG sig, sum inputs = outputs) are correct
     //decodeRct: (c.f. https://eprint.iacr.org/2015/1098 section 5.1.1)
     //   uses the attached ecdh info to find the amounts represented by each output commitment 
     //   must know the destination private key to find the correct amount, else will return a random number
     //   Note: For txn fees, the last index in the amounts vector should contain that
-    //   Thus the amounts vector will be "one" longer than the destinations vectort
+    //   Thus the amounts vector will be "one" longer than the destinations vector
     rctSig genRct(const key &message, const ctkeyV & inSk, const keyV & destinations, const vector<xmr_amount> & amounts, const ctkeyM &mixRing, const keyV &amount_keys, unsigned int index, ctkeyV &outSk, const RCTConfig &rct_config, hw::device &hwdev) {
         CHECK_AND_ASSERT_THROW_MES(amounts.size() == destinations.size() || amounts.size() == destinations.size() + 1, "Different number of amounts/destinations");
         CHECK_AND_ASSERT_THROW_MES(amount_keys.size() == destinations.size(), "Different number of amount_keys/destinations");
@@ -1274,7 +1274,7 @@ namespace rct {
     //   columns that are claimed as inputs, and that the sum of inputs  = sum of outputs.
     //   Also contains masked "amount" and "mask" so the receiver can see how much they received
     //verRct:
-    //   verifies that all signatures (rangeProogs, MG sig, sum inputs = outputs) are correct
+    //   verifies that all signatures (rangeProofs, MG sig, sum inputs = outputs) are correct
     //decodeRct: (c.f. https://eprint.iacr.org/2015/1098 section 5.1.1)
     //   uses the attached ecdh info to find the amounts represented by each output commitment 
     //   must know the destination private key to find the correct amount, else will return a random number    

--- a/src/ringct/rctSigs.h
+++ b/src/ringct/rctSigs.h
@@ -69,7 +69,7 @@ namespace rct {
     bool verifyBorromean(const boroSig &bb, const key64 P1, const key64 P2);
 
     //Multilayered Spontaneous Anonymous Group Signatures (MLSAG signatures)
-    //These are aka MG signatutes in earlier drafts of the ring ct paper
+    //These are aka MG signatures in earlier drafts of the ring ct paper
     // c.f. https://eprint.iacr.org/2015/1098 section 2.
     // Gen creates a signature which proves that for some column in the keymatrix "pk"
     //   the signer knows a secret key for each row in that column
@@ -119,7 +119,7 @@ namespace rct {
     //   columns that are claimed as inputs, and that the sum of inputs  = sum of outputs.
     //   Also contains masked "amount" and "mask" so the receiver can see how much they received
     //verRct:
-    //   verifies that all signatures (rangeProogs, MG sig, sum inputs = outputs) are correct
+    //   verifies that all signatures (rangeProofs, MG sig, sum inputs = outputs) are correct
     //decodeRct: (c.f. https://eprint.iacr.org/2015/1098 section 5.1.1)
     //   uses the attached ecdh info to find the amounts represented by each output commitment
     //   must know the destination private key to find the correct amount, else will throw

--- a/src/rpc/rpc_args.cpp
+++ b/src/rpc/rpc_args.cpp
@@ -73,7 +73,7 @@ namespace cryptonote
         }
       }
 
-      // user specified CA file or fingeprints implies enabled SSL by default
+      // user specified CA file or fingerprints implies enabled SSL by default
       if (!ssl_required && !epee::net_utils::ssl_support_from_string(ssl_options.support, command_line::get_arg(vm, arg.rpc_ssl)))
       {
         MERROR("Invalid argument for " << std::string(arg.rpc_ssl.name));

--- a/src/serialization/variant.h
+++ b/src/serialization/variant.h
@@ -45,7 +45,7 @@
 #include <boost/mpl/pop_front.hpp>
 #include "serialization.h"
 
-/*! \struct variant_serialization_triats
+/*! \struct variant_serialization_traits
  * 
  * \brief used internally to contain a variant's traits/possible types
  *

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1409,13 +1409,13 @@ size_t WalletImpl::numSubaddresses(uint32_t accountIndex) const
 }
 void WalletImpl::addSubaddress(uint32_t accountIndex, const std::string& label)
 {
-    if (checkBackgroundSync("cannot add subbaddress"))
+    if (checkBackgroundSync("cannot add subaddress"))
         return;
     m_wallet->add_subaddress(accountIndex, label);
 }
 std::string WalletImpl::getSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex) const
 {
-    if (checkBackgroundSync("cannot get subbaddress label"))
+    if (checkBackgroundSync("cannot get subaddress label"))
         return "";
     try
     {
@@ -1430,7 +1430,7 @@ std::string WalletImpl::getSubaddressLabel(uint32_t accountIndex, uint32_t addre
 }
 void WalletImpl::setSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex, const std::string &label)
 {
-    if (checkBackgroundSync("cannot set subbaddress label"))
+    if (checkBackgroundSync("cannot set subaddress label"))
         return;
     try
     {

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -726,7 +726,7 @@ struct Wallet
     virtual bool rescanBlockchain() = 0;
 
     /**
-     * @brief rescanBlockchainAsync - rescans wallet asynchronously, starting from genesys
+     * @brief rescanBlockchainAsync - rescans wallet asynchronously, starting from genesis
      */
     virtual void rescanBlockchainAsync() = 0;
 
@@ -991,7 +991,7 @@ struct Wallet
      */
     virtual uint32_t defaultMixin() const = 0;
     /*!
-     * \brief setDefaultMixin - setum number of mixins to be used for new transactions
+     * \brief setDefaultMixin - sets the number of mixins to be used for new transactions
      * \param arg
      */
     virtual void setDefaultMixin(uint32_t arg) = 0;

--- a/src/wallet/message_store.cpp
+++ b/src/wallet/message_store.cpp
@@ -142,7 +142,7 @@ void message_store::set_signer(const multisig_wallet_state &state,
     m.monero_address_known = true;
     m.monero_address = monero_address.get();
   }
-  // Save to minimize the chance to loose that info
+  // Save to minimize the chance to lose that info
   save(state);
 }
 
@@ -709,7 +709,7 @@ void message_store::delete_all_messages()
 // This is mostly geared towards the safe display of notes sent by "mms note" with a "mms show" command
 std::string message_store::get_sanitized_text(const std::string &text, size_t max_length)
 {
-  // Restrict the size to fend of DOS-style attacks with heaps of data
+  // Restrict the size to fend off DOS-style attacks with heaps of data
   size_t length = std::min(text.length(), max_length);
   std::string sanitized_text = text.substr(0, length);
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -342,7 +342,7 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   auto daemon_ssl_allow_any_cert = command_line::get_arg(vm, opts.daemon_ssl_allow_any_cert);
   auto daemon_ssl = command_line::get_arg(vm, opts.daemon_ssl);
 
-  // user specified CA file or fingeprints implies enabled SSL by default
+  // user specified CA file or fingerprints implies enabled SSL by default
   epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
   if (daemon_ssl_allow_any_cert)
     ssl_options.verification = epee::net_utils::ssl_verification_t::none;
@@ -2070,7 +2070,7 @@ bool wallet2::frozen(const multisig_tx_set& txs) const
   for (const auto& ptx : txs.m_ptx)
   {
     const tools::wallet2::tx_construction_data& cd = ptx.construction_data;
-    CHECK_AND_ASSERT_THROW_MES(cd.sources.size() == ptx.tx.vin.size(), "mismatched multisg tx set source sizes");
+    CHECK_AND_ASSERT_THROW_MES(cd.sources.size() == ptx.tx.vin.size(), "mismatched multisig tx set source sizes");
     for (size_t src_idx = 0; src_idx < cd.sources.size(); ++src_idx)
     {
       // Extract keys images from tx vin and construction data
@@ -9174,7 +9174,7 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
     // statistically independent from other picks, since we pick outputs from a finite set
     // *without replacement*, due to the protocol not allowing duplicate ring members. This effect
     // is exacerbated by the fact that we pick 1.5x + 75 as many outputs as we need per RPC
-    // request to account for unusable outputs. This effect is small, but non-neglibile and gets
+    // request to account for unusable outputs. This effect is small, but non-negligible and gets
     // worse with larger ring sizes.
     std::vector<get_outputs_out> secret_picking_order;
 
@@ -10353,7 +10353,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
       while (subtractable_remaining)
       {
         // Set the amount to subtract iterating at the beginning of the list so equal amounts are
-        // subtracted throughout the list of destinations. We use max(x, 1) so that we we still step
+        // subtracted throughout the list of destinations. We use max(x, 1) so that we still step
         // forwards even when the amount remaining is less than the number of subtractable indices
         if (si_it == subtractable_indices.cbegin())
           amount_to_subtract = std::max<uint64_t>(subtractable_remaining / subtractable_indices.size(), 1);
@@ -10957,7 +10957,7 @@ bool wallet2::sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, c
 
   // For destinations from where the fee is subtracted, the required amount has to be at least
   // target amount - (tx fee / num_subtractable + 1). +1 since fee might not be evenly divisible by
-  // the number of subtractble destinations. For non-subtractable destinations, we need at least
+  // the number of subtractable destinations. For non-subtractable destinations, we need at least
   // the target amount.
   const size_t num_subtractable_dests = subtract_fee_from_outputs.size();
   const uint64_t fee0 = ptx_vector[0].fee;
@@ -14211,7 +14211,7 @@ size_t wallet2::import_outputs(const std::tuple<uint64_t, uint64_t, std::vector<
         continue;
     }
 
-    // construct a synthetix tx prefix that has the info we'll need: the output with its pubkey, the tx pubkey in extra
+    // construct a synthetic tx prefix that has the info we'll need: the output with its pubkey, the tx pubkey in extra
     td.m_tx = {};
 
     THROW_WALLET_EXCEPTION_IF(etd.m_internal_output_index >= 65536, error::wallet_internal_error, "internal output index seems outrageously high, rejecting");

--- a/src/wallet/wallet2_basic/wallet2_types.h
+++ b/src/wallet/wallet2_basic/wallet2_types.h
@@ -68,7 +68,7 @@ public:
     */
     size_t offset() const { return m_offset; }
     /**
-     * @brief: get the genesis bloch hash
+     * @brief: get the genesis block hash
     */
     const crypto::hash &genesis() const { return m_genesis; }
     /**


### PR DESCRIPTION
So after seeing #10814 I realized the codespell approach still left out plenty of typos, so I asked AI to read every single file in the codebase for spelling issues.

I was initially skeptical to open this PR because with AI I realized the codebase is riddled with typos also in variable names and function names, so I figured it's better to just ignore it since the issue can never be truly fixed.