### PR TITLE
cmake: use wrapped __cxa_throw on GNU/Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,11 @@ if (WIN32 OR STATIC)
   add_definitions(-DSTATICLIB)
 endif ()
 
+set(STACK_TRACE_USE_WRAP OFF)
+if (STACK_TRACE AND NOT STATIC AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(STACK_TRACE_USE_WRAP ON)
+endif()
+
 function (monero_private_headers group)
   source_group("${group}\\Private"
     FILES

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -63,6 +63,10 @@ monero_add_library(common
   ${common_headers}
   ${common_private_headers})
 
+if (STACK_TRACE_USE_WRAP)
+  target_compile_definitions(obj_common PRIVATE STACK_TRACE_USE_WRAP)
+endif()
+
 if(BUILD_TRANSLATIONS)
   add_dependencies(obj_common generate_translations_header)
 endif()
@@ -80,6 +84,12 @@ target_link_libraries(common
   PRIVATE
     ${OPENSSL_LIBRARIES}
     ${EXTRA_LIBRARIES})
+
+if (STACK_TRACE_USE_WRAP)
+  set_property(TARGET common APPEND PROPERTY INTERFACE_LINK_OPTIONS
+    "-Wl,--wrap=__cxa_throw"
+    "-Wl,-u,__wrap___cxa_throw")
+endif()
 target_include_directories(common
   PRIVATE
     ${Boost_INCLUDE_DIRS})

--- a/src/common/stack_trace.cpp
+++ b/src/common/stack_trace.cpp
@@ -41,7 +41,7 @@
 #include <libunwind.h>
 #include <cxxabi.h>
 #endif
-#ifndef STATICLIB
+#if !defined(STATICLIB) && !defined(STACK_TRACE_USE_WRAP)
 #include <dlfcn.h>
 #endif
 #include <boost/algorithm/string.hpp>
@@ -74,12 +74,12 @@
 #define CXA_THROW_INFO_T void
 #endif // !__clang__
 
-#ifdef STATICLIB
+#if defined(STATICLIB) || defined(STACK_TRACE_USE_WRAP)
 #define CXA_THROW __wrap___cxa_throw
 extern "C"
 __attribute__((noreturn))
 void __real___cxa_throw(void *ex, CXA_THROW_INFO_T *info, void (*dest)(void*));
-#else // !STATICLIB
+#else // STATICLIB || STACK_TRACE_USE_WRAP
 #define CXA_THROW __cxa_throw
 extern "C"
 typedef
@@ -87,7 +87,7 @@ typedef
 __attribute__((noreturn))
 #endif // __clang__
 void (cxa_throw_t)(void *ex, CXA_THROW_INFO_T *info, void (*dest)(void*));
-#endif // !STATICLIB
+#endif // STATICLIB || STACK_TRACE_USE_WRAP
 
 extern "C"
 __attribute__((noreturn))
@@ -99,12 +99,12 @@ void CXA_THROW(void *ex, CXA_THROW_INFO_T *info, void (*dest)(void*))
   tools::log_stack_trace((std::string("Exception: ")+((!status && dsym) ? dsym : (const char*)info)).c_str());
   free(dsym);
 
-#ifndef STATICLIB
+#if !defined(STATICLIB) && !defined(STACK_TRACE_USE_WRAP)
 #ifndef __clang__ // for GCC the attr can't be applied in typedef like for clang
   __attribute__((noreturn))
 #endif // !__clang__
    cxa_throw_t *__real___cxa_throw = (cxa_throw_t*)dlsym(RTLD_NEXT, "__cxa_throw");
-#endif // !STATICLIB
+#endif // !STATICLIB && !STACK_TRACE_USE_WRAP
   __real___cxa_throw(ex, info, dest);
 }
 


### PR DESCRIPTION
```
multiple definition of `__cxa_throw'
/usr/lib/.../libstdc++.a(eh_throw.o)
../common/libcommon.a(stack_trace.cpp.o)
```

Fixes build on Arch Linux.