### PR TITLE
tests: fix Windows unit test failures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 .git* export-ignore
 version.cmake export-subst
+tests/data/** -text

--- a/tests/unit_tests/wallet_storage.cpp
+++ b/tests/unit_tests/wallet_storage.cpp
@@ -302,7 +302,7 @@ TEST(wallet_storage, gen_ascii_format)
         ASSERT_TRUE(epee::file_io_utils::load_file_to_string(target_wallet_file.string() + ".keys", key_file_contents));
         EXPECT_NE(std::string::npos, key_file_contents.find(WALLET2_ASCII_OUTPUT_MAGIC));
         for (const char c : key_file_contents)
-            ASSERT_TRUE(std::isprint(c) || c == '\n' || c == '\r');
+            ASSERT_TRUE(std::isprint(static_cast<unsigned char>(c)) || c == '\n' || c == '\r');
     }
 
     {
@@ -340,12 +340,16 @@ TEST(wallet_storage, change_export_format)
         // Assert that we initially store keys in binary format
         {
             std::string key_file_contents;
-            ASSERT_TRUE(epee::file_io_utils::load_file_to_string(target_wallet_file.string() + ".keys", key_file_contents));
+            ASSERT_TRUE(w.unlock_keys_file());
+            const bool loaded = epee::file_io_utils::load_file_to_string(target_wallet_file.string() + ".keys", key_file_contents);
+            ASSERT_TRUE(w.lock_keys_file());
+            ASSERT_TRUE(w.is_keys_file_locked());
+            ASSERT_TRUE(loaded);
             EXPECT_EQ(std::string::npos, key_file_contents.find(WALLET2_ASCII_OUTPUT_MAGIC));
             bool only_printable = true;
             for (const char c : key_file_contents)
             {
-                if (!std::isprint(c) && c != '\n' && c != '\r')
+                if (!std::isprint(static_cast<unsigned char>(c)) && c != '\n' && c != '\r')
                 {
                     only_printable = false;
                     break;
@@ -369,7 +373,7 @@ TEST(wallet_storage, change_export_format)
         ASSERT_TRUE(epee::file_io_utils::load_file_to_string(target_wallet_file.string() + ".keys", key_file_contents));
         EXPECT_NE(std::string::npos, key_file_contents.find(WALLET2_ASCII_OUTPUT_MAGIC));
         for (const char c : key_file_contents)
-            ASSERT_TRUE(std::isprint(c) || c == '\n' || c == '\r');
+            ASSERT_TRUE(std::isprint(static_cast<unsigned char>(c)) || c == '\n' || c == '\r');
     }
 
     {


### PR DESCRIPTION
- Preserve line endings for test fixtures so file hashes remain stable across platforms.
- Temporarily release the wallet keys lock while inspecting the keys file, then reacquire it and verify the lock state. This lets the test read the file on Windows, where the lock prevents a concurrent read open.
- Avoid passing possibly negative char values to std::isprint(), which is undefined behavior except for EOF.

Related: #8547