### PR TITLE
p2p: support IPv6 subnet bans

### DIFF
--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -168,6 +168,54 @@ namespace net_utils
 	inline bool operator>=(const ipv4_network_subnet& lhs, const ipv4_network_subnet& rhs) noexcept
 	{ return !lhs.less(rhs); }
 
+	class ipv6_network_address;
+
+	class ipv6_network_subnet
+	{
+		boost::asio::ip::address_v6 m_address;
+		uint8_t m_mask;
+
+	public:
+		ipv6_network_subnet()
+			: ipv6_network_subnet(boost::asio::ip::address_v6{}, 0)
+		{}
+
+		ipv6_network_subnet(const boost::asio::ip::address_v6& address, uint8_t mask)
+			: m_address(address), m_mask(mask)
+		{
+			CHECK_AND_ASSERT_THROW_MES(mask <= 128, "invalid IPv6 subnet mask");
+		}
+
+		bool equal(const ipv6_network_subnet& other) const noexcept;
+		bool less(const ipv6_network_subnet& other) const noexcept;
+		bool is_same_host(const ipv6_network_subnet& other) const noexcept
+		{ return subnet() == other.subnet(); }
+		bool matches(const ipv6_network_address &address) const;
+
+		uint8_t mask() const noexcept { return m_mask; }
+		boost::asio::ip::address_v6 subnet() const noexcept;
+		std::string str() const;
+		std::string host_str() const;
+		bool is_loopback() const;
+		bool is_local() const;
+		static constexpr address_type get_type_id() noexcept { return address_type::invalid; }
+		static constexpr zone get_zone() noexcept { return zone::public_; }
+		static constexpr bool is_blockable() noexcept { return true; }
+	};
+
+	inline bool operator==(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return lhs.equal(rhs); }
+	inline bool operator!=(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return !lhs.equal(rhs); }
+	inline bool operator<(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return lhs.less(rhs); }
+	inline bool operator<=(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return !rhs.less(lhs); }
+	inline bool operator>(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return rhs.less(lhs); }
+	inline bool operator>=(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return !lhs.less(rhs); }
+
 	class ipv6_network_address
 	{
 	protected:

--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -176,6 +176,50 @@ namespace net_utils
 	inline bool operator>=(const ipv4_network_subnet& lhs, const ipv4_network_subnet& rhs) noexcept
 	{ return !lhs.less(rhs); }
 
+	class ipv6_network_address;
+
+	class ipv6_network_subnet
+	{
+		boost::asio::ip::address_v6 m_subnet;
+		uint8_t m_mask;
+
+	public:
+		ipv6_network_subnet()
+			: ipv6_network_subnet(boost::asio::ip::address_v6{}, 0)
+		{}
+
+		ipv6_network_subnet(const boost::asio::ip::address_v6& address, uint8_t mask);
+
+		bool equal(const ipv6_network_subnet& other) const noexcept;
+		bool less(const ipv6_network_subnet& other) const noexcept;
+		bool is_same_host(const ipv6_network_subnet& other) const noexcept
+		{ return subnet() == other.subnet(); }
+		bool matches(const ipv6_network_address &address) const;
+
+		uint8_t mask() const noexcept { return m_mask; }
+		const boost::asio::ip::address_v6& subnet() const noexcept { return m_subnet; }
+		std::string str() const;
+		std::string host_str() const;
+		bool is_loopback() const;
+		bool is_local() const;
+		static constexpr address_type get_type_id() noexcept { return address_type::invalid; }
+		static constexpr zone get_zone() noexcept { return zone::public_; }
+		static constexpr bool is_blockable() noexcept { return true; }
+	};
+
+	inline bool operator==(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return lhs.equal(rhs); }
+	inline bool operator!=(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return !lhs.equal(rhs); }
+	inline bool operator<(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return lhs.less(rhs); }
+	inline bool operator<=(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return !rhs.less(lhs); }
+	inline bool operator>(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return rhs.less(lhs); }
+	inline bool operator>=(const ipv6_network_subnet& lhs, const ipv6_network_subnet& rhs) noexcept
+	{ return !lhs.less(rhs); }
+
 	class ipv6_network_address
 	{
 	protected:

--- a/contrib/epee/src/net_utils_base.cpp
+++ b/contrib/epee/src/net_utils_base.cpp
@@ -17,6 +17,27 @@ static inline uint32_t make_address_v4_from_v6(const boost::asio::ip::address_v6
   return htonl(v4);
 }
 
+static inline boost::asio::ip::address_v6 apply_ipv6_cidr_mask(const boost::asio::ip::address_v6& address, const uint8_t mask)
+{
+  auto bytes = address.to_bytes();
+  uint8_t remaining = mask;
+  for (uint8_t &byte: bytes)
+  {
+    if (remaining >= 8)
+    {
+      remaining -= 8;
+    }
+    else if (remaining > 0)
+    {
+      byte &= static_cast<uint8_t>(0xffu << (8 - remaining));
+      remaining = 0;
+    }
+    else
+      byte = 0;
+  }
+  return boost::asio::ip::address_v6{bytes};
+}
+
 namespace epee { namespace net_utils
 {
 	bool ipv4_network_address::equal(const ipv4_network_address& other) const noexcept
@@ -61,6 +82,26 @@ namespace epee { namespace net_utils
 	bool ipv4_network_subnet::matches(const ipv4_network_address &address) const
 	{
 		return (address.ip() & ~(0xffffffffull << m_mask)) == subnet();
+	}
+
+	bool ipv6_network_subnet::equal(const ipv6_network_subnet& other) const noexcept
+	{ return is_same_host(other) && m_mask == other.m_mask; }
+
+	bool ipv6_network_subnet::less(const ipv6_network_subnet& other) const noexcept
+	{ return subnet() < other.subnet() ? true : (other.subnet() < subnet() ? false : (m_mask < other.m_mask)); }
+
+	boost::asio::ip::address_v6 ipv6_network_subnet::subnet() const noexcept
+	{ return apply_ipv6_cidr_mask(m_address, m_mask); }
+
+	std::string ipv6_network_subnet::str() const
+	{ return subnet().to_string() + "/" + std::to_string(m_mask); }
+
+	std::string ipv6_network_subnet::host_str() const { return str(); }
+	bool ipv6_network_subnet::is_loopback() const { return subnet().is_loopback(); }
+	bool ipv6_network_subnet::is_local() const { return subnet().is_link_local(); }
+	bool ipv6_network_subnet::matches(const ipv6_network_address &address) const
+	{
+		return apply_ipv6_cidr_mask(address.ip(), m_mask) == subnet();
 	}
 
 
@@ -159,4 +200,3 @@ namespace epee { namespace net_utils
     return zone::invalid;
   }
 }}
-

--- a/contrib/epee/src/net_utils_base.cpp
+++ b/contrib/epee/src/net_utils_base.cpp
@@ -16,6 +16,27 @@ static inline uint32_t make_ipv4_cidr_mask(const uint8_t mask)
   return SWAP32BE(0xffffffffu << (32 - mask));
 }
 
+static inline boost::asio::ip::address_v6 apply_ipv6_cidr_mask(const boost::asio::ip::address_v6& address, const uint8_t mask)
+{
+  auto bytes = address.to_bytes();
+  uint8_t remaining = mask;
+  for (uint8_t &byte: bytes)
+  {
+    if (remaining >= 8)
+    {
+      remaining -= 8;
+    }
+    else if (remaining > 0)
+    {
+      byte &= static_cast<uint8_t>(0xffu << (8 - remaining));
+      remaining = 0;
+    }
+    else
+      byte = 0;
+  }
+  return boost::asio::ip::address_v6{bytes};
+}
+
 namespace epee { namespace net_utils
 {
 	bool ipv4_network_address::equal(const ipv4_network_address& other) const noexcept
@@ -102,6 +123,30 @@ namespace epee { namespace net_utils
 	bool ipv4_network_subnet::matches(const ipv4_network_address &address) const
 	{
 		return (address.ip() & make_ipv4_cidr_mask(m_mask)) == subnet();
+	}
+
+	ipv6_network_subnet::ipv6_network_subnet(const boost::asio::ip::address_v6& address, uint8_t mask)
+		: m_subnet(address), m_mask(mask)
+	{
+		CHECK_AND_ASSERT_THROW_MES(mask <= 128, "invalid IPv6 subnet mask");
+		m_subnet = apply_ipv6_cidr_mask(address, mask);
+	}
+
+	bool ipv6_network_subnet::equal(const ipv6_network_subnet& other) const noexcept
+	{ return is_same_host(other) && m_mask == other.m_mask; }
+
+	bool ipv6_network_subnet::less(const ipv6_network_subnet& other) const noexcept
+	{ return subnet() < other.subnet() ? true : (other.subnet() < subnet() ? false : (m_mask < other.m_mask)); }
+
+	std::string ipv6_network_subnet::str() const
+	{ return subnet().to_string() + "/" + std::to_string(m_mask); }
+
+	std::string ipv6_network_subnet::host_str() const { return str(); }
+	bool ipv6_network_subnet::is_loopback() const { return subnet().is_loopback(); }
+	bool ipv6_network_subnet::is_local() const { return subnet().is_link_local(); }
+	bool ipv6_network_subnet::matches(const ipv6_network_address &address) const
+	{
+		return apply_ipv6_cidr_mask(address.ip(), m_mask) == subnet();
 	}
 
 
@@ -203,4 +248,3 @@ namespace epee { namespace net_utils
     return zone::invalid;
   }
 }}
-

--- a/src/daemon/command_parser_executor.cpp
+++ b/src/daemon/command_parser_executor.cpp
@@ -712,13 +712,19 @@ bool t_command_parser_executor::ban(const std::vector<std::string>& args)
           ret &= m_executor.ban(subnet->str(), seconds);
           continue;
         }
+        auto ipv6_subnet = net::get_ipv6_subnet_address(line);
+        if (ipv6_subnet)
+        {
+          ret &= m_executor.ban(ipv6_subnet->str(), seconds);
+          continue;
+        }
         const expect<epee::net_utils::network_address> parsed_addr = net::get_network_address(line, 0);
         if (parsed_addr)
         {
           ret &= m_executor.ban(parsed_addr->host_str(), seconds);
           continue;
         }
-        std::cout << "Invalid IP address or IPv4 subnet: " << line << std::endl;
+        std::cout << "Invalid IP address or subnet: " << line << std::endl;
       }
       return ret;
     }

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -229,19 +229,19 @@ t_command_server::t_command_server(
     m_command_lookup.set_handler(
       "bans"
     , std::bind(&t_command_parser_executor::show_bans, &m_parser, p::_1)
-    , "Show the currently banned IPs."
+    , "Show the currently banned addresses and subnets."
     );
     m_command_lookup.set_handler(
       "ban"
     , std::bind(&t_command_parser_executor::ban, &m_parser, p::_1)
-    , "ban [<IP>|@<filename>] [<seconds>]"
-    , "Ban a given <IP> or list of IPs from a file for a given amount of <seconds>."
+    , "ban [<address>|<subnet>|@<filename>] [<seconds>]"
+    , "Ban a given <address>, <subnet>, or list from a file for a given amount of <seconds>."
     );
     m_command_lookup.set_handler(
       "unban"
     , std::bind(&t_command_parser_executor::unban, &m_parser, p::_1)
-    , "unban <address>"
-    , "Unban a given <IP>."
+    , "unban <address>|<subnet>"
+    , "Unban a given <address> or <subnet>."
     );
     m_command_lookup.set_handler(
       "banned"

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -229,19 +229,19 @@ t_command_server::t_command_server(
     m_command_lookup.set_handler(
       "bans"
     , std::bind(&t_command_parser_executor::show_bans, &m_parser, p::_1)
-    , "Show the currently banned IPs."
+    , "Show the currently banned addresses and subnets."
     );
     m_command_lookup.set_handler(
       "ban"
     , std::bind(&t_command_parser_executor::ban, &m_parser, p::_1)
-    , "ban [<IP>|@<filename>] [<seconds>]"
-    , "Ban a given <IP> or list of IPs from a file for a given amount of <seconds>."
+    , "ban [<address>|<subnet>|@<filename>] [<seconds>]"
+    , "Ban a given <address>, <subnet>, or list from a file for a given amount of <seconds>."
     );
     m_command_lookup.set_handler(
       "unban"
     , std::bind(&t_command_parser_executor::unban, &m_parser, p::_1)
-    , "unban <address>|all"
-    , "Unban a given <address>, or all banned addresses."
+    , "unban <address>|<subnet>|all"
+    , "Unban a given <address> or <subnet>, or all banned addresses."
     );
     m_command_lookup.set_handler(
       "banned"

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1713,7 +1713,7 @@ bool t_rpc_command_executor::print_bans()
         }
     }
     else 
-        tools::msg_writer() << "No IPs are banned";
+        tools::msg_writer() << "No addresses or subnets are banned";
 
     return true;
 }

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1695,7 +1695,7 @@ bool t_rpc_command_executor::print_bans()
         }
     }
     else 
-        tools::msg_writer() << "No IPs are banned";
+        tools::msg_writer() << "No addresses or subnets are banned";
 
     return true;
 }

--- a/src/net/parse.cpp
+++ b/src/net/parse.cpp
@@ -221,6 +221,35 @@ namespace net
         return {epee::net_utils::ipv4_network_subnet{ip, (uint8_t)mask}};
     }
 
+    expect<epee::net_utils::ipv6_network_subnet>
+    get_ipv6_subnet_address(const boost::string_ref address, bool allow_implicit_128)
+    {
+        uint32_t mask = 128;
+        const boost::string_ref::size_type slash = address.find_first_of('/');
+        if (slash != boost::string_ref::npos)
+        {
+            if (!epee::string_tools::get_xtype_from_string(mask, std::string{address.substr(slash + 1)}))
+                return make_error_code(net::error::invalid_mask);
+            if (mask > 128)
+                return make_error_code(net::error::invalid_mask);
+        }
+        else if (!allow_implicit_128)
+            return make_error_code(net::error::invalid_mask);
+
+        boost::string_ref host(address.data(), slash != boost::string_ref::npos ? slash : address.size());
+        if (host.starts_with("[") && host.ends_with("]"))
+            host = host.substr(1, host.size() - 2);
+        else if (host.find_first_of("[]") != boost::string_ref::npos)
+            return make_error_code(net::error::invalid_host);
+
+        boost::system::error_code ec;
+        const boost::asio::ip::address_v6 ip = boost::asio::ip::make_address_v6(std::string{host}, ec);
+        if (ec)
+            return make_error_code(net::error::invalid_host);
+
+        return {epee::net_utils::ipv6_network_subnet{ip, (uint8_t)mask}};
+    }
+
     expect<boost::asio::ip::tcp::endpoint> get_tcp_endpoint(const boost::string_ref address)
     {
         uint16_t port = 0;

--- a/src/net/parse.cpp
+++ b/src/net/parse.cpp
@@ -226,6 +226,41 @@ namespace net
         return {epee::net_utils::ipv4_network_subnet{ip, (uint8_t)mask}};
     }
 
+    expect<epee::net_utils::ipv6_network_subnet>
+    get_ipv6_subnet_address(const boost::string_ref address, bool allow_implicit_128)
+    {
+        uint32_t mask = 128;
+        const boost::string_ref::size_type slash = address.find_first_of('/');
+        if (slash != boost::string_ref::npos)
+        {
+            if (!epee::string_tools::get_xtype_from_string(mask, std::string{address.substr(slash + 1)}))
+                return make_error_code(net::error::invalid_mask);
+            if (mask > 128)
+                return make_error_code(net::error::invalid_mask);
+        }
+        else if (!allow_implicit_128)
+            return make_error_code(net::error::invalid_mask);
+
+        boost::string_ref host(address.data(), slash != boost::string_ref::npos ? slash : address.size());
+        if (host.starts_with("[") && host.ends_with("]"))
+            host = host.substr(1, host.size() - 2);
+        else if (host.find_first_of("[]") != boost::string_ref::npos)
+            return make_error_code(net::error::invalid_host);
+
+        boost::system::error_code ec;
+        const boost::asio::ip::address_v6 ip = boost::asio::ip::make_address_v6(std::string{host}, ec);
+        if (ec)
+            return make_error_code(net::error::invalid_host);
+        const auto bytes = ip.to_bytes();
+        const bool is_v4_compatible =
+            std::all_of(bytes.begin(), bytes.begin() + 12, [](const unsigned char byte) { return byte == 0; }) &&
+            !ip.is_unspecified() && !ip.is_loopback();
+        if (ip.is_v4_mapped() || is_v4_compatible)
+            return make_error_code(net::error::unsupported_address);
+
+        return {epee::net_utils::ipv6_network_subnet{ip, (uint8_t)mask}};
+    }
+
     expect<boost::asio::ip::tcp::endpoint> get_tcp_endpoint(const boost::string_ref address)
     {
         uint16_t port = 0;

--- a/src/net/parse.h
+++ b/src/net/parse.h
@@ -138,6 +138,9 @@ namespace net
     expect<epee::net_utils::ipv4_network_subnet>
         get_ipv4_subnet_address(boost::string_ref address, bool allow_implicit_32 = false);
 
+    expect<epee::net_utils::ipv6_network_subnet>
+        get_ipv6_subnet_address(boost::string_ref address, bool allow_implicit_128 = false);
+
     expect<boost::asio::ip::tcp::endpoint> get_tcp_endpoint(const boost::string_ref address);
 
     namespace socks
@@ -157,4 +160,3 @@ namespace net
         };
     }
 }
-

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -156,7 +156,7 @@ namespace nodetool
     const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_seed_node   = {"seed-node", "Connect to a node to retrieve peer addresses, and disconnect"};
     const command_line::arg_descriptor<std::vector<std::string> > arg_tx_proxy = {"tx-proxy", "Send local txes through proxy: <network-type>,[socks5://[user:pass@]]<socks-ip:port>[,max_connections][,disable_noise] i.e. \"tor,127.0.0.1:9050,100,disable_noise\""};
     const command_line::arg_descriptor<std::vector<std::string> > arg_anonymous_inbound = {"anonymous-inbound", "<hidden-service-address>,<[bind-ip:]port>[,max_connections] i.e. \"x.onion,127.0.0.1:18083,100\""};
-    const command_line::arg_descriptor<std::string> arg_ban_list = {"ban-list", "Specify ban list file, one IP address per line"};
+    const command_line::arg_descriptor<std::string> arg_ban_list = {"ban-list", "Specify ban list file, one address or subnet per line"};
     const command_line::arg_descriptor<bool> arg_p2p_hide_my_port   =    {"hide-my-port", "Do not announce yourself as peerlist candidate", false, true};
     const command_line::arg_descriptor<bool> arg_no_sync = {"no-sync", "Don't synchronize the blockchain with other peers", false};
     const command_line::arg_descriptor<bool> arg_enable_dns_blocklist = {"enable-dns-blocklist", "Apply realtime blocklist from DNS", false};

--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -142,7 +142,7 @@ namespace nodetool
     const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_seed_node   = {"seed-node", "Connect to a node to retrieve peer addresses, and disconnect"};
     const command_line::arg_descriptor<std::vector<std::string> > arg_tx_proxy = {"tx-proxy", "Send local txes through proxy: <network-type>,[socks5://[user:pass@]]<socks-ip:port>[,max_connections][,disable_noise] i.e. \"tor,127.0.0.1:9050,100,disable_noise\""};
     const command_line::arg_descriptor<std::vector<std::string> > arg_anonymous_inbound = {"anonymous-inbound", "<hidden-service-address>,<[bind-ip:]port>[,max_connections] i.e. \"x.onion,127.0.0.1:18083,100\""};
-    const command_line::arg_descriptor<std::string> arg_ban_list = {"ban-list", "Specify ban list file, one IP address per line"};
+    const command_line::arg_descriptor<std::string> arg_ban_list = {"ban-list", "Specify ban list file, one address or subnet per line"};
     const command_line::arg_descriptor<bool> arg_p2p_hide_my_port   =    {"hide-my-port", "Do not announce yourself as peerlist candidate", false, true};
     const command_line::arg_descriptor<bool> arg_no_sync = {"no-sync", "Don't synchronize the blockchain with other peers", false};
     const command_line::arg_descriptor<bool> arg_enable_dns_blocklist = {"enable-dns-blocklist", "Apply realtime blocklist from DNS", false};

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -284,9 +284,12 @@ namespace nodetool
     virtual bool unblock_host(const epee::net_utils::network_address &address);
     virtual bool block_subnet(const epee::net_utils::ipv4_network_subnet &subnet, time_t seconds = P2P_IP_BLOCKTIME);
     virtual bool unblock_subnet(const epee::net_utils::ipv4_network_subnet &subnet);
+    virtual bool block_subnet(const epee::net_utils::ipv6_network_subnet &subnet, time_t seconds = P2P_IP_BLOCKTIME);
+    virtual bool unblock_subnet(const epee::net_utils::ipv6_network_subnet &subnet);
     virtual bool is_host_blocked(const epee::net_utils::network_address &address, time_t *seconds) { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return !is_remote_host_allowed(address, seconds); }
     virtual std::map<std::string, time_t> get_blocked_hosts() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_hosts; }
     virtual std::map<epee::net_utils::ipv4_network_subnet, time_t> get_blocked_subnets() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_subnets; }
+    virtual std::map<epee::net_utils::ipv6_network_subnet, time_t> get_blocked_ipv6_subnets() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_ipv6_subnets; }
 
     virtual void add_used_stripe_peer(const typename t_payload_net_handler::connection_context &context);
     virtual void remove_used_stripe_peer(const typename t_payload_net_handler::connection_context &context);
@@ -490,6 +493,7 @@ namespace nodetool
     epee::critical_section m_blocked_hosts_lock; // for both hosts and subnets
     std::map<std::string, time_t> m_blocked_hosts;
     std::map<epee::net_utils::ipv4_network_subnet, time_t> m_blocked_subnets;
+    std::map<epee::net_utils::ipv6_network_subnet, time_t> m_blocked_ipv6_subnets;
 
     epee::critical_section m_host_fails_score_lock;
     std::map<std::string, uint64_t> m_host_fails_score;
@@ -544,4 +548,3 @@ namespace nodetool
 }
 
 POP_WARNINGS
-

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -280,16 +280,24 @@ namespace nodetool
     virtual bool unblock_host(const epee::net_utils::network_address &address);
     virtual bool block_subnet(const epee::net_utils::ipv4_network_subnet &subnet, time_t seconds = P2P_IP_BLOCKTIME);
     virtual bool unblock_subnet(const epee::net_utils::ipv4_network_subnet &subnet);
+    virtual bool block_subnet(const epee::net_utils::ipv6_network_subnet &subnet, time_t seconds = P2P_IP_BLOCKTIME);
+    virtual bool unblock_subnet(const epee::net_utils::ipv6_network_subnet &subnet);
     virtual bool clear_bans();
     virtual bool is_host_blocked(const epee::net_utils::network_address &address, time_t *seconds) { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return !is_remote_host_allowed(address, seconds); }
     virtual std::map<std::string, time_t> get_blocked_hosts() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_hosts; }
     virtual std::map<epee::net_utils::ipv4_network_subnet, time_t> get_blocked_subnets() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_subnets; }
+    virtual std::map<epee::net_utils::ipv6_network_subnet, time_t> get_blocked_ipv6_subnets() { CRITICAL_REGION_LOCAL(m_blocked_hosts_lock); return m_blocked_ipv6_subnets; }
 
     virtual void add_used_stripe_peer(const typename t_payload_net_handler::connection_context &context);
     virtual void remove_used_stripe_peer(const typename t_payload_net_handler::connection_context &context);
     virtual void clear_used_stripe_peers();
 
   private:
+    template<typename Subnet>
+    bool block_subnet_impl(std::map<Subnet, time_t> &blocked_subnets, const Subnet &subnet, time_t seconds);
+    template<typename Subnet>
+    bool unblock_subnet_impl(std::map<Subnet, time_t> &blocked_subnets, const Subnet &subnet);
+
     const std::vector<std::string> m_seed_nodes_list =
     { "seeds.moneroseeds.se"
     , "seeds.moneroseeds.ae.org"
@@ -472,6 +480,7 @@ namespace nodetool
     epee::critical_section m_blocked_hosts_lock; // for both hosts and subnets
     std::map<std::string, time_t> m_blocked_hosts;
     std::map<epee::net_utils::ipv4_network_subnet, time_t> m_blocked_subnets;
+    std::map<epee::net_utils::ipv6_network_subnet, time_t> m_blocked_ipv6_subnets;
 
     epee::critical_section m_host_fails_score_lock;
     std::map<std::string, uint64_t> m_host_fails_score;
@@ -526,4 +535,3 @@ namespace nodetool
 }
 
 POP_WARNINGS
-

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -34,6 +34,7 @@
 #include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -66,6 +67,85 @@
 
 namespace nodetool
 {
+  namespace
+  {
+    boost::multiprecision::uint256_t ipv6_to_uint256(const boost::asio::ip::address_v6& address)
+    {
+      boost::multiprecision::uint256_t value = 0;
+      for (const auto byte : address.to_bytes())
+        value = (value << 8) | byte;
+      return value;
+    }
+
+    boost::asio::ip::address_v6 uint256_to_ipv6(boost::multiprecision::uint256_t value)
+    {
+      boost::asio::ip::address_v6::bytes_type bytes = {};
+      for (auto i = bytes.rbegin(); i != bytes.rend(); ++i)
+      {
+        *i = static_cast<unsigned char>((value & 0xff).convert_to<unsigned int>());
+        value >>= 8;
+      }
+      return boost::asio::ip::address_v6{bytes};
+    }
+
+    boost::multiprecision::uint256_t ipv6_subnet_size(const uint8_t mask)
+    {
+      CHECK_AND_ASSERT_THROW_MES(mask <= 128, "invalid IPv6 subnet mask");
+      return boost::multiprecision::uint256_t{1} << (128 - mask);
+    }
+
+    boost::multiprecision::uint256_t ipv6_subnet_first(const epee::net_utils::ipv6_network_subnet &subnet)
+    {
+      return ipv6_to_uint256(subnet.subnet());
+    }
+
+    boost::multiprecision::uint256_t ipv6_subnet_last(const epee::net_utils::ipv6_network_subnet &subnet)
+    {
+      return ipv6_subnet_first(subnet) + ipv6_subnet_size(subnet.mask()) - 1;
+    }
+
+    epee::net_utils::ipv6_network_subnet make_ipv6_subnet(const boost::multiprecision::uint256_t &first, const uint8_t mask)
+    {
+      return {uint256_to_ipv6(first), mask};
+    }
+
+    void subtract_ipv6_subnet(
+      const epee::net_utils::ipv6_network_subnet &blocked,
+      const epee::net_utils::ipv6_network_subnet &removed,
+      std::vector<epee::net_utils::ipv6_network_subnet> &result)
+    {
+      const boost::multiprecision::uint256_t blocked_first = ipv6_subnet_first(blocked);
+      const boost::multiprecision::uint256_t blocked_last = ipv6_subnet_last(blocked);
+      const boost::multiprecision::uint256_t removed_first = ipv6_subnet_first(removed);
+      const boost::multiprecision::uint256_t removed_last = ipv6_subnet_last(removed);
+
+      if (removed_last < blocked_first || blocked_last < removed_first)
+      {
+        result.push_back(blocked);
+        return;
+      }
+      if (removed_first <= blocked_first && blocked_last <= removed_last)
+        return;
+
+      const uint8_t child_mask = blocked.mask() + 1;
+      CHECK_AND_ASSERT_THROW_MES(child_mask <= 128, "invalid IPv6 subnet split");
+
+      const boost::multiprecision::uint256_t child_size = ipv6_subnet_size(child_mask);
+      subtract_ipv6_subnet(make_ipv6_subnet(blocked_first, child_mask), removed, result);
+      subtract_ipv6_subnet(make_ipv6_subnet(blocked_first + child_size, child_mask), removed, result);
+    }
+
+    void emplace_blocked_ipv6_subnet(
+      std::map<epee::net_utils::ipv6_network_subnet, time_t> &subnets,
+      const epee::net_utils::ipv6_network_subnet &subnet,
+      const time_t limit)
+    {
+      auto entry = subnets.find(subnet);
+      if (entry == subnets.end() || entry->second < limit)
+        subnets[subnet] = limit;
+    }
+  }
+
   template<class t_payload_net_handler>
   node_server<t_payload_net_handler>::~node_server()
   {
@@ -204,6 +284,27 @@ namespace nodetool
         ++it;
       }
     }
+    else if (address.get_type_id() == epee::net_utils::address_type::ipv6)
+    {
+      auto ipv6_address = address.template as<epee::net_utils::ipv6_network_address>();
+      std::map<epee::net_utils::ipv6_network_subnet, time_t>::iterator it;
+      for (it = m_blocked_ipv6_subnets.begin(); it != m_blocked_ipv6_subnets.end(); )
+      {
+        if (now >= it->second)
+        {
+          MCLOG_CYAN(el::Level::Info, "global", "Subnet " << it->first.host_str() << " unblocked.");
+          it = m_blocked_ipv6_subnets.erase(it);
+          continue;
+        }
+        if (it->first.matches(ipv6_address))
+        {
+          if (t)
+            *t = it->second - now;
+          return false;
+        }
+        ++it;
+      }
+    }
 
     // not found in hosts or subnets, allowed
     return true;
@@ -258,6 +359,18 @@ namespace nodetool
         for (auto jt = m_blocked_subnets.begin(); jt != m_blocked_subnets.end(); ++jt)
         {
           if (jt->first.matches(ipv4_address))
+          {
+            matches_blocked_subnet = true;
+            break;
+          }
+        }
+      }
+      else if (addr.get_type_id() == epee::net_utils::address_type::ipv6)
+      {
+        auto ipv6_address = addr.template as<epee::net_utils::ipv6_network_address>();
+        for (auto jt = m_blocked_ipv6_subnets.begin(); jt != m_blocked_ipv6_subnets.end(); ++jt)
+        {
+          if (jt->first.matches(ipv6_address))
           {
             matches_blocked_subnet = true;
             break;
@@ -376,6 +489,57 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
+  bool node_server<t_payload_net_handler>::block_subnet(const epee::net_utils::ipv6_network_subnet &subnet, time_t seconds)
+  {
+    const time_t now = time(nullptr);
+
+    CRITICAL_REGION_LOCAL(m_blocked_hosts_lock);
+    time_t limit;
+    if (now > std::numeric_limits<time_t>::max() - seconds)
+      limit = std::numeric_limits<time_t>::max();
+    else
+      limit = now + seconds;
+    const bool added = m_blocked_ipv6_subnets.find(subnet) == m_blocked_ipv6_subnets.end();
+    m_blocked_ipv6_subnets[subnet] = limit;
+
+    // drop any connection to that subnet. This should only have to look into
+    // the zone related to the connection, but really make sure everything is
+    // swept ...
+    std::vector<boost::uuids::uuid> conns;
+    for(auto& zone : m_network_zones)
+    {
+      zone.second.m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context& cntxt)
+      {
+        if (cntxt.m_remote_address.get_type_id() != epee::net_utils::ipv6_network_address::get_type_id())
+          return true;
+        auto ipv6_address = cntxt.m_remote_address.template as<epee::net_utils::ipv6_network_address>();
+        if (subnet.matches(ipv6_address))
+        {
+          conns.push_back(cntxt.m_connection_id);
+        }
+        return true;
+      });
+      for (const auto &c: conns)
+        zone.second.m_net_server.get_config_object().close(c, false);
+
+      for (int i = 0; i < 2; ++i)
+        zone.second.m_peerlist.filter(i == 0, [&subnet](const peerlist_entry &pe){
+          if (pe.adr.get_type_id() != epee::net_utils::ipv6_network_address::get_type_id())
+            return false;
+          return subnet.matches(pe.adr.as<const epee::net_utils::ipv6_network_address>());
+        });
+
+      conns.clear();
+    }
+
+    if (added)
+      MCLOG_CYAN(el::Level::Info, "global", "Subnet " << subnet.host_str() << " blocked.");
+    else
+      MINFO("Subnet " << subnet.host_str() << " blocked.");
+    return true;
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::unblock_subnet(const epee::net_utils::ipv4_network_subnet &subnet)
   {
     CRITICAL_REGION_LOCAL(m_blocked_hosts_lock);
@@ -384,6 +548,45 @@ namespace nodetool
       return false;
     m_blocked_subnets.erase(i);
     MCLOG_CYAN(el::Level::Info, "global", "Subnet " << subnet.host_str() << " unblocked.");
+    return true;
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
+  bool node_server<t_payload_net_handler>::unblock_subnet(const epee::net_utils::ipv6_network_subnet &subnet)
+  {
+    CRITICAL_REGION_LOCAL(m_blocked_hosts_lock);
+    bool unblocked = false;
+
+    for (auto i = m_blocked_hosts.begin(); i != m_blocked_hosts.end(); )
+    {
+      auto address = net::get_network_address(i->first, 0);
+      if (address && address->get_type_id() == epee::net_utils::ipv6_network_address::get_type_id()
+        && subnet.matches(address->template as<epee::net_utils::ipv6_network_address>()))
+      {
+        i = m_blocked_hosts.erase(i);
+        unblocked = true;
+      }
+      else
+        ++i;
+    }
+
+    std::map<epee::net_utils::ipv6_network_subnet, time_t> blocked_subnets;
+    std::vector<epee::net_utils::ipv6_network_subnet> remaining;
+    remaining.reserve(128);
+    for (const auto &blocked_subnet : m_blocked_ipv6_subnets)
+    {
+      remaining.clear();
+      subtract_ipv6_subnet(blocked_subnet.first, subnet, remaining);
+      if (remaining.size() != 1 || remaining.front() != blocked_subnet.first)
+        unblocked = true;
+      for (const auto &entry : remaining)
+        emplace_blocked_ipv6_subnet(blocked_subnets, entry, blocked_subnet.second);
+    }
+
+    if (!unblocked)
+      return false;
+    m_blocked_ipv6_subnets.swap(blocked_subnets);
+    MCLOG_CYAN(el::Level::Info, "global", "Subnet " << subnet.str() << " unblocked.");
     return true;
   }
   //-----------------------------------------------------------------------------------
@@ -525,13 +728,19 @@ namespace nodetool
           block_subnet(*subnet, std::numeric_limits<time_t>::max());
           continue;
         }
+        auto ipv6_subnet = net::get_ipv6_subnet_address(line);
+        if (ipv6_subnet)
+        {
+          block_subnet(*ipv6_subnet, std::numeric_limits<time_t>::max());
+          continue;
+        }
         const expect<epee::net_utils::network_address> parsed_addr = net::get_network_address(line, 0);
         if (parsed_addr)
         {
           block_host(*parsed_addr, std::numeric_limits<time_t>::max());
           continue;
         }
-        MERROR("Invalid IP address or IPv4 subnet: " << line);
+        MERROR("Invalid IP address or subnet: " << line);
       }
     }
 
@@ -2139,6 +2348,13 @@ namespace nodetool
         if (subnet)
         {
           block_subnet(*subnet, DNS_BLOCKLIST_LIFETIME);
+          ++good;
+          continue;
+        }
+        auto ipv6_subnet = net::get_ipv6_subnet_address(ip);
+        if (ipv6_subnet)
+        {
+          block_subnet(*ipv6_subnet, DNS_BLOCKLIST_LIFETIME);
           ++good;
           continue;
         }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -34,6 +34,7 @@
 #include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -69,36 +70,72 @@ namespace nodetool
 {
   namespace
   {
-    uint64_t ipv4_subnet_size(const uint8_t mask)
+    template<typename Subnet>
+    struct subnet_traits;
+
+    template<>
+    struct subnet_traits<epee::net_utils::ipv4_network_subnet>
     {
-      CHECK_AND_ASSERT_THROW_MES(mask <= 32, "invalid IPv4 subnet mask");
-      return mask == 0 ? (uint64_t{1} << 32) : (uint64_t{1} << (32 - mask));
+      using address_type = epee::net_utils::ipv4_network_address;
+      using value_type = uint64_t;
+      static constexpr uint8_t bits = 32;
+
+      static value_type first(const epee::net_utils::ipv4_network_subnet &subnet)
+      {
+        return SWAP32BE(subnet.subnet());
+      }
+
+      static epee::net_utils::ipv4_network_subnet make(const value_type first, const uint8_t mask)
+      {
+        return {SWAP32BE(static_cast<uint32_t>(first)), mask};
+      }
+    };
+
+    template<>
+    struct subnet_traits<epee::net_utils::ipv6_network_subnet>
+    {
+      using address_type = epee::net_utils::ipv6_network_address;
+      using value_type = boost::multiprecision::uint256_t;
+      static constexpr uint8_t bits = 128;
+
+      static value_type first(const epee::net_utils::ipv6_network_subnet &subnet)
+      {
+        value_type value = 0;
+        for (const auto byte : subnet.subnet().to_bytes())
+          value = (value << 8) | byte;
+        return value;
+      }
+
+      static epee::net_utils::ipv6_network_subnet make(value_type first, const uint8_t mask)
+      {
+        boost::asio::ip::address_v6::bytes_type bytes = {};
+        for (auto i = bytes.rbegin(); i != bytes.rend(); ++i)
+        {
+          *i = static_cast<unsigned char>((first & 0xff).convert_to<unsigned int>());
+          first >>= 8;
+        }
+        return {boost::asio::ip::address_v6{bytes}, mask};
+      }
+    };
+
+    template<typename Subnet>
+    typename subnet_traits<Subnet>::value_type subnet_size(const uint8_t mask)
+    {
+      using traits = subnet_traits<Subnet>;
+      using value_type = typename traits::value_type;
+      CHECK_AND_ASSERT_THROW_MES(mask <= traits::bits, "invalid subnet mask");
+      return value_type{1} << (traits::bits - mask);
     }
 
-    uint64_t ipv4_subnet_first(const epee::net_utils::ipv4_network_subnet &subnet)
+    template<typename Subnet>
+    void subtract_subnet(const Subnet &blocked, const Subnet &removed, std::vector<Subnet> &result)
     {
-      return SWAP32BE(subnet.subnet());
-    }
-
-    uint64_t ipv4_subnet_last(const epee::net_utils::ipv4_network_subnet &subnet)
-    {
-      return ipv4_subnet_first(subnet) + ipv4_subnet_size(subnet.mask()) - 1;
-    }
-
-    epee::net_utils::ipv4_network_subnet make_ipv4_subnet(const uint64_t first, const uint8_t mask)
-    {
-      return {SWAP32BE(static_cast<uint32_t>(first)), mask};
-    }
-
-    void subtract_ipv4_subnet(
-      const epee::net_utils::ipv4_network_subnet &blocked,
-      const epee::net_utils::ipv4_network_subnet &removed,
-      std::vector<epee::net_utils::ipv4_network_subnet> &result)
-    {
-      const uint64_t blocked_first = ipv4_subnet_first(blocked);
-      const uint64_t blocked_last = ipv4_subnet_last(blocked);
-      const uint64_t removed_first = ipv4_subnet_first(removed);
-      const uint64_t removed_last = ipv4_subnet_last(removed);
+      using traits = subnet_traits<Subnet>;
+      using value_type = typename traits::value_type;
+      const value_type blocked_first = traits::first(blocked);
+      const value_type blocked_last = blocked_first + subnet_size<Subnet>(blocked.mask()) - 1;
+      const value_type removed_first = traits::first(removed);
+      const value_type removed_last = removed_first + subnet_size<Subnet>(removed.mask()) - 1;
 
       if (removed_last < blocked_first || blocked_last < removed_first)
       {
@@ -109,21 +146,49 @@ namespace nodetool
         return;
 
       const uint8_t child_mask = blocked.mask() + 1;
-      CHECK_AND_ASSERT_THROW_MES(child_mask <= 32, "invalid IPv4 subnet split");
+      CHECK_AND_ASSERT_THROW_MES(child_mask <= traits::bits, "invalid subnet split");
 
-      const uint64_t child_size = ipv4_subnet_size(child_mask);
-      subtract_ipv4_subnet(make_ipv4_subnet(blocked_first, child_mask), removed, result);
-      subtract_ipv4_subnet(make_ipv4_subnet(blocked_first + child_size, child_mask), removed, result);
+      const value_type child_size = subnet_size<Subnet>(child_mask);
+      subtract_subnet(traits::make(blocked_first, child_mask), removed, result);
+      subtract_subnet(traits::make(blocked_first + child_size, child_mask), removed, result);
     }
 
-    void emplace_blocked_subnet(
-      std::map<epee::net_utils::ipv4_network_subnet, time_t> &subnets,
-      const epee::net_utils::ipv4_network_subnet &subnet,
-      const time_t limit)
+    template<typename Subnet>
+    void emplace_blocked_subnet(std::map<Subnet, time_t> &subnets, const Subnet &subnet, const time_t limit)
     {
       auto entry = subnets.find(subnet);
       if (entry == subnets.end() || entry->second < limit)
         subnets[subnet] = limit;
+    }
+
+    template<typename Address, typename Subnet>
+    bool is_address_allowed(const Address &address, std::map<Subnet, time_t> &subnets, const time_t now, time_t *t)
+    {
+      for (auto i = subnets.begin(); i != subnets.end(); )
+      {
+        if (now >= i->second)
+        {
+          MCLOG_CYAN(el::Level::Info, "global", "Subnet " << i->first.host_str() << " unblocked.");
+          i = subnets.erase(i);
+          continue;
+        }
+        if (i->first.matches(address))
+        {
+          if (t)
+            *t = i->second - now;
+          return false;
+        }
+        ++i;
+      }
+      return true;
+    }
+
+    template<typename Address, typename Subnet>
+    bool matches_blocked_subnet(const Address &address, const std::map<Subnet, time_t> &subnets)
+    {
+      return std::any_of(subnets.begin(), subnets.end(), [&address](const auto &subnet) {
+        return subnet.first.matches(address);
+      });
     }
   }
 
@@ -287,28 +352,10 @@ namespace nodetool
       }
     }
 
-    // manually loop in subnets
     if (address.get_type_id() == epee::net_utils::address_type::ipv4)
-    {
-      auto ipv4_address = address.template as<epee::net_utils::ipv4_network_address>();
-      std::map<epee::net_utils::ipv4_network_subnet, time_t>::iterator it;
-      for (it = m_blocked_subnets.begin(); it != m_blocked_subnets.end(); )
-      {
-        if (now >= it->second)
-        {
-          MCLOG_CYAN(el::Level::Info, "global", "Subnet " << it->first.host_str() << " unblocked.");
-          it = m_blocked_subnets.erase(it);
-          continue;
-        }
-        if (it->first.matches(ipv4_address))
-        {
-          if (t)
-            *t = it->second - now;
-          return false;
-        }
-        ++it;
-      }
-    }
+      return is_address_allowed(address.template as<epee::net_utils::ipv4_network_address>(), m_blocked_subnets, now, t);
+    if (address.get_type_id() == epee::net_utils::address_type::ipv6)
+      return is_address_allowed(address.template as<epee::net_utils::ipv6_network_address>(), m_blocked_ipv6_subnets, now, t);
 
     // not found in hosts or subnets, allowed
     return true;
@@ -356,20 +403,14 @@ namespace nodetool
       m_blocked_hosts[host_str] = limit;
 
       // if the host was already blocked due to being in a blocked subnet, let it be silent
-      bool matches_blocked_subnet = false;
+      bool blocked_by_subnet = false;
       if (addr.get_type_id() == epee::net_utils::address_type::ipv4)
-      {
-        auto ipv4_address = addr.template as<epee::net_utils::ipv4_network_address>();
-        for (auto jt = m_blocked_subnets.begin(); jt != m_blocked_subnets.end(); ++jt)
-        {
-          if (jt->first.matches(ipv4_address))
-          {
-            matches_blocked_subnet = true;
-            break;
-          }
-        }
-      }
-      if (!matches_blocked_subnet)
+        blocked_by_subnet = matches_blocked_subnet(
+          addr.template as<epee::net_utils::ipv4_network_address>(), m_blocked_subnets);
+      else if (addr.get_type_id() == epee::net_utils::address_type::ipv6)
+        blocked_by_subnet = matches_blocked_subnet(
+          addr.template as<epee::net_utils::ipv6_network_address>(), m_blocked_ipv6_subnets);
+      if (!blocked_by_subnet)
         added = true;
     }
     else if (it->second < limit || !add_only)
@@ -430,8 +471,11 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
-  bool node_server<t_payload_net_handler>::block_subnet(const epee::net_utils::ipv4_network_subnet &subnet, time_t seconds)
+  template<typename Subnet>
+  bool node_server<t_payload_net_handler>::block_subnet_impl(
+    std::map<Subnet, time_t> &blocked_subnets, const Subnet &subnet, time_t seconds)
   {
+    using address_type = typename subnet_traits<Subnet>::address_type;
     const time_t now = time(nullptr);
 
     CRITICAL_REGION_LOCAL(m_blocked_hosts_lock);
@@ -440,8 +484,8 @@ namespace nodetool
       limit = std::numeric_limits<time_t>::max();
     else
       limit = now + seconds;
-    const bool added = m_blocked_subnets.find(subnet) == m_blocked_subnets.end();
-    m_blocked_subnets[subnet] = limit;
+    const bool added = blocked_subnets.find(subnet) == blocked_subnets.end();
+    blocked_subnets[subnet] = limit;
 
     // drop any connection to that subnet. This should only have to look into
     // the zone related to the connection, but really make sure everything is
@@ -451,10 +495,9 @@ namespace nodetool
     {
       zone.second.m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context& cntxt)
       {
-        if (cntxt.m_remote_address.get_type_id() != epee::net_utils::ipv4_network_address::get_type_id())
+        if (cntxt.m_remote_address.get_type_id() != address_type::get_type_id())
           return true;
-        auto ipv4_address = cntxt.m_remote_address.template as<epee::net_utils::ipv4_network_address>();
-        if (subnet.matches(ipv4_address))
+        if (subnet.matches(cntxt.m_remote_address.template as<address_type>()))
         {
           conns.push_back(cntxt.m_connection_id);
         }
@@ -465,9 +508,9 @@ namespace nodetool
 
       for (int i = 0; i < 2; ++i)
         zone.second.m_peerlist.filter(i == 0, [&subnet](const peerlist_entry &pe){
-          if (pe.adr.get_type_id() != epee::net_utils::ipv4_network_address::get_type_id())
+          if (pe.adr.get_type_id() != address_type::get_type_id())
             return false;
-          return subnet.matches(pe.adr.as<const epee::net_utils::ipv4_network_address>());
+          return subnet.matches(pe.adr.as<const address_type>());
         });
 
       conns.clear();
@@ -481,16 +524,32 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
-  bool node_server<t_payload_net_handler>::unblock_subnet(const epee::net_utils::ipv4_network_subnet &subnet)
+  bool node_server<t_payload_net_handler>::block_subnet(const epee::net_utils::ipv4_network_subnet &subnet, time_t seconds)
   {
+    return block_subnet_impl(m_blocked_subnets, subnet, seconds);
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
+  bool node_server<t_payload_net_handler>::block_subnet(const epee::net_utils::ipv6_network_subnet &subnet, time_t seconds)
+  {
+    return block_subnet_impl(m_blocked_ipv6_subnets, subnet, seconds);
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
+  template<typename Subnet>
+  bool node_server<t_payload_net_handler>::unblock_subnet_impl(
+    std::map<Subnet, time_t> &blocked_subnets, const Subnet &subnet)
+  {
+    using traits = subnet_traits<Subnet>;
+    using address_type = typename traits::address_type;
     CRITICAL_REGION_LOCAL(m_blocked_hosts_lock);
     bool unblocked = false;
 
     for (auto i = m_blocked_hosts.begin(); i != m_blocked_hosts.end(); )
     {
       auto address = net::get_network_address(i->first, 0);
-      if (address && address->get_type_id() == epee::net_utils::ipv4_network_address::get_type_id()
-        && subnet.matches(address->template as<epee::net_utils::ipv4_network_address>()))
+      if (address && address->get_type_id() == address_type::get_type_id()
+        && subnet.matches(address->template as<address_type>()))
       {
         i = m_blocked_hosts.erase(i);
         unblocked = true;
@@ -499,33 +558,46 @@ namespace nodetool
         ++i;
     }
 
-    std::map<epee::net_utils::ipv4_network_subnet, time_t> blocked_subnets;
-    std::vector<epee::net_utils::ipv4_network_subnet> remaining;
-    remaining.reserve(32);
-    for (const auto &blocked_subnet : m_blocked_subnets)
+    std::map<Subnet, time_t> remaining_subnets;
+    std::vector<Subnet> remaining;
+    remaining.reserve(traits::bits);
+    for (const auto &blocked_subnet : blocked_subnets)
     {
       remaining.clear();
-      subtract_ipv4_subnet(blocked_subnet.first, subnet, remaining);
+      subtract_subnet(blocked_subnet.first, subnet, remaining);
       if (remaining.size() != 1 || remaining.front() != blocked_subnet.first)
         unblocked = true;
       for (const auto &entry : remaining)
-        emplace_blocked_subnet(blocked_subnets, entry, blocked_subnet.second);
+        emplace_blocked_subnet(remaining_subnets, entry, blocked_subnet.second);
     }
 
     if (!unblocked)
       return false;
-    m_blocked_subnets.swap(blocked_subnets);
+    blocked_subnets.swap(remaining_subnets);
     MCLOG_CYAN(el::Level::Info, "global", "Subnet " << subnet.str() << " unblocked.");
     return true;
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
+  bool node_server<t_payload_net_handler>::unblock_subnet(const epee::net_utils::ipv4_network_subnet &subnet)
+  {
+    return unblock_subnet_impl(m_blocked_subnets, subnet);
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
+  bool node_server<t_payload_net_handler>::unblock_subnet(const epee::net_utils::ipv6_network_subnet &subnet)
+  {
+    return unblock_subnet_impl(m_blocked_ipv6_subnets, subnet);
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::clear_bans()
   {
     CRITICAL_REGION_LOCAL(m_blocked_hosts_lock);
-    const bool had_bans = !m_blocked_hosts.empty() || !m_blocked_subnets.empty();
+    const bool had_bans = !m_blocked_hosts.empty() || !m_blocked_subnets.empty() || !m_blocked_ipv6_subnets.empty();
     m_blocked_hosts.clear();
     m_blocked_subnets.clear();
+    m_blocked_ipv6_subnets.clear();
     if (had_bans)
       MCLOG_CYAN(el::Level::Info, "global", "All bans cleared.");
     return had_bans;
@@ -669,13 +741,19 @@ namespace nodetool
           block_subnet(*subnet, std::numeric_limits<time_t>::max());
           continue;
         }
+        auto ipv6_subnet = net::get_ipv6_subnet_address(line);
+        if (ipv6_subnet)
+        {
+          block_subnet(*ipv6_subnet, std::numeric_limits<time_t>::max());
+          continue;
+        }
         const expect<epee::net_utils::network_address> parsed_addr = net::get_network_address(line, 0);
         if (parsed_addr)
         {
           block_host(*parsed_addr, std::numeric_limits<time_t>::max());
           continue;
         }
-        MERROR("Invalid IP address or IPv4 subnet: " << line);
+        MERROR("Invalid IP address or subnet: " << line);
       }
     }
 
@@ -2234,6 +2312,13 @@ namespace nodetool
         if (subnet)
         {
           block_subnet(*subnet, DNS_BLOCKLIST_LIFETIME);
+          ++good;
+          continue;
+        }
+        auto ipv6_subnet = net::get_ipv6_subnet_address(ip);
+        if (ipv6_subnet)
+        {
+          block_subnet(*ipv6_subnet, DNS_BLOCKLIST_LIFETIME);
           ++good;
           continue;
         }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2724,6 +2724,17 @@ namespace cryptonote
         res.bans.push_back(b);
       }
     }
+    std::map<epee::net_utils::ipv6_network_subnet, time_t> blocked_ipv6_subnets = m_p2p.get_blocked_ipv6_subnets();
+    for (std::map<epee::net_utils::ipv6_network_subnet, time_t>::const_iterator i = blocked_ipv6_subnets.begin(); i != blocked_ipv6_subnets.end(); ++i)
+    {
+      if (i->second > now) {
+        COMMAND_RPC_GETBANS::ban b;
+        b.host = i->first.host_str();
+        b.ip = 0;
+        b.seconds = i->second - now;
+        res.bans.push_back(b);
+      }
+    }
 
     res.status = CORE_RPC_STATUS_OK;
     return true;
@@ -2776,6 +2787,15 @@ namespace cryptonote
             m_p2p.block_subnet(*ns_parsed, i->seconds);
           else
             m_p2p.unblock_subnet(*ns_parsed);
+          continue;
+        }
+        auto ipv6_ns_parsed = net::get_ipv6_subnet_address(i->host);
+        if (ipv6_ns_parsed)
+        {
+          if (i->ban)
+            m_p2p.block_subnet(*ipv6_ns_parsed, i->seconds);
+          else
+            m_p2p.unblock_subnet(*ipv6_ns_parsed);
           continue;
         }
       }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2333,6 +2333,17 @@ namespace cryptonote
         res.bans.push_back(b);
       }
     }
+    std::map<epee::net_utils::ipv6_network_subnet, time_t> blocked_ipv6_subnets = m_p2p.get_blocked_ipv6_subnets();
+    for (std::map<epee::net_utils::ipv6_network_subnet, time_t>::const_iterator i = blocked_ipv6_subnets.begin(); i != blocked_ipv6_subnets.end(); ++i)
+    {
+      if (i->second > now) {
+        COMMAND_RPC_GETBANS::ban b;
+        b.host = i->first.host_str();
+        b.ip = 0;
+        b.seconds = i->second - now;
+        res.bans.push_back(b);
+      }
+    }
 
     res.status = CORE_RPC_STATUS_OK;
     return true;
@@ -2391,6 +2402,15 @@ namespace cryptonote
             m_p2p.block_subnet(*ns_parsed, i->seconds);
           else
             m_p2p.unblock_subnet(*ns_parsed);
+          continue;
+        }
+        auto ipv6_ns_parsed = net::get_ipv6_subnet_address(i->host);
+        if (ipv6_ns_parsed)
+        {
+          if (i->ban)
+            m_p2p.block_subnet(*ipv6_ns_parsed, i->seconds);
+          else
+            m_p2p.unblock_subnet(*ipv6_ns_parsed);
           continue;
         }
       }

--- a/tests/data/node/banlist_1.txt
+++ b/tests/data/node/banlist_1.txt
@@ -10,8 +10,9 @@
 1.0.0.7#Literally James Bond, he wrecked my aston martin
 100.98.1.13 # Earl from HOA
 100.98.1.0/24   #The rest of the HOA for good measure
+2001:db8:1234::1
+2001:db8:abcd::/48
 #
 
 #7.7.7.7
 #^^^We're chill now, she's truly an angel
-

--- a/tests/functional_tests/bans.py
+++ b/tests/functional_tests/bans.py
@@ -112,6 +112,27 @@ class BanTest():
         res = daemon.get_bans()
         assert 'bans' not in res or len(res.bans) == 0
 
+        daemon.set_bans([{'host': '2001:db8:abcd::/48', 'ban': True, 'seconds': 100}])
+        res = daemon.get_bans()
+        assert len(res.bans) == 1
+        assert res.bans[0].host == '2001:db8:abcd::/48'
+        assert res.bans[0].seconds >= 98 and res.bans[0].seconds <= 100 # allow for slow RPC
+
+        res = daemon.banned('2001:db8:abcd::1')
+        assert res.banned
+        res = daemon.banned('2001:db8:abce::1')
+        assert not res.banned
+
+        daemon.set_bans([{'host': '2001:db8:abcd:1234::/64', 'ban': False}])
+        res = daemon.banned('2001:db8:abcd:1234::1')
+        assert not res.banned
+        res = daemon.banned('2001:db8:abcd:1235::1')
+        assert res.banned
+
+        daemon.set_bans([{'host': '2001:db8:abcd::/48', 'ban': False}])
+        res = daemon.get_bans()
+        assert 'bans' not in res or len(res.bans) == 0
+
 
 if __name__ == '__main__':
     BanTest().run_test()

--- a/tests/functional_tests/bans.py
+++ b/tests/functional_tests/bans.py
@@ -112,12 +112,41 @@ class BanTest():
         res = daemon.get_bans()
         assert 'bans' not in res or len(res.bans) == 0
 
+        rejected = False
+        try:
+            daemon.set_bans([{'host': '::ffff:192.0.2.0/120', 'ban': True, 'seconds': 100}])
+        except AssertionError:
+            rejected = True
+        assert rejected
+
+        daemon.set_bans([{'host': '2001:db8:abcd::/48', 'ban': True, 'seconds': 100}])
+        res = daemon.get_bans()
+        assert len(res.bans) == 1
+        assert res.bans[0].host == '2001:db8:abcd::/48'
+        assert res.bans[0].seconds >= 98 and res.bans[0].seconds <= 100 # allow for slow RPC
+
+        res = daemon.banned('2001:db8:abcd::1')
+        assert res.banned
+        res = daemon.banned('2001:db8:abce::1')
+        assert not res.banned
+
+        daemon.set_bans([{'host': '2001:db8:abcd:1234::/64', 'ban': False}])
+        res = daemon.banned('2001:db8:abcd:1234::1')
+        assert not res.banned
+        res = daemon.banned('2001:db8:abcd:1235::1')
+        assert res.banned
+
+        daemon.set_bans([{'host': '2001:db8:abcd::/48', 'ban': False}])
+        res = daemon.get_bans()
+        assert 'bans' not in res or len(res.bans) == 0
+
         daemon.set_bans([
             {'host': '1.2.3.4', 'ban': True, 'seconds': 100},
             {'host': '5.6.7.0/24', 'ban': True, 'seconds': 100},
+            {'host': '2001:db8:abcd::/48', 'ban': True, 'seconds': 100},
         ])
         res = daemon.get_bans()
-        assert len(res.bans) == 2
+        assert len(res.bans) == 3
         daemon.set_bans([{'host': 'all', 'ban': False}])
         res = daemon.get_bans()
         assert 'bans' not in res or len(res.bans) == 0

--- a/tests/unit_tests/net.cpp
+++ b/tests/unit_tests/net.cpp
@@ -907,6 +907,37 @@ TEST(get_network_address, ipv4subnet)
     EXPECT_STREQ("12.34.0.0/16", address->str().c_str());
 }
 
+TEST(get_network_address, ipv6subnet)
+{
+    expect<epee::net_utils::ipv6_network_subnet> address = net::get_ipv6_subnet_address("::1", true);
+    ASSERT_TRUE(bool(address));
+    EXPECT_STREQ("::1/128", address->str().c_str());
+
+    address = net::get_ipv6_subnet_address("::1");
+    EXPECT_TRUE(!address);
+
+    address = net::get_ipv6_subnet_address("::/0");
+    ASSERT_TRUE(bool(address));
+    EXPECT_STREQ("::/0", address->str().c_str());
+
+    address = net::get_ipv6_subnet_address("2001:db8:abcd:1234::1/32");
+    ASSERT_TRUE(bool(address));
+    EXPECT_STREQ("2001:db8::/32", address->str().c_str());
+    EXPECT_TRUE(address->matches(epee::net_utils::ipv6_network_address{boost::asio::ip::make_address_v6("2001:db8::1"), 0}));
+    EXPECT_TRUE(address->matches(epee::net_utils::ipv6_network_address{boost::asio::ip::make_address_v6("2001:db8:ffff:ffff::1"), 0}));
+    EXPECT_FALSE(address->matches(epee::net_utils::ipv6_network_address{boost::asio::ip::make_address_v6("2001:db9::1"), 0}));
+
+    address = net::get_ipv6_subnet_address("[2001:db8:abcd:1234::1]/64");
+    ASSERT_TRUE(bool(address));
+    EXPECT_STREQ("2001:db8:abcd:1234::/64", address->str().c_str());
+
+    address = net::get_ipv6_subnet_address("2001:db8::/129");
+    EXPECT_EQ(net::error::invalid_mask, address);
+
+    address = net::get_ipv6_subnet_address("[2001:db8::1/64");
+    EXPECT_EQ(net::error::invalid_host, address);
+}
+
 namespace
 {
     void na_host_and_port_test(std::string addr, std::string exp_host, std::string exp_port)
@@ -2322,4 +2353,3 @@ TEST(zmq, read_write_termination)
     ASSERT_FALSE(bool(received));
     EXPECT_EQ(net::zmq::make_error_code(ETERM), received.error());
 }
-

--- a/tests/unit_tests/net.cpp
+++ b/tests/unit_tests/net.cpp
@@ -1241,6 +1241,43 @@ TEST(get_network_address, ipv4subnet)
     EXPECT_FALSE(address->matches(epee::net_utils::ipv4_network_address{MAKE_IP(172,32,0,0), 0}));
 }
 
+TEST(get_network_address, ipv6subnet)
+{
+    expect<epee::net_utils::ipv6_network_subnet> address = net::get_ipv6_subnet_address("::1", true);
+    ASSERT_TRUE(bool(address));
+    EXPECT_STREQ("::1/128", address->str().c_str());
+
+    address = net::get_ipv6_subnet_address("::1");
+    EXPECT_TRUE(!address);
+
+    address = net::get_ipv6_subnet_address("::/0");
+    ASSERT_TRUE(bool(address));
+    EXPECT_STREQ("::/0", address->str().c_str());
+
+    address = net::get_ipv6_subnet_address("2001:db8:abcd:1234::1/32");
+    ASSERT_TRUE(bool(address));
+    EXPECT_STREQ("2001:db8::/32", address->str().c_str());
+    EXPECT_TRUE(address->matches(epee::net_utils::ipv6_network_address{boost::asio::ip::make_address_v6("2001:db8::1"), 0}));
+    EXPECT_TRUE(address->matches(epee::net_utils::ipv6_network_address{boost::asio::ip::make_address_v6("2001:db8:ffff:ffff::1"), 0}));
+    EXPECT_FALSE(address->matches(epee::net_utils::ipv6_network_address{boost::asio::ip::make_address_v6("2001:db9::1"), 0}));
+
+    address = net::get_ipv6_subnet_address("[2001:db8:abcd:1234::1]/64");
+    ASSERT_TRUE(bool(address));
+    EXPECT_STREQ("2001:db8:abcd:1234::/64", address->str().c_str());
+
+    address = net::get_ipv6_subnet_address("2001:db8::/129");
+    EXPECT_EQ(net::error::invalid_mask, address);
+
+    address = net::get_ipv6_subnet_address("[2001:db8::1/64");
+    EXPECT_EQ(net::error::invalid_host, address);
+
+    address = net::get_ipv6_subnet_address("::ffff:192.0.2.0/120");
+    EXPECT_EQ(net::error::unsupported_address, address);
+
+    address = net::get_ipv6_subnet_address("::192.0.2.0/120");
+    EXPECT_EQ(net::error::unsupported_address, address);
+}
+
 namespace
 {
     void na_host_and_port_test(std::string addr, std::string exp_host, std::string exp_port)
@@ -2656,4 +2693,3 @@ TEST(zmq, read_write_termination)
     ASSERT_FALSE(bool(received));
     EXPECT_EQ(net::zmq::make_error_code(ETERM), received.error());
 }
-

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -56,6 +56,16 @@ namespace
       return path;
     return boost::filesystem::path{};
   }
+
+  epee::net_utils::ipv6_network_address make_ipv6_address(const char *address)
+  {
+    return {boost::asio::ip::make_address_v6(address), 0};
+  }
+
+  epee::net_utils::ipv6_network_subnet make_ipv6_subnet(const char *address, uint8_t mask)
+  {
+    return {boost::asio::ip::make_address_v6(address), mask};
+  }
 }
 
 namespace cryptonote {
@@ -132,16 +142,24 @@ static bool is_blocked(Server &server, const epee::net_utils::network_address &a
     }
   }
 
-  if (address.get_type_id() != epee::net_utils::address_type::ipv4)
-    return false;
-  
-  const epee::net_utils::ipv4_network_address ipv4_address = address.as<epee::net_utils::ipv4_network_address>();
+  if (address.get_type_id() == epee::net_utils::address_type::ipv4)
+  {
+    const epee::net_utils::ipv4_network_address ipv4_address = address.as<epee::net_utils::ipv4_network_address>();
 
-  // check if in a blocked ipv4 subnet
-  const std::map<epee::net_utils::ipv4_network_subnet, time_t> subnets = server.get_blocked_subnets();
-  for (const auto &subnet : subnets)
-    if (subnet.first.matches(ipv4_address))
-      return true;
+    const std::map<epee::net_utils::ipv4_network_subnet, time_t> subnets = server.get_blocked_subnets();
+    for (const auto &subnet : subnets)
+      if (subnet.first.matches(ipv4_address))
+        return true;
+  }
+  else if (address.get_type_id() == epee::net_utils::address_type::ipv6)
+  {
+    const epee::net_utils::ipv6_network_address ipv6_address = address.as<epee::net_utils::ipv6_network_address>();
+
+    const std::map<epee::net_utils::ipv6_network_subnet, time_t> subnets = server.get_blocked_ipv6_subnets();
+    for (const auto &subnet : subnets)
+      if (subnet.first.matches(ipv6_address))
+        return true;
+  }
 
   return false;
 }
@@ -353,6 +371,57 @@ TEST(ban, subnet)
   ASSERT_TRUE(server.get_blocked_subnets().size() == 0);
 }
 
+TEST(ban, ipv6_subnet)
+{
+  time_t seconds;
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  {
+    boost::program_options::options_description opts{};
+    Server::init_options(opts);
+    cryptonote::core::init_options(opts);
+
+    const char *argv[] = {"ban_ipv6_subnet_test"};
+    boost::program_options::variables_map vm;
+    boost::program_options::store(
+      boost::program_options::parse_command_line(1, argv, opts), vm
+    );
+    ASSERT_TRUE(server.init(vm));
+  }
+  cprotocol.set_p2p_endpoint(&server);
+
+  ASSERT_TRUE(server.block_subnet(make_ipv6_subnet("2001:db8:1:2::1234", 64), 10));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().size() == 1);
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("2001:db8:1:2::1"), &seconds));
+  ASSERT_TRUE(seconds >= 9);
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("2001:db8:1:2:ffff::1"), &seconds));
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db8:1:3::1"), &seconds));
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db8:1:1:ffff::1"), &seconds));
+  ASSERT_FALSE(server.unblock_subnet(make_ipv6_subnet("2001:db8:1:3::", 64)));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().size() == 1);
+  ASSERT_TRUE(server.unblock_subnet(make_ipv6_subnet("2001:db8:1:2::", 64)));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().empty());
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db8:1:2::1"), &seconds));
+
+  ASSERT_TRUE(server.block_subnet(make_ipv6_subnet("2001:db8::", 32), 10));
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("2001:db8:ffff:ffff::1"), &seconds));
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db9::1"), &seconds));
+  ASSERT_TRUE(server.unblock_subnet(make_ipv6_subnet("2001:db8::", 32)));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().empty());
+
+  ASSERT_TRUE(server.block_subnet(make_ipv6_subnet("2001:db8::", 32), 10));
+  ASSERT_TRUE(server.block_host(make_ipv6_address("2001:db8:abcd::1234"), 10));
+  ASSERT_TRUE(server.unblock_subnet(make_ipv6_subnet("2001:db8:abcd::", 48)));
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db8:abcd::1"), &seconds));
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db8:abcd::1234"), &seconds));
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("2001:db8:abcc:ffff::1"), &seconds));
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("2001:db8:abce::1"), &seconds));
+  ASSERT_FALSE(server.get_blocked_ipv6_subnets().empty());
+  ASSERT_TRUE(server.unblock_subnet(make_ipv6_subnet("2001:db8::", 32)));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().empty());
+}
+
 TEST(ban, ignores_port)
 {
   test_core pr_core;
@@ -423,6 +492,10 @@ TEST(ban, file_banlist)
   EXPECT_TRUE(  is_blocked(server, MAKE_IPV4_ADDRESS_PORT(100,98,1,255,9999)) );
   EXPECT_FALSE( is_blocked(server, MAKE_IPV4_ADDRESS_PORT(100,98,2,0,9999)) );
   EXPECT_FALSE( is_blocked(server, MAKE_IPV4_ADDRESS_PORT(100,98,0,255,9999)) );
+  EXPECT_TRUE(  is_blocked(server, make_ipv6_address("2001:db8:1234::1")) );
+  EXPECT_TRUE(  is_blocked(server, make_ipv6_address("2001:db8:abcd::1")) );
+  EXPECT_TRUE(  is_blocked(server, make_ipv6_address("2001:db8:abcd:ffff::1")) );
+  EXPECT_FALSE( is_blocked(server, make_ipv6_address("2001:db8:abce::1")) );
 
   // angel
   EXPECT_FALSE( is_blocked(server, MAKE_IPV4_ADDRESS_PORT(007,007,007,007,9999)) );

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -57,6 +57,16 @@ namespace
       return path;
     return boost::filesystem::path{};
   }
+
+  epee::net_utils::ipv6_network_address make_ipv6_address(const char *address)
+  {
+    return {boost::asio::ip::make_address_v6(address), 0};
+  }
+
+  epee::net_utils::ipv6_network_subnet make_ipv6_subnet(const char *address, uint8_t mask)
+  {
+    return {boost::asio::ip::make_address_v6(address), mask};
+  }
 }
 
 namespace cryptonote {
@@ -154,16 +164,24 @@ static bool is_blocked(Server &server, const epee::net_utils::network_address &a
     }
   }
 
-  if (address.get_type_id() != epee::net_utils::address_type::ipv4)
-    return false;
-  
-  const epee::net_utils::ipv4_network_address ipv4_address = address.as<epee::net_utils::ipv4_network_address>();
+  if (address.get_type_id() == epee::net_utils::address_type::ipv4)
+  {
+    const epee::net_utils::ipv4_network_address ipv4_address = address.as<epee::net_utils::ipv4_network_address>();
 
-  // check if in a blocked ipv4 subnet
-  const std::map<epee::net_utils::ipv4_network_subnet, time_t> subnets = server.get_blocked_subnets();
-  for (const auto &subnet : subnets)
-    if (subnet.first.matches(ipv4_address))
-      return true;
+    const std::map<epee::net_utils::ipv4_network_subnet, time_t> subnets = server.get_blocked_subnets();
+    for (const auto &subnet : subnets)
+      if (subnet.first.matches(ipv4_address))
+        return true;
+  }
+  else if (address.get_type_id() == epee::net_utils::address_type::ipv6)
+  {
+    const epee::net_utils::ipv6_network_address ipv6_address = address.as<epee::net_utils::ipv6_network_address>();
+
+    const std::map<epee::net_utils::ipv6_network_subnet, time_t> subnets = server.get_blocked_ipv6_subnets();
+    for (const auto &subnet : subnets)
+      if (subnet.first.matches(ipv6_address))
+        return true;
+  }
 
   return false;
 }
@@ -501,9 +519,11 @@ TEST(ban, clear)
   ASSERT_FALSE(server.clear_bans());
   ASSERT_TRUE(server.block_host(MAKE_IPV4_ADDRESS(1,2,3,4)));
   ASSERT_TRUE(server.block_subnet(MAKE_IPV4_SUBNET(5,6,7,0,24)));
+  ASSERT_TRUE(server.block_subnet(make_ipv6_subnet("2001:db8::", 32)));
   ASSERT_TRUE(server.clear_bans());
   ASSERT_TRUE(server.get_blocked_hosts().empty());
   ASSERT_TRUE(server.get_blocked_subnets().empty());
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().empty());
   ASSERT_FALSE(server.clear_bans());
 }
 
@@ -627,6 +647,72 @@ TEST(ban, subnet_arithmetic)
   ASSERT_TRUE(server.get_blocked_subnets().empty());
 }
 
+TEST(ban, ipv6_subnet)
+{
+  time_t seconds;
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  {
+    boost::program_options::options_description opts{};
+    Server::init_options(opts);
+    cryptonote::core::init_options(opts);
+
+    const char *argv[] = {"ban_ipv6_subnet_test"};
+    boost::program_options::variables_map vm;
+    boost::program_options::store(
+      boost::program_options::parse_command_line(1, argv, opts), vm
+    );
+    ASSERT_TRUE(server.init(vm));
+  }
+  cprotocol.set_p2p_endpoint(&server);
+
+  ASSERT_TRUE(server.block_subnet(make_ipv6_subnet("2001:db8:1:2::1234", 64), 10));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().size() == 1);
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("2001:db8:1:2::1"), &seconds));
+  ASSERT_TRUE(seconds >= 9);
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("2001:db8:1:2:ffff::1"), &seconds));
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db8:1:3::1"), &seconds));
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db8:1:1:ffff::1"), &seconds));
+  ASSERT_FALSE(server.unblock_subnet(make_ipv6_subnet("2001:db8:1:3::", 64)));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().size() == 1);
+  ASSERT_TRUE(server.unblock_subnet(make_ipv6_subnet("2001:db8:1:2::", 64)));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().empty());
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db8:1:2::1"), &seconds));
+
+  ASSERT_TRUE(server.block_subnet(make_ipv6_subnet("2001:db8::", 32), 10));
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("2001:db8:ffff:ffff::1"), &seconds));
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db9::1"), &seconds));
+  ASSERT_TRUE(server.unblock_subnet(make_ipv6_subnet("2001:db8::", 32)));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().empty());
+
+  ASSERT_TRUE(server.block_subnet(make_ipv6_subnet("2001:db8::", 32), 10));
+  ASSERT_TRUE(server.block_host(make_ipv6_address("2001:db8:abcd::1234"), 10));
+  ASSERT_TRUE(server.unblock_subnet(make_ipv6_subnet("2001:db8:abcd::", 48)));
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db8:abcd::1"), &seconds));
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address("2001:db8:abcd::1234"), &seconds));
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("2001:db8:abcc:ffff::1"), &seconds));
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("2001:db8:abce::1"), &seconds));
+  ASSERT_FALSE(server.get_blocked_ipv6_subnets().empty());
+  ASSERT_TRUE(server.unblock_subnet(make_ipv6_subnet("2001:db8::", 32)));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().empty());
+
+  const char *max_address = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff";
+  ASSERT_TRUE(server.block_subnet(make_ipv6_subnet(max_address, 128), 10));
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address(max_address), &seconds));
+  ASSERT_TRUE(server.unblock_subnet(make_ipv6_subnet(max_address, 128)));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().empty());
+
+  ASSERT_TRUE(server.block_subnet(make_ipv6_subnet("::", 0), 10));
+  ASSERT_TRUE(server.unblock_subnet(make_ipv6_subnet(max_address, 128)));
+  ASSERT_FALSE(server.is_host_blocked(make_ipv6_address(max_address), &seconds));
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe"), &seconds));
+  ASSERT_TRUE(server.is_host_blocked(make_ipv6_address("::"), &seconds));
+  ASSERT_EQ(128, server.get_blocked_ipv6_subnets().size());
+  ASSERT_TRUE(server.unblock_subnet(make_ipv6_subnet("::", 0)));
+  ASSERT_TRUE(server.get_blocked_ipv6_subnets().empty());
+}
+
 TEST(ban, ignores_port)
 {
   test_core pr_core;
@@ -697,6 +783,10 @@ TEST(ban, file_banlist)
   EXPECT_TRUE(  is_blocked(server, MAKE_IPV4_ADDRESS_PORT(100,98,1,255,9999)) );
   EXPECT_FALSE( is_blocked(server, MAKE_IPV4_ADDRESS_PORT(100,98,2,0,9999)) );
   EXPECT_FALSE( is_blocked(server, MAKE_IPV4_ADDRESS_PORT(100,98,0,255,9999)) );
+  EXPECT_TRUE(  is_blocked(server, make_ipv6_address("2001:db8:1234::1")) );
+  EXPECT_TRUE(  is_blocked(server, make_ipv6_address("2001:db8:abcd::1")) );
+  EXPECT_TRUE(  is_blocked(server, make_ipv6_address("2001:db8:abcd:ffff::1")) );
+  EXPECT_FALSE( is_blocked(server, make_ipv6_address("2001:db8:abce::1")) );
 
   // angel
   EXPECT_FALSE( is_blocked(server, MAKE_IPV4_ADDRESS_PORT(007,007,007,007,9999)) );


### PR DESCRIPTION
Adds IPv6 CIDR support to the existing ban paths

This lets `--ban-list`, DNS blocklist entries, daemon `ban` / `unban`, and RPC `set_bans` accept entries like `2001:db8::/32`

Single IPv6 hosts keep using the existing address parser

IPv6 subnets stay as a separate internal ban type, matching the existing IPv4 subnet approach

Nested unbans split the remaining IPv6 ranges, so `unban 2001:db8:abcd::/48` works after `2001:db8::/32` was banned

IPv4-mapped and deprecated IPv4-compatible CIDRs are rejected to avoid alternate spellings for IPv4 ranges

Tests:
- `cmake --build build --target daemon wallet_rpc_server unit_tests test_notifier --parallel 2`
- `build/tests/unit_tests/unit_tests --data-dir tests/data --gtest_filter="ban.*:get_network_address.ipv6subnet"`
- `python3 tests/functional_tests/functional_tests_rpc.py python3 tests/functional_tests build bans`
- `ctest --test-dir build/tests/unit_tests --output-on-failure -j2`