### PR TITLE
wallet: persist set_daemon params across wallet loads.

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -321,7 +321,7 @@ std::string get_weight_string(const cryptonote::transaction &tx, size_t blob_siz
   return get_weight_string(get_transaction_weight(tx, blob_size));
 }
 
-std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variables_map& vm, bool unattended, const options& opts, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
+std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variables_map& vm, bool unattended, const options& opts, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter, const boost::optional<tools::wallet2::daemon_config>& daemon_override = boost::none)
 {
   const bool testnet = command_line::get_arg(vm, opts.testnet);
   const bool stagenet = command_line::get_arg(vm, opts.stagenet);
@@ -450,7 +450,19 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   THROW_WALLET_EXCEPTION_IF(!command_line::is_arg_defaulted(vm, opts.trusted_daemon) && !command_line::is_arg_defaulted(vm, opts.untrusted_daemon),
     tools::error::wallet_internal_error, tools::wallet2::tr("--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted"));
 
-  // set --trusted-daemon if local and not overridden
+  // a set_daemon issued before this wallet existed replaces the daemon connection wholesale
+  if (daemon_override)
+  {
+    daemon_address = daemon_override->address;
+    login = boost::none;
+    if (!daemon_override->username.empty() || !daemon_override->password.empty())
+      login.emplace(daemon_override->username, daemon_override->password);
+    proxy = daemon_override->proxy;
+    trusted_daemon = daemon_override->trusted;
+    ssl_options = daemon_override->ssl_options;
+  }
+
+  // set --trusted-daemon if local and not overridden by command line or set_daemon
   if (!trusted_daemon)
   {
     try
@@ -1337,7 +1349,7 @@ std::pair<std::unique_ptr<wallet2>, tools::password_container> wallet2::make_fro
 }
 
 std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_from_file(
-  const boost::program_options::variables_map& vm, bool unattended, const std::string& wallet_file, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
+  const boost::program_options::variables_map& vm, bool unattended, const std::string& wallet_file, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter, const boost::optional<daemon_config>& daemon_override)
 {
   const options opts{};
   auto pwd = get_password(vm, opts, password_prompter, false);
@@ -1345,7 +1357,7 @@ std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_from_file(
   {
     return {nullptr, password_container{}};
   }
-  auto wallet = make_basic(vm, unattended, opts, password_prompter);
+  auto wallet = make_basic(vm, unattended, opts, password_prompter, daemon_override);
   if (wallet && !wallet_file.empty())
   {
     wallet->load(wallet_file, pwd->password());
@@ -1353,7 +1365,7 @@ std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_from_file(
   return {std::move(wallet), std::move(*pwd)};
 }
 
-std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_new(const boost::program_options::variables_map& vm, bool unattended, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter)
+std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_new(const boost::program_options::variables_map& vm, bool unattended, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter, const boost::optional<daemon_config>& daemon_override)
 {
   const options opts{};
   auto pwd = get_password(vm, opts, password_prompter, true);
@@ -1361,7 +1373,7 @@ std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_new(const 
   {
     return {nullptr, password_container{}};
   }
-  return {make_basic(vm, unattended, opts, password_prompter), std::move(*pwd)};
+  return {make_basic(vm, unattended, opts, password_prompter, daemon_override), std::move(*pwd)};
 }
 
 std::unique_ptr<wallet2> wallet2::make_dummy(const boost::program_options::variables_map& vm, bool unattended, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
@@ -1395,7 +1407,10 @@ bool wallet2::set_daemon(std::string daemon_address, boost::optional<epee::net_u
   }
 
   const std::string address = get_daemon_address();
-  MINFO("setting daemon to " << address);
+  if (m_proxy.empty())
+    MINFO("setting daemon to " << address);
+  else
+    MINFO("setting daemon to " << address << ". Connecting via proxy @ " << m_proxy);
   bool ret =  m_http_client->set_server(address, get_daemon_login(), std::move(ssl_options));
   if (ret)
   {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1287,11 +1287,6 @@ bool wallet2::has_stagenet_option(const boost::program_options::variables_map& v
   return command_line::get_arg(vm, options().stagenet);
 }
 
-bool wallet2::has_proxy_option() const
-{
-  return !m_proxy.empty();
-}
-
 std::string wallet2::device_name_option(const boost::program_options::variables_map& vm)
 {
   return command_line::get_arg(vm, options().hw_device);
@@ -1386,9 +1381,8 @@ bool wallet2::set_daemon(std::string daemon_address, boost::optional<epee::net_u
 
   if(m_http_client->is_connected())
     m_http_client->disconnect();
-  CHECK_AND_ASSERT_MES2(m_proxy.empty() || proxy.empty() , "It is not possible to set global proxy (--proxy) and daemon specific proxy together.");
-  if(m_proxy.empty())
-    CHECK_AND_ASSERT_MES(set_proxy(proxy), false, "failed to set proxy address");
+  CHECK_AND_ASSERT_MES(set_proxy(proxy), false, "failed to set proxy address");
+  m_proxy = proxy;
   const bool changed = m_daemon_address != daemon_address;
   m_daemon_address = std::move(daemon_address);
   m_daemon_login = std::move(daemon_login);
@@ -1418,12 +1412,10 @@ bool wallet2::set_proxy(const std::string &address)
 //----------------------------------------------------------------------------------------------------
 bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, const std::string &proxy_address, uint64_t upper_transaction_weight_limit, bool trusted_daemon, epee::net_utils::ssl_options_t ssl_options)
 {
-  m_proxy = proxy_address;
-  CHECK_AND_ASSERT_MES(set_proxy(m_proxy), false, "failed to set proxy address");
   m_checkpoints.init_default_checkpoints(m_nettype);
   m_is_initialized = true;
   m_upper_transaction_weight_limit = upper_transaction_weight_limit;
-  return set_daemon(daemon_address, daemon_login, trusted_daemon, std::move(ssl_options));
+  return set_daemon(daemon_address, daemon_login, trusted_daemon, std::move(ssl_options), proxy_address);
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::is_deterministic() const

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -463,7 +463,7 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   }
 
   // set --trusted-daemon if local and not overridden by command line or set_daemon
-  if (!trusted_daemon)
+  if (!trusted_daemon.is_initialized())
   {
     try
     {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1292,11 +1292,6 @@ bool wallet2::has_stagenet_option(const boost::program_options::variables_map& v
   return command_line::get_arg(vm, options().stagenet);
 }
 
-bool wallet2::has_proxy_option() const
-{
-  return !m_proxy.empty();
-}
-
 std::string wallet2::device_name_option(const boost::program_options::variables_map& vm)
 {
   return command_line::get_arg(vm, options().hw_device);
@@ -1391,9 +1386,8 @@ bool wallet2::set_daemon(std::string daemon_address, boost::optional<epee::net_u
 
   if(m_http_client->is_connected())
     m_http_client->disconnect();
-  CHECK_AND_ASSERT_MES2(m_proxy.empty() || proxy.empty() , "It is not possible to set global proxy (--proxy) and daemon specific proxy together.");
-  if(m_proxy.empty())
-    CHECK_AND_ASSERT_MES(set_proxy(proxy), false, "failed to set proxy address");
+  CHECK_AND_ASSERT_MES(set_proxy(proxy), false, "failed to set proxy address");
+  m_proxy = proxy;
   const bool changed = m_daemon_address != daemon_address;
   m_daemon_address = std::move(daemon_address);
   m_daemon_login = std::move(daemon_login);
@@ -1423,12 +1417,10 @@ bool wallet2::set_proxy(const std::string &address)
 //----------------------------------------------------------------------------------------------------
 bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, const std::string &proxy_address, uint64_t upper_transaction_weight_limit, bool trusted_daemon, epee::net_utils::ssl_options_t ssl_options)
 {
-  m_proxy = proxy_address;
-  CHECK_AND_ASSERT_MES(set_proxy(m_proxy), false, "failed to set proxy address");
   m_checkpoints.init_default_checkpoints(m_nettype);
   m_is_initialized = true;
   m_upper_transaction_weight_limit = upper_transaction_weight_limit;
-  return set_daemon(daemon_address, daemon_login, trusted_daemon, std::move(ssl_options));
+  return set_daemon(daemon_address, daemon_login, trusted_daemon, std::move(ssl_options), proxy_address);
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::is_deterministic() const

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -325,7 +325,7 @@ std::string get_weight_string(const cryptonote::transaction &tx, size_t blob_siz
   return get_weight_string(get_transaction_weight(tx, blob_size));
 }
 
-std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variables_map& vm, bool unattended, const options& opts, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
+std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variables_map& vm, bool unattended, const options& opts, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter, const boost::optional<tools::wallet2::daemon_config>& daemon_override = boost::none)
 {
   const bool testnet = command_line::get_arg(vm, opts.testnet);
   const bool stagenet = command_line::get_arg(vm, opts.stagenet);
@@ -454,8 +454,20 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   THROW_WALLET_EXCEPTION_IF(!command_line::is_arg_defaulted(vm, opts.trusted_daemon) && !command_line::is_arg_defaulted(vm, opts.untrusted_daemon),
     tools::error::wallet_internal_error, tools::wallet2::tr("--trusted-daemon and --untrusted-daemon are both seen, assuming untrusted"));
 
-  // set --trusted-daemon if local and not overridden
-  if (!trusted_daemon)
+  // a set_daemon issued before this wallet existed replaces the daemon connection wholesale
+  if (daemon_override)
+  {
+    daemon_address = daemon_override->address;
+    login = boost::none;
+    if (!daemon_override->username.empty() || !daemon_override->password.empty())
+      login.emplace(daemon_override->username, daemon_override->password);
+    proxy = daemon_override->proxy;
+    trusted_daemon = daemon_override->trusted;
+    ssl_options = daemon_override->ssl_options;
+  }
+
+  // set --trusted-daemon if local and not overridden by command line or set_daemon
+  if (!trusted_daemon.is_initialized())
   {
     try
     {
@@ -1342,7 +1354,7 @@ std::pair<std::unique_ptr<wallet2>, tools::password_container> wallet2::make_fro
 }
 
 std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_from_file(
-  const boost::program_options::variables_map& vm, bool unattended, const std::string& wallet_file, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
+  const boost::program_options::variables_map& vm, bool unattended, const std::string& wallet_file, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter, const boost::optional<daemon_config>& daemon_override)
 {
   const options opts{};
   auto pwd = get_password(vm, opts, password_prompter, false);
@@ -1350,7 +1362,7 @@ std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_from_file(
   {
     return {nullptr, password_container{}};
   }
-  auto wallet = make_basic(vm, unattended, opts, password_prompter);
+  auto wallet = make_basic(vm, unattended, opts, password_prompter, daemon_override);
   if (wallet && !wallet_file.empty())
   {
     wallet->load(wallet_file, pwd->password());
@@ -1358,7 +1370,7 @@ std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_from_file(
   return {std::move(wallet), std::move(*pwd)};
 }
 
-std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_new(const boost::program_options::variables_map& vm, bool unattended, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter)
+std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_new(const boost::program_options::variables_map& vm, bool unattended, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter, const boost::optional<daemon_config>& daemon_override)
 {
   const options opts{};
   auto pwd = get_password(vm, opts, password_prompter, true);
@@ -1366,7 +1378,7 @@ std::pair<std::unique_ptr<wallet2>, password_container> wallet2::make_new(const 
   {
     return {nullptr, password_container{}};
   }
-  return {make_basic(vm, unattended, opts, password_prompter), std::move(*pwd)};
+  return {make_basic(vm, unattended, opts, password_prompter, daemon_override), std::move(*pwd)};
 }
 
 std::unique_ptr<wallet2> wallet2::make_dummy(const boost::program_options::variables_map& vm, bool unattended, const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter)
@@ -1400,7 +1412,10 @@ bool wallet2::set_daemon(std::string daemon_address, boost::optional<epee::net_u
   }
 
   const std::string address = get_daemon_address();
-  MINFO("setting daemon to " << address);
+  if (m_proxy.empty())
+    MINFO("setting daemon to " << address);
+  else
+    MINFO("setting daemon to " << address << ". Connecting via proxy @ " << m_proxy);
   bool ret =  m_http_client->set_server(address, get_daemon_login(), std::move(ssl_options));
   if (ret)
   {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -220,15 +220,26 @@ private:
     static std::string device_derivation_path_option(const boost::program_options::variables_map &vm);
     static void init_options(boost::program_options::options_description& desc_params);
 
+    //! Daemon connection settings that override the ones from the command line when passed to make_new/make_from_file.
+    struct daemon_config
+    {
+      std::string address;
+      std::string username;
+      std::string password;
+      std::string proxy;
+      bool trusted = false;
+      epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::e_ssl_support_autodetect;
+    };
+
     //! Uses stdin and stdout. Returns a wallet2 if no errors.
     static std::pair<std::unique_ptr<wallet2>, password_container> make_from_json(const boost::program_options::variables_map& vm, bool unattended, const std::string& json_file, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
 
     //! Uses stdin and stdout. Returns a wallet2 and password for `wallet_file` if no errors.
     static std::pair<std::unique_ptr<wallet2>, password_container>
-      make_from_file(const boost::program_options::variables_map& vm, bool unattended, const std::string& wallet_file, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
+      make_from_file(const boost::program_options::variables_map& vm, bool unattended, const std::string& wallet_file, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter, const boost::optional<daemon_config>& daemon_override = boost::none);
 
     //! Uses stdin and stdout. Returns a wallet2 and password for wallet with no file if no errors.
-    static std::pair<std::unique_ptr<wallet2>, password_container> make_new(const boost::program_options::variables_map& vm, bool unattended, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);
+    static std::pair<std::unique_ptr<wallet2>, password_container> make_new(const boost::program_options::variables_map& vm, bool unattended, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter, const boost::optional<daemon_config>& daemon_override = boost::none);
 
     //! Just parses variables.
     static std::unique_ptr<wallet2> make_dummy(const boost::program_options::variables_map& vm, bool unattended, const std::function<boost::optional<password_container>(const char *, bool)> &password_prompter);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -755,12 +755,6 @@ private:
     std::string path() const;
 
     /*!
-     * \brief has_proxy_option      Check the global proxy (--proxy) has been defined or not.
-     * \return                      returns bool representing the global proxy (--proxy).
-     */
-    bool has_proxy_option() const;
-
-    /*!
      * \brief verifies given password is correct for default wallet keys file
      */
     bool verify_password(const epee::wipeable_string& password) {crypto::secret_key key = crypto::null_skey; return verify_password(password, key);};

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4778,13 +4778,6 @@ namespace tools
     }
     if (!m_wallet) return not_open(er);
 
-    if (m_wallet->has_proxy_option() && !req.proxy.empty())
-    {
-      er.code = WALLET_RPC_ERROR_CODE_PROXY_ALREADY_DEFINED;
-      er.message = "It is not possible to set daemon specific proxy when --proxy is defined.";
-      return false;
-    }
-   
     std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints;
     ssl_allowed_fingerprints.reserve(req.ssl_allowed_fingerprints.size());
     for (const std::string &fp: req.ssl_allowed_fingerprints)

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3616,7 +3616,7 @@ namespace tools
       command_line::add_arg(desc, arg_password);
       po::store(po::parse_command_line(argc, argv, desc), vm2);
     }
-    std::unique_ptr<tools::wallet2> wal = tools::wallet2::make_new(vm2, true, nullptr).first;
+    std::unique_ptr<tools::wallet2> wal = tools::wallet2::make_new(vm2, true, nullptr, m_pending_daemon).first;
     if (!wal)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
@@ -3721,7 +3721,7 @@ namespace tools
     }
     std::unique_ptr<tools::wallet2> wal = nullptr;
     try {
-      wal = tools::wallet2::make_from_file(vm2, true, wallet_file, nullptr).first;
+      wal = tools::wallet2::make_from_file(vm2, true, wallet_file, nullptr, m_pending_daemon).first;
     }
     catch (const std::exception& e)
     {
@@ -3952,8 +3952,7 @@ namespace tools
       command_line::add_arg(desc, arg_password);
       po::store(po::parse_command_line(argc, argv, desc), vm2);
     }
-
-    auto rc = tools::wallet2::make_new(vm2, true, nullptr);
+    auto rc = tools::wallet2::make_new(vm2, true, nullptr, m_pending_daemon);
     std::unique_ptr<wallet2> wal;
     wal = std::move(rc.first);
     if (!wal)
@@ -4182,8 +4181,7 @@ namespace tools
       command_line::add_arg(desc, arg_password);
       po::store(po::parse_command_line(argc, argv, desc), vm2);
     }
-
-    auto rc = tools::wallet2::make_new(vm2, true, nullptr);
+    auto rc = tools::wallet2::make_new(vm2, true, nullptr, m_pending_daemon);
     std::unique_ptr<wallet2> wal;
     wal = std::move(rc.first);
     if (!wal)
@@ -4776,7 +4774,6 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
 
     std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints;
     ssl_allowed_fingerprints.reserve(req.ssl_allowed_fingerprints.size());
@@ -4831,16 +4828,30 @@ namespace tools
       return false;
     }
 
-    boost::optional<epee::net_utils::http::login> daemon_login{};
-    if (!req.username.empty() || !req.password.empty())
-      daemon_login.emplace(req.username, req.password);
+    wallet2::daemon_config cfg;
+    cfg.address = req.address;
+    cfg.username = req.username;
+    cfg.password = req.password;
+    cfg.proxy = req.proxy;
+    cfg.trusted = req.trusted;
+    cfg.ssl_options = ssl_options;
 
-    if (!m_wallet->set_daemon(req.address, daemon_login, req.trusted, std::move(ssl_options), req.proxy))
+    // apply to the open wallet now; the config also seeds wallets opened/created later
+    if (m_wallet)
     {
-      er.code = WALLET_RPC_ERROR_CODE_NO_DAEMON_CONNECTION;
-      er.message = std::string("Unable to set daemon");
-      return false;
+      boost::optional<epee::net_utils::http::login> daemon_login{};
+      if (!req.username.empty() || !req.password.empty())
+        daemon_login.emplace(req.username, req.password);
+
+      if (!m_wallet->set_daemon(req.address, daemon_login, req.trusted, std::move(ssl_options), req.proxy))
+      {
+        er.code = WALLET_RPC_ERROR_CODE_NO_DAEMON_CONNECTION;
+        er.message = std::string("Unable to set daemon");
+        return false;
+      }
     }
+
+    m_pending_daemon = std::move(cfg);
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3624,7 +3624,7 @@ namespace tools
       command_line::add_arg(desc, arg_password);
       po::store(po::parse_command_line(argc, argv, desc), vm2);
     }
-    std::unique_ptr<tools::wallet2> wal = tools::wallet2::make_new(vm2, true, nullptr).first;
+    std::unique_ptr<tools::wallet2> wal = tools::wallet2::make_new(vm2, true, nullptr, m_pending_daemon).first;
     if (!wal)
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
@@ -3729,7 +3729,7 @@ namespace tools
     }
     std::unique_ptr<tools::wallet2> wal = nullptr;
     try {
-      wal = tools::wallet2::make_from_file(vm2, true, wallet_file, nullptr).first;
+      wal = tools::wallet2::make_from_file(vm2, true, wallet_file, nullptr, m_pending_daemon).first;
     }
     catch (const std::exception& e)
     {
@@ -3960,8 +3960,7 @@ namespace tools
       command_line::add_arg(desc, arg_password);
       po::store(po::parse_command_line(argc, argv, desc), vm2);
     }
-
-    auto rc = tools::wallet2::make_new(vm2, true, nullptr);
+    auto rc = tools::wallet2::make_new(vm2, true, nullptr, m_pending_daemon);
     std::unique_ptr<wallet2> wal;
     wal = std::move(rc.first);
     if (!wal)
@@ -4190,8 +4189,7 @@ namespace tools
       command_line::add_arg(desc, arg_password);
       po::store(po::parse_command_line(argc, argv, desc), vm2);
     }
-
-    auto rc = tools::wallet2::make_new(vm2, true, nullptr);
+    auto rc = tools::wallet2::make_new(vm2, true, nullptr, m_pending_daemon);
     std::unique_ptr<wallet2> wal;
     wal = std::move(rc.first);
     if (!wal)
@@ -4784,7 +4782,6 @@ namespace tools
       er.message = "Command unavailable in restricted mode.";
       return false;
     }
-    if (!m_wallet) return not_open(er);
 
     std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints;
     ssl_allowed_fingerprints.reserve(req.ssl_allowed_fingerprints.size());
@@ -4842,16 +4839,30 @@ namespace tools
       return false;
     }
 
-    boost::optional<epee::net_utils::http::login> daemon_login{};
-    if (!req.username.empty() || !req.password.empty())
-      daemon_login.emplace(req.username, req.password);
+    wallet2::daemon_config cfg;
+    cfg.address = req.address;
+    cfg.username = req.username;
+    cfg.password = req.password;
+    cfg.proxy = req.proxy;
+    cfg.trusted = req.trusted;
+    cfg.ssl_options = ssl_options;
 
-    if (!m_wallet->set_daemon(req.address, daemon_login, req.trusted, std::move(ssl_options), req.proxy))
+    // apply to the open wallet now; the config also seeds wallets opened/created later
+    if (m_wallet)
     {
-      er.code = WALLET_RPC_ERROR_CODE_NO_DAEMON_CONNECTION;
-      er.message = std::string("Unable to set daemon");
-      return false;
+      boost::optional<epee::net_utils::http::login> daemon_login{};
+      if (!req.username.empty() || !req.password.empty())
+        daemon_login.emplace(req.username, req.password);
+
+      if (!m_wallet->set_daemon(req.address, daemon_login, req.trusted, std::move(ssl_options), req.proxy))
+      {
+        er.code = WALLET_RPC_ERROR_CODE_NO_DAEMON_CONNECTION;
+        er.message = std::string("Unable to set daemon");
+        return false;
+      }
     }
+
+    m_pending_daemon = std::move(cfg);
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4786,13 +4786,6 @@ namespace tools
     }
     if (!m_wallet) return not_open(er);
 
-    if (m_wallet->has_proxy_option() && !req.proxy.empty())
-    {
-      er.code = WALLET_RPC_ERROR_CODE_PROXY_ALREADY_DEFINED;
-      er.message = "It is not possible to set daemon specific proxy when --proxy is defined.";
-      return false;
-    }
-   
     std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints;
     ssl_allowed_fingerprints.reserve(req.ssl_allowed_fingerprints.size());
     for (const std::string &fp: req.ssl_allowed_fingerprints)

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -283,6 +283,8 @@ namespace tools
       void check_background_mining();
 
       wallet2 *m_wallet;
+      // set_daemon settings reused for wallets opened/created later
+      boost::optional<wallet2::daemon_config> m_pending_daemon;
       std::string m_wallet_dir;
       tools::private_file rpc_login_file;
       std::atomic<bool> m_stop;

--- a/tests/functional_tests/multisig.py
+++ b/tests/functional_tests/multisig.py
@@ -683,7 +683,8 @@ class WrongDaemonGuard:
     def __enter__(self):
         Wallet(idx = self.idx).set_daemon("localhost:0")
     def __exit__(self, exc_type, exc_value, traceback):
-        Wallet(idx = self.idx).set_daemon("localhost:" + str(self.correct_port))
+        # set_daemon settings persist across wallet loads, so restore trust explicitly
+        Wallet(idx = self.idx).set_daemon("localhost:" + str(self.correct_port), trusted = True)
 
 if __name__ == '__main__':
     with AutoRefreshGuard() as arguard:


### PR DESCRIPTION
Fixes: https://github.com/monero-project/monero/issues/10322

Builds on top of: https://github.com/monero-project/monero/pull/10861

context: attempted to move basicswap away from setting commandline daemon flags for monero-wallet-rpc, so it could failover to a user prescribed list of nodes using set_daemon.

ran into a few issues
1. After using `set_daemon` -> `open_wallet`, if there was a daemon set on the commandline (--daemon-address), the connection is unexpectedly reverted to it on a wallet load.
2. Even if you started monero-wallet-rpc without --daemon-address, and exclusively used `set_daemon`, then **all params** would be dropped when you issue an `open_wallet`. _the daemon is retained!_ this means that you will leak your ip to the node, since proxy is dropped.
(this was discovered by basicswap's ci. It ran a rest against a password protected node, and on open_wallet, the connection would fail because the credentials were dropped. Upon investigation, it was discovered that _all_ params are dropped)

* params dropping also happens for (1). Only daemon flags are retained. Not as bad of an outcome, since the configure node was intentional, whereas set_daemon node dropping ssl and proxy is anything-but intentional.
3. You cannot run set_daemon before opening a wallet.


This PR
1. Allows you to run set_daemon without a wallet loaded. Same behavior as CLi flags. 
2. Values set by set_daemon override CLI flags.
3. Values set by set_daemon are retained across wallet changes.