### PR TITLE
wallet: let set_daemon override --proxy

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1287,11 +1287,6 @@ bool wallet2::has_stagenet_option(const boost::program_options::variables_map& v
   return command_line::get_arg(vm, options().stagenet);
 }
 
-bool wallet2::has_proxy_option() const
-{
-  return !m_proxy.empty();
-}
-
 std::string wallet2::device_name_option(const boost::program_options::variables_map& vm)
 {
   return command_line::get_arg(vm, options().hw_device);
@@ -1386,9 +1381,8 @@ bool wallet2::set_daemon(std::string daemon_address, boost::optional<epee::net_u
 
   if(m_http_client->is_connected())
     m_http_client->disconnect();
-  CHECK_AND_ASSERT_MES2(m_proxy.empty() || proxy.empty() , "It is not possible to set global proxy (--proxy) and daemon specific proxy together.");
-  if(m_proxy.empty())
-    CHECK_AND_ASSERT_MES(set_proxy(proxy), false, "failed to set proxy address");
+  CHECK_AND_ASSERT_MES(set_proxy(proxy), false, "failed to set proxy address");
+  m_proxy = proxy;
   const bool changed = m_daemon_address != daemon_address;
   m_daemon_address = std::move(daemon_address);
   m_daemon_login = std::move(daemon_login);
@@ -1418,12 +1412,10 @@ bool wallet2::set_proxy(const std::string &address)
 //----------------------------------------------------------------------------------------------------
 bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, const std::string &proxy_address, uint64_t upper_transaction_weight_limit, bool trusted_daemon, epee::net_utils::ssl_options_t ssl_options)
 {
-  m_proxy = proxy_address;
-  CHECK_AND_ASSERT_MES(set_proxy(m_proxy), false, "failed to set proxy address");
   m_checkpoints.init_default_checkpoints(m_nettype);
   m_is_initialized = true;
   m_upper_transaction_weight_limit = upper_transaction_weight_limit;
-  return set_daemon(daemon_address, daemon_login, trusted_daemon, std::move(ssl_options));
+  return set_daemon(daemon_address, daemon_login, trusted_daemon, std::move(ssl_options), proxy_address);
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::is_deterministic() const

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -755,12 +755,6 @@ private:
     std::string path() const;
 
     /*!
-     * \brief has_proxy_option      Check the global proxy (--proxy) has been defined or not.
-     * \return                      returns bool representing the global proxy (--proxy).
-     */
-    bool has_proxy_option() const;
-
-    /*!
      * \brief verifies given password is correct for default wallet keys file
      */
     bool verify_password(const epee::wipeable_string& password) {crypto::secret_key key = crypto::null_skey; return verify_password(password, key);};

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4778,13 +4778,6 @@ namespace tools
     }
     if (!m_wallet) return not_open(er);
 
-    if (m_wallet->has_proxy_option() && !req.proxy.empty())
-    {
-      er.code = WALLET_RPC_ERROR_CODE_PROXY_ALREADY_DEFINED;
-      er.message = "It is not possible to set daemon specific proxy when --proxy is defined.";
-      return false;
-    }
-   
     std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints;
     ssl_allowed_fingerprints.reserve(req.ssl_allowed_fingerprints.size());
     for (const std::string &fp: req.ssl_allowed_fingerprints)


### PR DESCRIPTION
When `proxy` was added to `set_daemon` it was decided that a commandline --proxy should not be overridden by the rpc. This change removes that restriction.

ive discovered a bunch of issues with the way monero-wallet-rpc handles its parameters (namely, dropping all params while retaining the last set_daemon address OR if --daemon-address was set, then it will revert to that(!)) so this allowed you to set a `proxy` param via rpc that would drop when you ran open_wallet, leaking your connections to the server.

this change is part 1 [of 2](https://github.com/monero-project/monero/pull/10864) to make set_daemon params persist in full across wallet changes. Having a singular  param not able to be overridden doesnt seem sane. (If you have access/credentials to the rpc server, you can do much more dangerous things than change the proxy.)

(alternative was to make it so that if a daemon was configured via command line, you could not use set_daemon to change it. A change would require restarting the server.)