### PR TITLE
common: increase performance timer buffer size (fix warning)

### DIFF
--- a/src/common/perf_timer.cpp
+++ b/src/common/perf_timer.cpp
@@ -155,7 +155,7 @@ LoggingPerformanceTimer::~LoggingPerformanceTimer()
   const bool log = ELPP->vRegistry()->allowed(level, cat.c_str());
   if (log)
   {
-    char s[12];
+    char s[24];
     snprintf(s, sizeof(s), "%8llu  ", (unsigned long long)(ticks_to_ns(ticks) / (1000000000 / unit)));
     size_t size = 0; for (const auto *tmp: *performance_timers) if (!tmp->paused || tmp==this) ++size;
     PERF_LOG_ALWAYS(level, cat.c_str(), "PERF " << s << std::string(size * 2, ' ') << "  " << name);


### PR DESCRIPTION
```
/__w/monero/monero/src/common/perf_timer.cpp:159:29: warning: ‘%8llu’ directive output may be truncated writing between 8 and 20 bytes into a region of size 12 [-Wformat-truncation=]
  159 |     snprintf(s, sizeof(s), "%8llu  ", (unsigned long long)(ticks_to_ns(ticks) / (1000000000 / unit)));
      |                             ^~~~~
```

`GCC 16.1.1`