### PR TITLE
tx_pool: remove redundant hashCompare comparator (fix warning)

### DIFF
--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -78,18 +78,9 @@ namespace cryptonote
     }
   }; 
 
-  class hashCompare
-  {
-  public:
-    bool operator()(const crypto::hash& a, const crypto::hash& b) const
-    {
-      return memcmp(a.data, b.data, sizeof(crypto::hash)) < 0;
-    }
-  };
-
   //! container for sorting transactions by fee per unit size
   typedef boost::bimap<boost::bimaps::multiset_of<std::pair<double, std::time_t>, txFeeCompare>,
-                       boost::bimaps::set_of<crypto::hash, hashCompare>> sorted_tx_container;
+                       boost::bimaps::set_of<crypto::hash>> sorted_tx_container;
   
 
   /**


### PR DESCRIPTION
```
/__w/monero/monero/src/cryptonote_core/tx_pool.h:86:20: warning: ‘int memcmp(const void*, const void*, size_t)’ specified bound 32 exceeds source size 0 [-Wstringop-overread]
   86 |       return memcmp(a.data, b.data, sizeof(crypto::hash)) < 0;
```

`GCC 16.1.1`