### PR TITLE
wallet: initialize URI parse outputs

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -14869,6 +14869,14 @@ bool wallet2::parse_uri(const std::string &uri, std::string &address, std::strin
     error = std::string("URI has wrong address: ") + address;
     return false;
   }
+
+  payment_id.clear();
+  amount = 0;
+  tx_description.clear();
+  recipient_name.clear();
+  unknown_parameters.clear();
+  error.clear();
+
   if (!strchr(remainder.c_str(), '?'))
     return true;
 
@@ -14896,7 +14904,6 @@ bool wallet2::parse_uri(const std::string &uri, std::string &address, std::strin
 
     if (kv[0] == "tx_amount")
     {
-      amount = 0;
       if (!cryptonote::parse_amount(amount, kv[1]))
       {
         error = std::string("URI has invalid amount: ") + kv[1];

--- a/tests/unit_tests/uri.cpp
+++ b/tests/unit_tests/uri.cpp
@@ -82,6 +82,27 @@ TEST(uri, good_address)
   ASSERT_EQ(address, TEST_ADDRESS);
 }
 
+TEST(uri, resets_outputs)
+{
+  std::string address = "old address";
+  std::string payment_id = "old payment id";
+  std::string recipient_name = "old recipient name";
+  std::string description = "old description";
+  std::string error = "old error";
+  uint64_t amount = 1;
+  std::vector<std::string> unknown_parameters{"old=parameter"};
+  tools::wallet2 w(cryptonote::TESTNET);
+
+  ASSERT_TRUE(w.parse_uri("monero:" TEST_ADDRESS, address, payment_id, amount, description, recipient_name, unknown_parameters, error));
+  EXPECT_EQ(address, TEST_ADDRESS);
+  EXPECT_EQ(amount, 0);
+  EXPECT_TRUE(payment_id.empty());
+  EXPECT_TRUE(description.empty());
+  EXPECT_TRUE(recipient_name.empty());
+  EXPECT_TRUE(unknown_parameters.empty());
+  EXPECT_TRUE(error.empty());
+}
+
 TEST(uri, good_integrated_address)
 {
   PARSE_URI("monero:" TEST_INTEGRATED_ADDRESS, true);


### PR DESCRIPTION
`parse_uri()` left optional outputs untouched when the URI omitted them, so a successful parse could expose stale values or an uninitialized amount

Reset the optional outputs after validating the address so each successful call only describes the current URI

Tests: `unit_tests --gtest_filter=uri.*`, full `unit_tests`