### PR TITLE
docs: clarify license info

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -96,7 +96,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Licensing and ownership
 
-- The project MUST use a share-alike license, such as BSD-3, the GPLv3 or a variant thereof (LGPL, AGPL), or the MPLv2.
+- The project MUST use a permissive or share-alike license, such as BSD-3, the GPLv3 or a variant thereof (LGPL, AGPL), or the MPLv2.
 - All contributions to the project source code ("patches") MUST use the same license as the project.
 - All patches are owned by their authors. There MUST NOT be any copyright assignment process.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -96,7 +96,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Licensing and ownership
 
-- The project MUST use a share-alike license, such as BSD-3, the GPLv3 or a variant thereof (LGPL, AGPL), or the MPLv2.
+- The project MUST use a permissive license, such as BSD-3, MIT, or Unlicense.
 - All contributions to the project source code ("patches") MUST use the same license as the project.
 - All patches are owned by their authors. There MUST NOT be any copyright assignment process.
 


### PR DESCRIPTION
`CONTRIBUTING.md` states that the project must use a share-alike license, however BSD-3 is a permissive license.