### PR TITLE
mnemonics: decode seeds with explicit language

### DIFF
--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -78,6 +78,7 @@ namespace
   uint32_t create_checksum_index(const std::vector<epee::wipeable_string> &word_list,
     const Language::Base *language);
   bool checksum_test(std::vector<epee::wipeable_string> seed, const Language::Base *language);
+  bool language_is_expected(const Language::Base *language, const std::string *expected_language);
 
   /*!
    * \brief Finds the word list that contains the seed words and puts the indices
@@ -88,8 +89,15 @@ namespace
    * \param  language        Language instance pointer to write to after it is found.
    * \return                 true if all the words were present in some language false if not.
    */
+  bool language_is_expected(const Language::Base *language, const std::string *expected_language)
+  {
+    return !expected_language || *expected_language == language->get_language_name() ||
+      *expected_language == language->get_english_language_name();
+  }
+
   bool find_seed_language(const std::vector<epee::wipeable_string> &seed,
-    bool has_checksum, std::vector<uint32_t> &matched_indices, Language::Base **language)
+    bool has_checksum, std::vector<uint32_t> &matched_indices, Language::Base **language,
+    const std::string *expected_language = NULL)
   {
     // If there's a new language added, add an instance of it here.
     std::vector<Language::Base*> language_instances({
@@ -116,6 +124,9 @@ namespace
     for (std::vector<Language::Base*>::iterator it1 = language_instances.begin();
       it1 != language_instances.end(); it1++)
     {
+      if (!language_is_expected(*it1, expected_language))
+        continue;
+
       const std::unordered_map<epee::wipeable_string, uint32_t, Language::WordHash, Language::WordEqual> &word_map = (*it1)->get_word_map();
       const std::unordered_map<epee::wipeable_string, uint32_t, Language::WordHash, Language::WordEqual> &trimmed_word_map = (*it1)->get_trimmed_word_map();
       // To iterate through seed words
@@ -264,6 +275,12 @@ namespace crypto
     bool words_to_bytes(const epee::wipeable_string &words, epee::wipeable_string& dst, size_t len, bool duplicate,
       std::string &language_name)
     {
+      return words_to_bytes(words, dst, len, duplicate, language_name, std::string());
+    }
+
+    bool words_to_bytes(const epee::wipeable_string &words, epee::wipeable_string& dst, size_t len, bool duplicate,
+      std::string &language_name, const std::string &expected_language)
+    {
       std::vector<epee::wipeable_string> seed;
 
       words.split(seed);
@@ -293,7 +310,8 @@ namespace crypto
       std::vector<uint32_t> matched_indices;
       auto wiper = epee::misc_utils::create_scope_leave_handler([&](){memwipe(matched_indices.data(), matched_indices.size() * sizeof(matched_indices[0]));});
       Language::Base *language;
-      if (!find_seed_language(seed, has_checksum, matched_indices, &language))
+      const std::string *language_hint = expected_language.empty() ? NULL : &expected_language;
+      if (!find_seed_language(seed, has_checksum, matched_indices, &language, language_hint))
       {
         MERROR("Invalid seed: language not found");
         return false;
@@ -356,8 +374,14 @@ namespace crypto
     bool words_to_bytes(const epee::wipeable_string &words, crypto::secret_key& dst,
       std::string &language_name)
     {
+      return words_to_bytes(words, dst, language_name, std::string());
+    }
+
+    bool words_to_bytes(const epee::wipeable_string &words, crypto::secret_key& dst,
+      std::string &language_name, const std::string &expected_language)
+    {
       epee::wipeable_string s;
-      if (!words_to_bytes(words, s, sizeof(dst), true, language_name))
+      if (!words_to_bytes(words, s, sizeof(dst), true, language_name, expected_language))
       {
         MERROR("Invalid seed: failed to convert words to bytes");
         return false;

--- a/src/mnemonics/electrum-words.h
+++ b/src/mnemonics/electrum-words.h
@@ -75,6 +75,18 @@ namespace crypto
       std::string &language_name);
     /*!
      * \brief Converts seed words to bytes (secret key).
+     * \param  words             String containing the words separated by spaces.
+     * \param  dst               To put the secret data restored from the words.
+     * \param  len               The number of bytes to expect, 0 if unknown
+     * \param  duplicate         If true and len is not zero, we accept half the data, and duplicate it
+     * \param  language_name     Language of the seed as found gets written here.
+     * \param  expected_language Language to use for decoding instead of inferring from the seed.
+     * \return                   false if not a multiple of 3 words, or if word is not in the words list
+     */
+    bool words_to_bytes(const epee::wipeable_string &words, epee::wipeable_string& dst, size_t len, bool duplicate,
+      std::string &language_name, const std::string &expected_language);
+    /*!
+     * \brief Converts seed words to bytes (secret key).
      * \param  words           String containing the words separated by spaces.
      * \param  dst             To put the secret key restored from the words.
      * \param  language_name   Language of the seed as found gets written here.
@@ -82,6 +94,16 @@ namespace crypto
      */
     bool words_to_bytes(const epee::wipeable_string &words, crypto::secret_key& dst,
       std::string &language_name);
+    /*!
+     * \brief Converts seed words to bytes (secret key).
+     * \param  words             String containing the words separated by spaces.
+     * \param  dst               To put the secret key restored from the words.
+     * \param  language_name     Language of the seed as found gets written here.
+     * \param  expected_language Language to use for decoding instead of inferring from the seed.
+     * \return                   false if not a multiple of 3 words, or if word is not in the words list
+     */
+    bool words_to_bytes(const epee::wipeable_string &words, crypto::secret_key& dst,
+      std::string &language_name, const std::string &expected_language);
 
     /*!
      * \brief Converts bytes to seed words.

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3964,7 +3964,15 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
       }
       else
       {
-        if (!crypto::ElectrumWords::words_to_bytes(m_electrum_seed, m_recovery_key, old_language))
+        const bool has_mnemonic_language = !m_mnemonic_language.empty();
+        if (has_mnemonic_language && !crypto::ElectrumWords::is_valid_language(m_mnemonic_language))
+        {
+          fail_msg_writer() << tr("invalid mnemonic language");
+          return false;
+        }
+        if (!(has_mnemonic_language ?
+            crypto::ElectrumWords::words_to_bytes(m_electrum_seed, m_recovery_key, old_language, m_mnemonic_language) :
+            crypto::ElectrumWords::words_to_bytes(m_electrum_seed, m_recovery_key, old_language)))
         {
           fail_msg_writer() << tr("Electrum-style word list failed verification");
           return false;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4135,7 +4135,15 @@ namespace tools
 
     // check the given seed
     if (!req.enable_multisig_experimental) {
-      if (!crypto::ElectrumWords::words_to_bytes(req.seed, recovery_key, old_language))
+      if (!req.language.empty() && !crypto::ElectrumWords::is_valid_language(req.language))
+      {
+        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+        er.message = "The specified seed language is invalid.";
+        return false;
+      }
+      if (!(req.language.empty() ?
+          crypto::ElectrumWords::words_to_bytes(req.seed, recovery_key, old_language) :
+          crypto::ElectrumWords::words_to_bytes(req.seed, recovery_key, old_language, req.language)))
       {
         er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
         er.message = "Electrum-style word list failed verification";
@@ -4211,12 +4219,6 @@ namespace tools
       {
         er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
         er.message = "Wallet was using the old seed language. You need to specify a new seed language.";
-        return false;
-      }
-      if (!crypto::ElectrumWords::is_valid_language(req.language))
-      {
-        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        er.message = "Wallet was using the old seed language, and the specified new seed language is invalid.";
         return false;
       }
       mnemonic_language = req.language;

--- a/tests/unit_tests/mnemonics.cpp
+++ b/tests/unit_tests/mnemonics.cpp
@@ -50,6 +50,7 @@
 #include "mnemonics/lojban.h"
 #include "mnemonics/english_old.h"
 #include "mnemonics/singleton.h"
+#include "string_tools.h"
 
 namespace
 {
@@ -205,6 +206,27 @@ TEST(mnemonics, language_detection_with_bad_checksum)
     res = crypto::ElectrumWords::words_to_bytes(base_seed + " " + real_checksum, key, language_name);
     ASSERT_EQ(true, res);
     ASSERT_STREQ(language_name.c_str(), "Português");
+}
+
+TEST(mnemonics, explicit_language_decoding)
+{
+    crypto::secret_key key;
+    std::string language_name;
+    bool res;
+
+    const std::string seed = "pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma pluma";
+
+    res = crypto::ElectrumWords::words_to_bytes(seed, key, language_name);
+    ASSERT_EQ(true, res);
+    ASSERT_STREQ(language_name.c_str(), "English");
+    ASSERT_EQ("3b0400003b0400003b0400003b0400003b0400003b0400003b0400003b040000",
+      epee::string_tools::pod_to_hex(unwrap(unwrap(key))));
+
+    res = crypto::ElectrumWords::words_to_bytes(seed, key, language_name, "Spanish");
+    ASSERT_EQ(true, res);
+    ASSERT_STREQ(language_name.c_str(), "Español");
+    ASSERT_EQ("b4050000b4050000b4050000b4050000b4050000b4050000b4050000b4050000",
+      epee::string_tools::pod_to_hex(unwrap(unwrap(key))));
 }
 
 TEST(mnemonics, utf8prefix)


### PR DESCRIPTION
## what

Decode Electrum seeds with the explicitly provided mnemonic language when one is supplied by `monero-wallet-cli --mnemonic-language` or wallet RPC `restore_deterministic_wallet.language`

The automatic detection path is unchanged

## why

Related to #9089

That issue shows a valid Spanish seed that gets inferred as English because English is checked first and the 3-letter prefix checksum passes for `plus`

The CLI and RPC already expose a way to provide a seed language, but restore parsing still inferred the language before those values could help

With this change, callers that know the seed language can restore that seed as Spanish without changing default restore behavior

## testing

- `./build-seed-language/tests/unit_tests/unit_tests --gtest_filter='mnemonics.*' --data-dir build-seed-language/tests/data`
- `cmake --build build-seed-language --target monero-wallet-cli monero-wallet-rpc -j2`
- `ctest --test-dir build-seed-language -R '^unit_tests$' --output-on-failure`
- local offline `monero-wallet-cli` restore of the `pluma ...` seed with and without `--mnemonic-language Spanish`
- local offline `monero-wallet-rpc restore_deterministic_wallet` call with `language: "Spanish"`