### PR TITLE
Improve initial refresh: use nearest checkpoint in fast_refresh [release-v0.18]

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -158,6 +158,19 @@ namespace cryptonote
     return m_points.rbegin()->first;
   }
   //---------------------------------------------------------------------------
+  uint64_t checkpoints::get_nearest_checkpoint_height(uint64_t block_height) const
+  {
+    if (m_points.empty())
+      return 0;
+
+    auto it = m_points.upper_bound(block_height);
+    if (it == m_points.begin())
+      return 0;
+
+    --it;
+    return it->first;
+  }
+  //---------------------------------------------------------------------------
   const std::map<uint64_t, crypto::hash>& checkpoints::get_points() const
   {
     return m_points;

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -163,7 +163,7 @@ namespace cryptonote
     if (m_points.empty())
       return 0;
 
-    auto it = m_points.upper_bound(block_height);
+    auto it = m_points.lower_bound(block_height);
     if (it == m_points.begin())
       return 0;
 

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -130,6 +130,14 @@ namespace cryptonote
     uint64_t get_max_height() const;
 
     /**
+     * @brief gets the highest checkpoint height less than the given block height
+     *
+     * @param block_height the reference block height
+     * @return the nearest checkpoint height below block_height, or 0 if none
+     */
+    uint64_t get_nearest_checkpoint_height(uint64_t block_height) const;
+
+    /**
      * @brief gets the checkpoints container
      *
      * @return a const reference to the checkpoints container

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3937,11 +3937,11 @@ void wallet2::fast_refresh(uint64_t stop_height, uint64_t &blocks_start_height, 
 {
   std::vector<crypto::hash> hashes;
 
-  const uint64_t checkpoint_height = m_checkpoints.get_max_height();
+  const uint64_t checkpoint_height = m_checkpoints.get_nearest_checkpoint_height(stop_height);
   if ((stop_height > checkpoint_height && m_blockchain.size()-1 < checkpoint_height) && !force)
   {
     // we will drop all these, so don't bother getting them
-    uint64_t missing_blocks = m_checkpoints.get_max_height() - m_blockchain.size();
+    uint64_t missing_blocks = checkpoint_height - m_blockchain.size();
     while (missing_blocks-- > 0)
       m_blockchain.push_back(crypto::null_hash); // maybe a bit suboptimal, but deque won't do huge reallocs like vector
     m_blockchain.push_back(m_checkpoints.get_points().at(checkpoint_height));

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3937,7 +3937,7 @@ void wallet2::fast_refresh(uint64_t stop_height, uint64_t &blocks_start_height, 
 {
   std::vector<crypto::hash> hashes;
 
-  const uint64_t checkpoint_height = m_checkpoints.get_nearest_checkpoint_height(stop_height);
+  const uint64_t checkpoint_height = (stop_height < 1000) ? 0 : m_checkpoints.get_nearest_checkpoint_height(stop_height);
   if ((stop_height > checkpoint_height && m_blockchain.size()-1 < checkpoint_height) && !force)
   {
     // we will drop all these, so don't bother getting them

--- a/tests/unit_tests/checkpoints.cpp
+++ b/tests/unit_tests/checkpoints.cpp
@@ -164,3 +164,21 @@ TEST(checkpoints_is_alternative_block_allowed, handles_two_and_more_checkpoints)
   ASSERT_TRUE (cp.is_alternative_block_allowed(11, 10));
   ASSERT_TRUE (cp.is_alternative_block_allowed(11, 11));
 }
+
+TEST(checkpoints_get_nearest_checkpoint_height, returns_nearest_checkpoint_below_height)
+{
+  checkpoints cp;
+
+  ASSERT_EQ(0, cp.get_nearest_checkpoint_height(7));
+
+  ASSERT_TRUE(cp.add_checkpoint(5, "0000000000000000000000000000000000000000000000000000000000000000"));
+  ASSERT_TRUE(cp.add_checkpoint(9, "0000000000000000000000000000000000000000000000000000000000000000"));
+
+  ASSERT_EQ(0, cp.get_nearest_checkpoint_height(0));
+  ASSERT_EQ(0, cp.get_nearest_checkpoint_height(4));
+  ASSERT_EQ(0, cp.get_nearest_checkpoint_height(5));
+  ASSERT_EQ(5, cp.get_nearest_checkpoint_height(6));
+  ASSERT_EQ(5, cp.get_nearest_checkpoint_height(9));
+  ASSERT_EQ(9, cp.get_nearest_checkpoint_height(10));
+  ASSERT_EQ(9, cp.get_nearest_checkpoint_height(11));
+}


### PR DESCRIPTION
cherry picked from https://github.com/monero-project/monero/pull/9935


do we also want this one for release?  https://github.com/monero-project/monero/pull/9344

there is an existing bug found under review and an 'off by one' for the easy fix - restoring at the exact height of a checkpoint means you scan from below it OR not the 1st block of your height... i think this needs tests

main bug fixed by woodsers commit