### PR TITLE
cryptonote_core: reject non-canonical key offsets

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -30,6 +30,7 @@
 
 #include <atomic>
 #include <boost/algorithm/string.hpp>
+#include <limits>
 #include "wipeable_string.h"
 #include "string_tools.h"
 #include "string_tools_lexical.h"
@@ -1513,6 +1514,18 @@ namespace cryptonote
     for(size_t i = 1; i < res.size(); i++)
       res[i] += res[i-1];
     return res;
+  }
+  //---------------------------------------------------------------
+  bool relative_output_offsets_are_non_overflowing(const std::vector<uint64_t>& off)
+  {
+    uint64_t absolute = 0;
+    for (uint64_t offset: off)
+    {
+      if (std::numeric_limits<uint64_t>::max() - absolute < offset)
+        return false;
+      absolute += offset;
+    }
+    return true;
   }
   //---------------------------------------------------------------
   std::vector<uint64_t> absolute_output_offsets_to_relative(const std::vector<uint64_t>& off)

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -144,6 +144,7 @@ namespace cryptonote
   bool check_inputs_overflow(const transaction& tx);
   uint64_t get_block_height(const block& b);
   std::vector<uint64_t> relative_output_offsets_to_absolute(const std::vector<uint64_t>& off);
+  bool relative_output_offsets_are_non_overflowing(const std::vector<uint64_t>& off);
   std::vector<uint64_t> absolute_output_offsets_to_relative(const std::vector<uint64_t>& off);
   void set_default_decimal_point(unsigned int decimal_point = CRYPTONOTE_DISPLAY_DECIMAL_POINT);
   unsigned int get_default_decimal_point();

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -118,6 +118,17 @@ namespace cryptonote
       if (candidate < next_check.load(std::memory_order_relaxed))
         next_check = candidate;
     }
+
+    bool check_tx_inputs_key_offsets_non_overflowing(const transaction& tx)
+    {
+      for (const auto& in: tx.vin)
+      {
+        CHECKED_GET_SPECIFIC_VARIANT(in, const txin_to_key, tokey_in, false);
+        if (!relative_output_offsets_are_non_overflowing(tokey_in.key_offsets))
+          return false;
+      }
+      return true;
+    }
   }
   //---------------------------------------------------------------------------------
   //---------------------------------------------------------------------------------
@@ -197,6 +208,15 @@ namespace cryptonote
       LOG_PRINT_L1("transaction unlock time is not zero: " << tx.unlock_time);
       tvc.m_verifivation_failed = true;
       tvc.m_nonzero_unlock_time = true;
+      tvc.m_no_drop_offense = true;
+      return false;
+    }
+
+    if (!kept_by_block && !check_tx_inputs_key_offsets_non_overflowing(tx))
+    {
+      LOG_PRINT_L1("transaction has non-canonical key offsets");
+      tvc.m_verifivation_failed = true;
+      tvc.m_invalid_input = true;
       tvc.m_no_drop_offense = true;
       return false;
     }

--- a/src/cryptonote_core/tx_sanity_check.cpp
+++ b/src/cryptonote_core/tx_sanity_check.cpp
@@ -62,6 +62,11 @@ bool tx_sanity_check(const cryptonote::blobdata &tx_blob, uint64_t rct_outs_avai
     if (txin.type() != typeid(cryptonote::txin_to_key))
       continue;
     const cryptonote::txin_to_key &in_to_key = boost::get<cryptonote::txin_to_key>(txin);
+    if (!cryptonote::relative_output_offsets_are_non_overflowing(in_to_key.key_offsets))
+    {
+      MERROR("Transaction has non-canonical key offsets");
+      return false;
+    }
     if (in_to_key.amount != 0)
       continue;
     const std::vector<uint64_t> absolute = cryptonote::relative_output_offsets_to_absolute(in_to_key.key_offsets);

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -89,6 +89,7 @@ set(unit_tests_sources
   test_protocol_pack.cpp
   threadpool.cpp
   tx_proof.cpp
+  tx_sanity_check.cpp
   tx_verification_utils.cpp
   hardfork.cpp
   unbound.cpp

--- a/tests/unit_tests/cryptonote_format_utils.cpp
+++ b/tests/unit_tests/cryptonote_format_utils.cpp
@@ -33,6 +33,8 @@
 #include "serialization/binary_utils.h"
 #include "serialization/string.h"
 
+#include <limits>
+
 TEST(cn_format_utils, add_extra_nonce_to_tx_extra)
 {
     static constexpr std::size_t max_nonce_size = TX_EXTRA_NONCE_MAX_COUNT + 1; // we *can* test higher if desired
@@ -102,6 +104,25 @@ TEST(cn_format_utils, add_extra_nonce_to_tx_extra)
             }
         }
     }
+}
+
+TEST(cn_format_utils, relative_output_offsets_are_non_overflowing)
+{
+    const uint64_t max_offset = std::numeric_limits<uint64_t>::max();
+
+    EXPECT_TRUE(cryptonote::relative_output_offsets_are_non_overflowing({}));
+    EXPECT_TRUE(cryptonote::relative_output_offsets_are_non_overflowing({0}));
+    EXPECT_TRUE(cryptonote::relative_output_offsets_are_non_overflowing({0, 1, 2}));
+    EXPECT_TRUE(cryptonote::relative_output_offsets_are_non_overflowing({max_offset}));
+    EXPECT_TRUE(cryptonote::relative_output_offsets_are_non_overflowing({max_offset - 1, 1}));
+
+    EXPECT_FALSE(cryptonote::relative_output_offsets_are_non_overflowing({max_offset, 1}));
+    EXPECT_FALSE(cryptonote::relative_output_offsets_are_non_overflowing({
+        157397969, 16660, 9681, 7938, 5385, 3831, 1437, 4950,
+        826, 813, 1237, 18446744073709482834ULL,
+        18446744073709534619ULL, 18446744073709550238ULL,
+        18446744073709546177ULL, 18446744073709183958ULL
+    }));
 }
 
 TEST(cn_format_utils, add_mm_merkle_root_to_tx_extra)

--- a/tests/unit_tests/tx_sanity_check.cpp
+++ b/tests/unit_tests/tx_sanity_check.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+
+#include "cryptonote_basic/cryptonote_basic.h"
+#include "cryptonote_basic/cryptonote_format_utils.h"
+#include "cryptonote_core/tx_sanity_check.h"
+
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace
+{
+  cryptonote::blobdata make_tx_blob(const std::vector<uint64_t>& key_offsets)
+  {
+    cryptonote::transaction tx;
+
+    cryptonote::txin_to_key input{};
+    input.amount = 0;
+    input.key_offsets = key_offsets;
+    tx.vin.push_back(input);
+
+    tx.signatures.resize(1);
+    tx.signatures[0].resize(key_offsets.size());
+
+    cryptonote::tx_out output{};
+    output.target = cryptonote::txout_to_key{};
+    tx.vout.push_back(output);
+
+    cryptonote::blobdata blob;
+    EXPECT_TRUE(cryptonote::t_serializable_object_to_blob(tx, blob));
+    return blob;
+  }
+}
+
+TEST(tx_sanity_check, accepts_canonical_key_offsets)
+{
+  EXPECT_TRUE(cryptonote::tx_sanity_check(make_tx_blob({1, 2, 3}), 100000));
+}
+
+TEST(tx_sanity_check, rejects_non_canonical_key_offsets)
+{
+  const uint64_t max_offset = std::numeric_limits<uint64_t>::max();
+  EXPECT_FALSE(cryptonote::tx_sanity_check(make_tx_blob({max_offset, 1}), 100000));
+}


### PR DESCRIPTION
## what

reject relayed txs whose relative key offsets overflow while being expanded to absolute output indices

## why

those offsets wrap back to lower absolute indices, which makes the ring non-canonical. this keeps new txs like that out of `tx_sanity_check` and the txpool relay path without changing block validation for historical txs already on-chain

refs #10848

## testing

- `git diff --check`
- `/usr/bin/cmake --build /tmp/monero-canonical-key-offsets-build --target unit_tests test_notifier -j2`
- `/tmp/monero-canonical-key-offsets-build/tests/unit_tests/unit_tests --gtest_filter='cn_format_utils.relative_output_offsets_are_non_overflowing:tx_sanity_check.*'`
- `/tmp/monero-canonical-key-offsets-build/tests/unit_tests/unit_tests --gtest_filter='cn_format_utils.*:tx_sanity_check.*'`
- `/tmp/monero-canonical-key-offsets-build/tests/unit_tests/unit_tests --gtest_filter='notify.works'`
