### PR TITLE
device: abort Ledger tx prefix hashing on denial

### DIFF
--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -1530,7 +1530,7 @@ namespace hw {
 
       this->buffer_send[4] = offset-5;
       this->length_send = offset;
-      this->exchange_wait_on_input();
+      CHECK_AND_ASSERT_THROW_MES(this->exchange_wait_on_input() == 0, "Transaction denied on device.");
 
       //hash remains
       int cnt = 0;


### PR DESCRIPTION
What changed:
- check the unchecked `exchange_wait_on_input()` call in `get_transaction_prefix_hash()`

Why:
- `exchange_wait_on_input()` returns `1` for `IO_SW_DENY` instead of throwing
- this is the only remaining Ledger user-input exchange in `device_ledger.cpp` that ignores that return value
- on denial, prefix hashing should stop before sending the remaining prefix hash chunks

Notes:
- plain `exchange()` calls already validate the device status through `ASSERT_SW`
- this only targets the prefix-hash denial path from #10035, not the whole broader Ledger issue

Validation:
- `git diff --check`
- `cmake -S . -B build-ledger-prefix-deny -G Ninja -D CMAKE_C_COMPILER=/usr/bin/gcc -D CMAKE_CXX_COMPILER=/usr/bin/g++ -D CMAKE_BUILD_TYPE=Debug -D BUILD_TESTS=OFF -D USE_DEVICE_TREZOR=OFF`
- `cmake --build build-ledger-prefix-deny --target device -j2`

Refs #10035
