### PR TITLE
wallet: add optional restore_height parameter to create_wallet

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3624,12 +3624,19 @@ namespace tools
       return false;
     }
     wal->set_seed_language(req.language);
-    cryptonote::COMMAND_RPC_GET_HEIGHT::request hreq;
-    cryptonote::COMMAND_RPC_GET_HEIGHT::response hres;
-    hres.height = 0;
-    bool r = wal->invoke_http_json("/getheight", hreq, hres);
-    if (r)
-      wal->set_refresh_from_block_height(hres.height);
+    if (req.restore_height > 0)
+    {
+      wal->set_refresh_from_block_height(req.restore_height);
+    }
+    else
+    {
+      cryptonote::COMMAND_RPC_GET_HEIGHT::request hreq;
+      cryptonote::COMMAND_RPC_GET_HEIGHT::response hres;
+      hres.height = 0;
+      bool r = wal->invoke_http_json("/getheight", hreq, hres);
+      if (r)
+        wal->set_refresh_from_block_height(hres.height);
+    }
     crypto::secret_key dummy_key;
     try {
       wal->generate(wallet_file, req.password, dummy_key, false, false);

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -2187,11 +2187,13 @@ namespace wallet_rpc
   {
     struct request_t
     {
+      uint64_t restore_height;
       std::string filename;
       std::string password;
       std::string language;
 
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_OPT(restore_height, (uint64_t)0)
         KV_SERIALIZE(filename)
         KV_SERIALIZE(password)
         KV_SERIALIZE(language)


### PR DESCRIPTION
similar to generate_from_keys, allows setting a static restore height for offline / no daemon setups.


can also be a workaround, but not a real fix for: https://github.com/monero-project/monero/issues/10322
