### PR TITLE
serialization: simplify tx.signatures blobs

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -282,8 +282,17 @@ namespace cryptonote
           PREPARE_CUSTOM_VECTOR_SERIALIZATION(signature_size, signatures[i]);
           if (signature_size != signatures[i].size())
             return false;
+          else if (0 == signature_size)
+            continue; // v1 miner txs serialize an empty signatures outer array
 
-          FIELDS(signatures[i]);
+          // for non-miner, serialize all inner `crypto::signature`s for this input in one big blob
+          static_assert(std::has_unique_object_representations_v<crypto::signature>);
+          ar.serialize_blob(signatures[i].data(), signature_size * sizeof(crypto::signature));
+          if (!ar.good())
+          {
+            if (!Archive<W>::is_saving()) signatures.clear(); // on load failure, clear all sigs for good measure
+            return false;
+          }
 
           if (vin.size() - i > 1)
             ar.delimit_array();

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -194,6 +194,7 @@
 #define HF_VERSION_BULLETPROOF_PLUS             15
 #define HF_VERSION_VIEW_TAGS                    15
 #define HF_VERSION_2021_SCALING                 15
+#define MAX_HF_VERSION                          16
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 #define CRYPTONOTE_SCALING_2021_FEE_ROUNDING_PLACES 2

--- a/src/serialization/crypto.h
+++ b/src/serialization/crypto.h
@@ -30,52 +30,11 @@
 
 #pragma once
 
-#include <vector>
-
 #include "serialization.h"
 #include "debug_archive.h"
 #include "crypto/chacha.h"
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
-
-// read
-template <template <bool> class Archive>
-bool do_serialize(Archive<false> &ar, std::vector<crypto::signature> &v)
-{
-  size_t cnt = v.size();
-  v.clear();
-
-  // very basic sanity check
-  if (ar.remaining_bytes() < cnt*sizeof(crypto::signature)) {
-    ar.set_fail();
-    return false;
-  }
-
-  v.reserve(cnt);
-  for (size_t i = 0; i < cnt; i++) {
-    v.resize(i+1);
-    ar.serialize_blob(&(v[i]), sizeof(crypto::signature), "");
-    if (!ar.good())
-      return false;
-  }
-  return true;
-}
-
-// write
-template <template <bool> class Archive>
-bool do_serialize(Archive<true> &ar, std::vector<crypto::signature> &v)
-{
-  if (0 == v.size()) return true;
-  ar.begin_string();
-  size_t cnt = v.size();
-  for (size_t i = 0; i < cnt; i++) {
-    ar.serialize_blob(&(v[i]), sizeof(crypto::signature), "");
-    if (!ar.good())
-      return false;
-  }
-  ar.end_string();
-  return true;
-}
 
 BLOB_SERIALIZER(crypto::chacha_iv);
 BLOB_SERIALIZER(crypto::hash);

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -115,6 +115,8 @@ namespace
 
     bool compare_tx_to_json_tx(const cryptonote::transaction &tx, const std::string &tx_json)
     {
+        static_assert(MAX_HF_VERSION == 16, "Update to compare FCMP++ tx JSON representations");
+
         using namespace epee::string_tools; // for pod_to_hex()
 
         const crypto::hash txid = get_transaction_hash(tx);


### PR DESCRIPTION
Simplifies serialization of `cryptonote::transaction::signatures`. Also, puts static assert reminder in the unit tests to update `compare_tx_to_json_tx()` when `MAX_HF_VERSION` is bumped.