### PR TITLE
workflows: split up test step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,8 @@ jobs:
         run: |
           ${{env.CCACHE_SETTINGS}}
           ${{env.BUILD_DEFAULT}}
-          ${{env.CTEST_EXCLUDE_SLOW}}
+      - name: reduced tests
+        run: ${{env.CTEST_EXCLUDE_SLOW}}
       - name: save ccache
         uses: actions/cache/save@v5
         if: github.event_name != 'pull_request' && steps.ccache-restore.outputs.cache-hit != 'true'
@@ -100,7 +101,8 @@ jobs:
         run: |
           ${{env.CCACHE_SETTINGS}}
           ${{env.BUILD_DEFAULT}}
-          ${{env.CTEST_EXCLUDE_SLOW}}
+      - name: reduced tests
+        run: ${{env.CTEST_EXCLUDE_SLOW}}
       - name: save ccache
         uses: actions/cache/save@v5
         if: github.event_name != 'pull_request' && steps.ccache-restore.outputs.cache-hit != 'true'


### PR DESCRIPTION
Follow up to https://github.com/monero-project/monero/pull/10650

For some reason if build fails it would start tests and then complain about missing test binaries, see for example here: https://github.com/monero-project/monero/actions/runs/29136668958/job/86502156100?pr=8867