### PR TITLE
serialization: remove {begin/end}_string() from archives

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -271,19 +271,18 @@ namespace cryptonote
         if (!pruned) for (size_t i = 0; i < vin.size(); ++i)
         {
           size_t signature_size = get_signature_size(vin[i]);
-          if (signatures_not_expected)
-          {
-            if (0 == signature_size)
-              continue;
-            else
-              return false;
-          }
+          if (signatures_not_expected && signature_size)
+            return false;
+          else if (!signature_size || signatures_not_expected)
+            continue;
 
           PREPARE_CUSTOM_VECTOR_SERIALIZATION(signature_size, signatures[i]);
           if (signature_size != signatures[i].size())
             return false;
 
-          FIELDS(signatures[i]);
+          // serialize all `crypto::signature`s for this input in one big blob
+          static_assert(std::has_unique_object_representations_v<crypto::signature>);
+          ar.serialize_blob(signatures[i].data(), signature_size * sizeof(crypto::signature));
 
           if (vin.size() - i > 1)
             ar.delimit_array();

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -194,6 +194,7 @@
 #define HF_VERSION_BULLETPROOF_PLUS             15
 #define HF_VERSION_VIEW_TAGS                    15
 #define HF_VERSION_2021_SCALING                 15
+#define MAX_HF_VERSION                          16
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 #define CRYPTONOTE_SCALING_2021_FEE_ROUNDING_PLACES 2

--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -129,7 +129,7 @@ struct binary_archive<false> : public binary_archive_base<false>
       v = 0; // ensures initialization
   }
   
-  void serialize_blob(void *buf, size_t len, const char *delimiter="")
+  void serialize_blob(void *buf, size_t len)
   {
     const std::size_t actual = bytes_.remove_prefix(len);
     good_ &= (len == actual);
@@ -160,9 +160,6 @@ struct binary_archive<false> : public binary_archive_base<false>
   void begin_array() { }
   void delimit_array() { }
   void end_array() { }
-
-  void begin_string(const char *delimiter /*="\""*/) { }
-  void end_string(const char *delimiter   /*="\""*/) { }
 
   void read_variant_tag(variant_tag_type &t) {
     serialize_int(t);
@@ -203,7 +200,7 @@ struct binary_archive<true> : public binary_archive_base<true>
     }
   }
 
-  void serialize_blob(void *buf, size_t len, const char *delimiter="")
+  void serialize_blob(void *buf, size_t len)
   {
     stream_.write((char *)buf, len);
   }
@@ -227,9 +224,6 @@ struct binary_archive<true> : public binary_archive_base<true>
   void begin_array() { }
   void delimit_array() { }
   void end_array() { }
-
-  void begin_string(const char *delimiter="\"") { }
-  void end_string(const char *delimiter="\"") { }
 
   void write_variant_tag(variant_tag_type t) {
     serialize_int(t);

--- a/src/serialization/crypto.h
+++ b/src/serialization/crypto.h
@@ -30,52 +30,11 @@
 
 #pragma once
 
-#include <vector>
-
 #include "serialization.h"
 #include "debug_archive.h"
 #include "crypto/chacha.h"
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
-
-// read
-template <template <bool> class Archive>
-bool do_serialize(Archive<false> &ar, std::vector<crypto::signature> &v)
-{
-  size_t cnt = v.size();
-  v.clear();
-
-  // very basic sanity check
-  if (ar.remaining_bytes() < cnt*sizeof(crypto::signature)) {
-    ar.set_fail();
-    return false;
-  }
-
-  v.reserve(cnt);
-  for (size_t i = 0; i < cnt; i++) {
-    v.resize(i+1);
-    ar.serialize_blob(&(v[i]), sizeof(crypto::signature), "");
-    if (!ar.good())
-      return false;
-  }
-  return true;
-}
-
-// write
-template <template <bool> class Archive>
-bool do_serialize(Archive<true> &ar, std::vector<crypto::signature> &v)
-{
-  if (0 == v.size()) return true;
-  ar.begin_string();
-  size_t cnt = v.size();
-  for (size_t i = 0; i < cnt; i++) {
-    ar.serialize_blob(&(v[i]), sizeof(crypto::signature), "");
-    if (!ar.good())
-      return false;
-  }
-  ar.end_string();
-  return true;
-}
 
 BLOB_SERIALIZER(crypto::chacha_iv);
 BLOB_SERIALIZER(crypto::hash);

--- a/src/serialization/json_archive.h
+++ b/src/serialization/json_archive.h
@@ -136,29 +136,19 @@ struct json_archive<true> : public json_archive_base<std::ostream, true>
     stream_ << std::dec << promote_to_printable_integer_type(v);
   }
 
-  void serialize_blob(void *buf, size_t len, const char *delimiter="\"") {
-    begin_string(delimiter);
+  void serialize_blob(void *buf, size_t len) {
+    stream_ << '"';
     for (size_t i = 0; i < len; i++) {
       unsigned char c = ((unsigned char *)buf)[i];
       stream_ << std::hex << std::setw(2) << std::setfill('0') << (int)c;
     }
-    end_string(delimiter);
+    stream_ << '"';
   }
 
   template <class T>
   void serialize_varint(T &v)
   {
     stream_ << std::dec << promote_to_printable_integer_type(v);
-  }
-
-  void begin_string(const char *delimiter="\"")
-  {
-    stream_ << delimiter;
-  }
-
-  void end_string(const char *delimiter="\"")
-  {
-    stream_ << delimiter;
   }
 
   void begin_array(size_t s=0)

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -115,6 +115,8 @@ namespace
 
     bool compare_tx_to_json_tx(const cryptonote::transaction &tx, const std::string &tx_json)
     {
+        static_assert(MAX_HF_VERSION == 16, "Update to compare FCMP++ tx JSON representations");
+
         using namespace epee::string_tools; // for pod_to_hex()
 
         const crypto::hash txid = get_transaction_hash(tx);


### PR DESCRIPTION
Cleanup. Depends on #10888 