### PR TITLE
wallet: rpc; dont allow startup with missing ssl params

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -4988,6 +4988,15 @@ public:
 
       if (!wallet_dir.empty())
       {
+        try
+        {
+          tools::wallet2::make_dummy(vm, true, password_prompt);
+        }
+        catch (const std::exception &e)
+        {
+          LOG_ERROR(tools::wallet_rpc_server::tr("Invalid configuration: ") << e.what());
+          return false;
+        }
         wal = NULL;
         goto just_dir;
       }


### PR DESCRIPTION
Starting monero-wallet-rpc with a --wallet-dir + clearnet daemon + proxy (or --daemon-ssl=enabled) would start the daemon, but upon running open_wallet, the daemon woukd attempt to apply, and fail due to missing --daemon-ssl* flags. You cannot fix this without modifying the startup flags.

this change makes it so that the wallet-rpc will error and refuse to start, instead of not-checking until a wallet is opened