### PR TITLE
wallet_api: set m_password in the recovery creation paths

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -681,6 +681,7 @@ bool WalletImpl::recoverFromKeysWithPassword(const std::string &path,
         setStatusError(string(tr("failed to generate new wallet: ")) + e.what());
         return false;
     }
+    m_password = password;
     return true;
 }
 
@@ -698,6 +699,7 @@ bool WalletImpl::recoverFromDevice(const std::string &path, const std::string &p
         setStatusError(string(tr("failed to generate new wallet: ")) + e.what());
         return false;
     }
+    m_password = password;
     return true;
 }
 
@@ -766,6 +768,7 @@ bool WalletImpl::recover(const std::string &path, const std::string &password, c
     try {
         m_wallet->set_seed_language(old_language);
         m_wallet->generate(path, password, recovery_key, true, false);
+        m_password = password;
 
     } catch (const std::exception &e) {
         setStatusCritical(e.what());

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -382,6 +382,43 @@ TEST_F(WalletManagerTest, WalletManagerRecoversWallet)
     ASSERT_TRUE(wmgr->closeWallet(wallet2));
 }
 
+TEST_F(WalletManagerTest, WalletManagerStoresPasswordOfWalletRecoveredFromSeed)
+{
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG, Monero::NetworkType::MAINNET);
+    std::string seed1 = wallet1->seed();
+    std::string address1 = wallet1->mainAddress();
+    ASSERT_TRUE(wmgr->closeWallet(wallet1));
+    Utils::deleteWallet(WALLET_NAME);
+    Monero::Wallet * wallet2 = wmgr->recoveryWallet(WALLET_NAME, WALLET_PASS, seed1, Monero::NetworkType::MAINNET, 0);
+    ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet2->mainAddress() == address1);
+    ASSERT_TRUE(wallet2->store(WALLET_NAME_COPY));
+    ASSERT_TRUE(wmgr->closeWallet(wallet2));
+    Monero::Wallet * wallet3 = wmgr->openWallet(WALLET_NAME_COPY, WALLET_PASS, Monero::NetworkType::MAINNET);
+    ASSERT_TRUE(wallet3->status() == Monero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet3->mainAddress() == address1);
+    ASSERT_TRUE(wmgr->closeWallet(wallet3));
+}
+
+TEST_F(WalletManagerTest, WalletManagerStoresPasswordOfWalletRecoveredFromKeys)
+{
+    Monero::Wallet * wallet1 = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG, Monero::NetworkType::MAINNET);
+    std::string address1 = wallet1->mainAddress();
+    std::string viewkey1 = wallet1->secretViewKey();
+    std::string spendkey1 = wallet1->secretSpendKey();
+    ASSERT_TRUE(wmgr->closeWallet(wallet1));
+    Utils::deleteWallet(WALLET_NAME);
+    Monero::Wallet * wallet2 = wmgr->createWalletFromKeys(WALLET_NAME, WALLET_PASS, WALLET_LANG, Monero::NetworkType::MAINNET, 0, address1, viewkey1, spendkey1);
+    ASSERT_TRUE(wallet2->status() == Monero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet2->mainAddress() == address1);
+    ASSERT_TRUE(wallet2->store(WALLET_NAME_COPY));
+    ASSERT_TRUE(wmgr->closeWallet(wallet2));
+    Monero::Wallet * wallet3 = wmgr->openWallet(WALLET_NAME_COPY, WALLET_PASS, Monero::NetworkType::MAINNET);
+    ASSERT_TRUE(wallet3->status() == Monero::Wallet::Status_Ok);
+    ASSERT_TRUE(wallet3->mainAddress() == address1);
+    ASSERT_TRUE(wmgr->closeWallet(wallet3));
+}
+
 
 TEST_F(WalletManagerTest, WalletManagerStoresWallet1)
 {


### PR DESCRIPTION
as a result of testing anonero-fork with fcmp stressnet. @j-berman commit surfaced the issue https://github.com/seraphis-migration/monero/commit/09aa37d1c4f8a390a1e84c377e23cef3056c91f4