### PR TITLE
crypto: reject invalid tree path indices

### DIFF
--- a/src/crypto/tree-hash.c
+++ b/src/crypto/tree-hash.c
@@ -107,7 +107,7 @@ void tree_hash(const char (*hashes)[HASH_SIZE], size_t count, char *root_hash) {
 
 bool tree_path(size_t count, size_t idx, uint32_t *path)
 {
-  if (count == 0)
+  if (count == 0 || idx >= count)
     return false;
 
   if (count == 1) {

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -131,8 +131,14 @@ TEST(Crypto, tree_branch)
     inputs[n].data[0] = n + 1;
   }
 
-  // empty
+  // invalid input
   ASSERT_FALSE(crypto::tree_branch((const char(*)[32])inputs, 0, crypto::null_hash.data, (char(*)[32])branch, &depth, &path));
+  ASSERT_FALSE(crypto::tree_path(0, 0, &path2));
+  ASSERT_FALSE(crypto::tree_path(1, 1, &path2));
+  ASSERT_FALSE(crypto::tree_path(2, 2, &path2));
+  ASSERT_FALSE(crypto::tree_path(3, 3, &path2));
+  ASSERT_FALSE(crypto::tree_path(3, 4, &path2));
+  ASSERT_FALSE(crypto::tree_path(5, 5, &path2));
 
   // one, matching
   ASSERT_TRUE(crypto::tree_branch((const char(*)[32])inputs, 1, inputs[0].data, (char(*)[32])branch, &depth, &path));


### PR DESCRIPTION
This makes `tree_path()` reject leaf indexes outside the tree, matching the way `tree_branch()` already fails when the requested leaf is not present

Before this, calls like `tree_path(1, 1, &path)` returned true and produced a path for a leaf that does not exist

The new regression checks fail before the guard and pass after it

Checks:
- `cmake --build build --target unit_tests -j 2`
- `cmake --build build --target test_notifier -j 2`
- `./build/tests/unit_tests/unit_tests --gtest_filter=Crypto.tree_branch`
- `./build/tests/unit_tests/unit_tests --gtest_filter=notify.works`
- `ctest --test-dir build --output-on-failure -R '^unit_tests$'`