### PR TITLE
utils/openrc: require net dependency

### DIFF
--- a/utils/openrc/monerod.openrc
+++ b/utils/openrc/monerod.openrc
@@ -18,7 +18,8 @@ respawn_delay=10
 respawn_max=0
 
 depend() {
-    after net
+    need net
+    use dns
 }
 
 start_pre() {


### PR DESCRIPTION
Using `after net` only requests startup rather than actually requiring it. `dns` is arguably "needed" as well.