### PR TITLE
epee: allow shared Windows file reads

### DIFF
--- a/contrib/epee/src/file_io_utils.cpp
+++ b/contrib/epee/src/file_io_utils.cpp
@@ -107,7 +107,7 @@ namespace file_io_utils
 #ifdef _WIN32
                 std::wstring wide_path;
                 try { wide_path = string_tools::utf8_to_utf16(path_to_file); } catch (...) { return false; }
-                HANDLE file_handle = CreateFileW(wide_path.c_str(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                HANDLE file_handle = CreateFileW(wide_path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                 if (file_handle == INVALID_HANDLE_VALUE)
                     return false;
                 DWORD file_size = GetFileSize(file_handle, NULL);

--- a/tests/unit_tests/logging.cpp
+++ b/tests/unit_tests/logging.cpp
@@ -136,6 +136,10 @@ TEST(logging, all)
   ASSERT_TRUE(str.find("error") != std::string::npos);
   ASSERT_TRUE(str.find("debug") != std::string::npos);
   ASSERT_TRUE(str.find("trace") != std::string::npos);
+
+  MINFO("after active log read");
+  ASSERT_TRUE(load_log_to_string(log_filename, str));
+  ASSERT_TRUE(str.find("after active log read") != std::string::npos);
   cleanup();
 }
 


### PR DESCRIPTION
Opening a file with a zero sharing mode makes read-only access exclusive on Windows. Allow read and write sharing so callers can inspect files that are already open, such as active log files.

Fixes logging related test cases on Windows.

Related: #8547