### PR TITLE
wallet: derive encrypted payment ID dummy/real status from tx.extra, not cd.dests

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7477,6 +7477,8 @@ bool simple_wallet::accept_loaded_tx(const std::function<size_t()> get_num_txes,
             if (e.is_integrated)
               is_dummy = false;
 
+          CHECK_AND_ASSERT_MES(is_dummy == (payment_id8 == crypto::null_hash8), false, "Bad loaded tx: mismatched payment ID info");
+
           if (is_dummy)
           {
             payment_id_string += std::string("dummy encrypted payment ID");
@@ -7508,7 +7510,7 @@ bool simple_wallet::accept_loaded_tx(const std::function<size_t()> get_num_txes,
     {
       const tx_destination_entry &entry = cd.splitted_dsts[d];
       std::string address, standard_address = get_account_address_as_str(m_wallet->nettype(), entry.is_subaddress, entry.addr);
-      if (has_encrypted_payment_id && !entry.is_subaddress && standard_address != entry.original)
+      if (has_encrypted_payment_id && !entry.is_subaddress)
       {
         address = get_account_integrated_address_as_str(m_wallet->nettype(), entry.addr, payment_id8);
         address += std::string(" (" + standard_address + " with encrypted payment id " + epee::string_tools::pod_to_hex(payment_id8) + ")");

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -122,8 +122,15 @@ bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_nu
         {
           if (!payment_id_string.empty())
             payment_id_string += ", ";
-          payment_id_string = std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
-          has_encrypted_payment_id = true;
+          if (payment_id8 == crypto::null_hash8)
+          {
+            payment_id_string += std::string("dummy encrypted payment ID");
+          }
+          else
+          {
+            payment_id_string += std::string("encrypted payment ID ") + epee::string_tools::pod_to_hex(payment_id8);
+            has_encrypted_payment_id = true;
+          }
         }
         else if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, payment_id))
         {

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1580,7 +1580,7 @@ namespace tools
         {
           const cryptonote::tx_destination_entry &entry = cd.splitted_dsts[d];
           std::string address = cryptonote::get_account_address_as_str(m_wallet->nettype(), entry.is_subaddress, entry.addr);
-          if (has_encrypted_payment_id && !entry.is_subaddress && address != entry.original)
+          if (has_encrypted_payment_id && !entry.is_subaddress)
             address = cryptonote::get_account_integrated_address_as_str(m_wallet->nettype(), entry.addr, payment_id8);
           auto i = tx_dests.find(entry.addr);
           if (i == tx_dests.end())


### PR DESCRIPTION
The wallet-CLI confirmation prompt derived a payment ID's dummy/real status from cd.dests[i].is_integrated, while the payment ID that actually lands in tx.extra comes from cd.extra. These two sources can be set inconsistently, so the prompt could display "dummy encrypted payment ID" while a different encrypted payment ID was signed onto the chain.

This changes the source of truth to the plaintext payment_id8 (from cd.extra), which is the value that gets XOR-encrypted into the chain-permanent tx.extra. It also drops the entry.original gate on integrated-form address rendering, since entry.original is proposer-controlled and can be pinned to suppress the integrated display. The same rendering fix is applied to on_describe_transfer in wallet_rpc_server.cpp.

Display-only change, per review scope. cc @selsta

Signed-off-by: sin99xx <sin99xx@users.noreply.github.com>