### PR TITLE
rpc: include hidden pool key images in unrestricted spent checks

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1000,11 +1000,11 @@ namespace cryptonote
     return res;
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent) const
+  bool core::are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent, const bool include_sensitive) const
   {
     spent.clear();
 
-    return m_mempool.check_for_key_images(key_im, spent);
+    return m_mempool.check_for_key_images(key_im, spent, include_sensitive);
   }
   //-----------------------------------------------------------------------------------------------
   std::pair<boost::multiprecision::uint128_t, boost::multiprecision::uint128_t> core::get_coinbase_tx_sum(const uint64_t start_offset, const size_t count)

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -988,11 +988,11 @@ namespace cryptonote
     return res;
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent) const
+  bool core::are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent, const bool include_sensitive) const
   {
     spent.clear();
 
-    return m_mempool.check_for_key_images(key_im, spent);
+    return m_mempool.check_for_key_images(key_im, spent, include_sensitive);
   }
   //-----------------------------------------------------------------------------------------------
   std::pair<boost::multiprecision::uint128_t, boost::multiprecision::uint128_t> core::get_coinbase_tx_sum(const uint64_t start_offset, const size_t count)

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -768,10 +768,11 @@ namespace cryptonote
       *
       * @param key_im list of key images to check
       * @param spent return-by-reference result for each image checked
+      * @param include_sensitive include key images from hidden pool transactions
       *
       * @return true
       */
-     bool are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent) const;
+     bool are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent, bool include_sensitive = false) const;
 
      /**
       * @brief get the number of blocks to sync in one go

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -750,10 +750,11 @@ namespace cryptonote
       *
       * @param key_im list of key images to check
       * @param spent return-by-reference result for each image checked
+      * @param include_sensitive include key images from hidden pool transactions
       *
       * @return true
       */
-     bool are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent) const;
+     bool are_key_images_spent_in_pool(const std::vector<crypto::key_image>& key_im, std::vector<bool> &spent, bool include_sensitive = false) const;
 
      /**
       * @brief get the number of blocks to sync in one go

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1347,12 +1347,13 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::check_for_key_images(const std::vector<crypto::key_image>& key_images, std::vector<bool>& spent) const
+  bool tx_memory_pool::check_for_key_images(const std::vector<crypto::key_image>& key_images, std::vector<bool>& spent, const bool include_sensitive) const
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     CRITICAL_REGION_LOCAL1(m_blockchain);
 
     spent.clear();
+    const relay_category category = include_sensitive ? relay_category::all : relay_category::broadcasted;
 
     for (const auto& image : key_images)
     {
@@ -1361,7 +1362,7 @@ namespace cryptonote
       if (found != m_spent_key_images.end())
       {
         for (const crypto::hash& tx_hash : found->second)
-          is_spent |= m_blockchain.txpool_tx_matches_category(tx_hash, relay_category::broadcasted);
+          is_spent |= m_blockchain.txpool_tx_matches_category(tx_hash, category);
       }
       spent.push_back(is_spent);
     }

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1319,12 +1319,13 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::check_for_key_images(const std::vector<crypto::key_image>& key_images, std::vector<bool>& spent) const
+  bool tx_memory_pool::check_for_key_images(const std::vector<crypto::key_image>& key_images, std::vector<bool>& spent, const bool include_sensitive) const
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     CRITICAL_REGION_LOCAL1(m_blockchain);
 
     spent.clear();
+    const relay_category category = include_sensitive ? relay_category::all : relay_category::broadcasted;
 
     for (const auto& image : key_images)
     {
@@ -1333,7 +1334,7 @@ namespace cryptonote
       if (found != m_spent_key_images.end())
       {
         for (const crypto::hash& tx_hash : found->second)
-          is_spent |= m_blockchain.txpool_tx_matches_category(tx_hash, relay_category::broadcasted);
+          is_spent |= m_blockchain.txpool_tx_matches_category(tx_hash, category);
       }
       spent.push_back(is_spent);
     }

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -352,10 +352,11 @@ namespace cryptonote
      *
      * @param key_images [in] vector of key images to check
      * @param spent [out] vector of bool to return
+     * @param include_sensitive include key images from hidden pool transactions
      *
      * @return true
      */
-    bool check_for_key_images(const std::vector<crypto::key_image>& key_images, std::vector<bool>& spent) const;
+    bool check_for_key_images(const std::vector<crypto::key_image>& key_images, std::vector<bool>& spent, bool include_sensitive = false) const;
 
     /**
      * @brief get a specific transaction from the pool

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -335,10 +335,11 @@ namespace cryptonote
      *
      * @param key_images [in] vector of key images to check
      * @param spent [out] vector of bool to return
+     * @param include_sensitive include key images from hidden pool transactions
      *
      * @return true
      */
-    bool check_for_key_images(const std::vector<crypto::key_image>& key_images, std::vector<bool>& spent) const;
+    bool check_for_key_images(const std::vector<crypto::key_image>& key_images, std::vector<bool>& spent, bool include_sensitive = false) const;
 
     /**
      * @brief get a specific transaction from the pool

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1211,7 +1211,7 @@ namespace cryptonote
 
     // check the pool too
     spent_status.clear();
-    r = m_core.are_key_images_spent_in_pool(filtered_key_images, spent_status);
+    r = m_core.are_key_images_spent_in_pool(filtered_key_images, spent_status, !restricted);
     if (!r || spent_status.size() != filtered_key_images.size())
     {
       res.status = "Failed";

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1014,7 +1014,7 @@ namespace cryptonote
 
     // check the pool too
     spent_status.clear();
-    r = m_core.are_key_images_spent_in_pool(filtered_key_images, spent_status);
+    r = m_core.are_key_images_spent_in_pool(filtered_key_images, spent_status, !restricted);
     if (!r || spent_status.size() != filtered_key_images.size())
     {
       res.status = "Failed";

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -331,7 +331,7 @@ namespace rpc
     std::vector<bool> pool_spent_status;
 
     m_core.are_key_images_spent(req.key_images, chain_spent_status);
-    m_core.are_key_images_spent_in_pool(req.key_images, pool_spent_status);
+    m_core.are_key_images_spent_in_pool(req.key_images, pool_spent_status, !m_restricted);
 
     if ((chain_spent_status.size() != req.key_images.size()) || (pool_spent_status.size() != req.key_images.size()))
     {

--- a/tests/core_tests/tx_pool.cpp
+++ b/tests/core_tests/tx_pool.cpp
@@ -74,6 +74,10 @@ bool txpool_base::check_txpool_spent_keys(cryptonote::core& c, size_t /*ev_index
     return false;
   }
 
+  std::unordered_set<std::string> broadcasted_key_images;
+  for (const cryptonote::spent_key_image_info& key_image : key_images)
+    broadcasted_key_images.insert(key_image.id_hash);
+
   infos.clear();
   key_images.clear();
   if (!c.get_pool_transactions_and_spent_keys_info(infos, key_images, false) || infos.size() != m_broadcasted_tx_count || key_images.size() != m_broadcasted_tx_count)
@@ -87,6 +91,42 @@ bool txpool_base::check_txpool_spent_keys(cryptonote::core& c, size_t /*ev_index
   if (!c.get_pool_transactions_and_spent_keys_info(infos, key_images, true) || infos.size() != m_all_tx_count || key_images.size() != m_all_tx_count)
   {
     MERROR("Failed all spent keys retrieval - Expected All Count: " << m_all_tx_count << " Actual Info Count: " << infos.size() << " Actual Key Image Count: " << key_images.size());
+    return false;
+  }
+
+  std::vector<crypto::key_image> all_key_images;
+  all_key_images.reserve(key_images.size());
+  for (const cryptonote::spent_key_image_info& key_image : key_images)
+  {
+    crypto::key_image parsed_key_image;
+    if (!epee::string_tools::hex_to_pod(key_image.id_hash, parsed_key_image))
+    {
+      MERROR("Failed to parse txpool key image");
+      return false;
+    }
+    all_key_images.push_back(parsed_key_image);
+  }
+
+  std::vector<bool> spent;
+  if (!c.are_key_images_spent_in_pool(all_key_images, spent) || spent.size() != all_key_images.size())
+  {
+    MERROR("Failed broadcasted key image spent check");
+    return false;
+  }
+  for (std::size_t i = 0; i < spent.size(); ++i)
+  {
+    if (spent[i] != (broadcasted_key_images.count(key_images[i].id_hash) != 0))
+    {
+      MERROR("Unexpected broadcasted key image spent status");
+      return false;
+    }
+  }
+
+  if (!c.are_key_images_spent_in_pool(all_key_images, spent, true) ||
+      spent.size() != all_key_images.size() ||
+      std::any_of(spent.begin(), spent.end(), [](const bool value) { return !value; }))
+  {
+    MERROR("Failed sensitive key image spent check");
     return false;
   }
 

--- a/tests/core_tests/tx_pool.cpp
+++ b/tests/core_tests/tx_pool.cpp
@@ -60,9 +60,53 @@ bool txpool_base::check_txpool_spent_keys(cryptonote::core& c, size_t /*ev_index
 {
   std::vector<cryptonote::tx_info> infos{};
   std::vector<cryptonote::spent_key_image_info> key_images{};
+  std::vector<cryptonote::rpc::tx_in_pool> broadcasted_infos;
+  cryptonote::rpc::key_images_with_tx_hashes broadcasted_key_images;
+  if (!c.get_pool_for_rpc(broadcasted_infos, broadcasted_key_images))
+  {
+    MERROR("Failed broadcasted spent keys retrieval");
+    return false;
+  }
+
   if (!c.get_pool_transactions_and_spent_keys_info(infos, key_images) || infos.size() != m_all_tx_count || key_images.size() != m_all_tx_count)
   {
     MERROR("Failed all spent keys retrieval - Expected All Count: " << m_all_tx_count << " Actual Info Count: " << infos.size() << " Actual Key Image Count: " << key_images.size());
+    return false;
+  }
+
+  std::vector<crypto::key_image> all_key_images;
+  all_key_images.reserve(key_images.size());
+  for (const cryptonote::spent_key_image_info& key_image : key_images)
+  {
+    crypto::key_image parsed_key_image;
+    if (!epee::string_tools::hex_to_pod(key_image.id_hash, parsed_key_image))
+    {
+      MERROR("Failed to parse txpool key image");
+      return false;
+    }
+    all_key_images.push_back(parsed_key_image);
+  }
+
+  std::vector<bool> spent;
+  if (!c.are_key_images_spent_in_pool(all_key_images, spent) || spent.size() != all_key_images.size())
+  {
+    MERROR("Failed broadcasted key image spent check");
+    return false;
+  }
+  for (std::size_t i = 0; i < spent.size(); ++i)
+  {
+    if (spent[i] != (broadcasted_key_images.count(all_key_images[i]) != 0))
+    {
+      MERROR("Unexpected broadcasted key image spent status");
+      return false;
+    }
+  }
+
+  if (!c.are_key_images_spent_in_pool(all_key_images, spent, true) ||
+      spent.size() != all_key_images.size() ||
+      std::any_of(spent.begin(), spent.end(), [](const bool value) { return !value; }))
+  {
+    MERROR("Failed sensitive key image spent check");
     return false;
   }
 

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -685,8 +685,6 @@ class TransferTest():
         res = self.wallet[0].sweep_single('44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW', key_image = ki)
         assert len(res.tx_hash) == 64
         tx_hash = res.tx_hash
-        # Avoid racing the txpool relay state update before checking spent status
-        time.sleep(0.1)
         res = daemon.is_key_image_spent([ki])
         assert len(res.spent_status) == 1
         assert res.spent_status[0] == 2

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -694,8 +694,6 @@ class TransferTest():
         res = self.wallet[0].sweep_single('44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW', key_image = ki)
         assert len(res.tx_hash) == 64
         tx_hash = res.tx_hash
-        # Avoid racing the txpool relay state update before checking spent status
-        time.sleep(0.1)
         res = daemon.is_key_image_spent([ki])
         assert len(res.spent_status) == 1
         assert res.spent_status[0] == 2


### PR DESCRIPTION
Fix unrestricted is_key_image_spent queries to include hidden/local txpool entries. Restricted RPC continues to report only broadcasted transactions, preserving txpool privacy. This avoids a race where a newly submitted transaction briefly appeared unspent before its asynchronous relay-state update completed.

Should fix following CI error

```
Sending single output
Traceback (most recent call last):
  File "/__w/monero/monero/tests/functional_tests/transfer.py", line 1638, in <module>
    TransferTest().run_test()
  File "/__w/monero/monero/tests/functional_tests/transfer.py", line 81, in run_test
    self.sweep_single()
  File "/__w/monero/monero/tests/functional_tests/transfer.py", line 689, in sweep_single
    assert res.spent_status[0] == 2
AssertionError
[TEST FAILED] transfer
```