### PR TITLE
take m_daemon_rpc_mutex in wallet2::get_daemon_address

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -12667,6 +12667,7 @@ std::string wallet2::get_keys_file() const
 
 std::string wallet2::get_daemon_address() const
 {
+  boost::lock_guard<boost::recursive_mutex> lock(m_daemon_rpc_mutex);
   return m_daemon_address;
 }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -12667,6 +12667,7 @@ std::string wallet2::get_keys_file() const
 
 std::string wallet2::get_daemon_address() const
 {
+  boost::lock_guard lock(m_daemon_rpc_mutex);
   return m_daemon_address;
 }
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1659,7 +1659,7 @@ private:
 
     std::atomic<bool> m_run;
 
-    boost::recursive_mutex m_daemon_rpc_mutex;
+    mutable boost::recursive_mutex m_daemon_rpc_mutex;
 
     bool m_trusted_daemon;
     i_wallet2_callback* m_callback;


### PR DESCRIPTION
Repro: call `get_daemon_address()` on one thread while another runs `set_daemon()`, which reassigns `m_daemon_address` via `std::move` under `m_daemon_rpc_mutex`.
Cause: the getter copies `m_daemon_address` with no lock, so it races the guarded reassignment — a torn read of the `std::string` (pointer/size/capacity), or a read of a freed buffer. It is the one daemon accessor in `wallet2` that skips `m_daemon_rpc_mutex`, and `wallet2` runs multithreaded through the libwallet `api/` layer (a GUI can change the daemon while a worker reports a connection error via `get_daemon_address`).
Fix: take `m_daemon_rpc_mutex` in the getter. It is recursive and `set_daemon` already calls the getter while holding it, so re-entry is safe; the mutex is marked `mutable` so the `const` getter can lock it.