### PR TITLE
p2p: omit sync data when retrieving seed peerlist

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1144,7 +1144,8 @@ namespace nodetool
     typename COMMAND_HANDSHAKE::request arg;
     typename COMMAND_HANDSHAKE::response rsp;
     get_local_node_data(arg.node_data, zone);
-    m_payload_handler.get_payload_sync_data(arg.payload_data);
+    if (!just_take_peerlist)
+      m_payload_handler.get_payload_sync_data(arg.payload_data);
 
     epee::simple_event ev;
     std::atomic<bool> hsh_result(false);


### PR DESCRIPTION
Resolves #6250

Without this patch, seed nodes that were not on the latest fork would reject the handshake before returning their peer list.