### PR TITLE
trezor: suppress generated protobuf deprecation warnings

### DIFF
--- a/cmake/CheckTrezor.cmake
+++ b/cmake/CheckTrezor.cmake
@@ -161,6 +161,15 @@ if(Protobuf_FOUND AND USE_DEVICE_TREZOR)
         file(READ "${_proto_out_dir}/${file}" file_content)
         string(REPLACE "PROTOBUF_DEPRECATED_ENUM" ""
                 updated_content "${file_content}")
+        string(PREPEND updated_content
+                "#if defined(__GNUC__)\n"
+                "#pragma GCC diagnostic push\n"
+                "#pragma GCC diagnostic ignored \"-Wdeprecated-declarations\"\n"
+                "#endif\n")
+        string(APPEND updated_content
+                "#if defined(__GNUC__)\n"
+                "#pragma GCC diagnostic pop\n"
+                "#endif\n")
         file(WRITE "${_proto_out_dir}/${file}" "${updated_content}")
     endforeach ()
 


### PR DESCRIPTION
```
In file included from /__w/monero/monero/src/device_trezor/trezor/transport.hpp:52,
                 from /__w/monero/monero/src/device_trezor/trezor.hpp:36,
                 from /__w/monero/monero/src/device_trezor/device_trezor.hpp:33,
                 from /__w/monero/monero/src/wallet/wallet2.cpp:94:
/__w/monero/monero/src/device_trezor/trezor/messages/messages-common.pb.h:2468:96: warning: ‘hw::trezor::messages::common::ButtonRequest_ButtonRequestType__Deprecated_ButtonRequest_PassphraseType’ is deprecated [-Wdeprecated-declarations]
 2468 |   [[deprecated]] static constexpr ButtonRequestType _Deprecated_ButtonRequest_PassphraseType = ButtonRequest_ButtonRequestType__Deprecated_ButtonRequest_PassphraseType;
```

`GCC 16.1.1`

Follow up to #10805