### PR TITLE
epee: avoid bad_weak_ptr during connection teardown

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -1221,16 +1221,13 @@ namespace net_utils
   template<typename T>
   bool connection<T>::add_ref()
   {
-    try {
-      auto self = connection<T>::shared_from_this();
-      std::lock_guard<std::mutex> guard(m_state.lock);
-      this->self = std::move(self);
-      ++m_state.protocol.reference_counter;
-      return true;
-    }
-    catch (boost::bad_weak_ptr &exception) {
+    auto self = connection<T>::weak_from_this().lock();
+    if (!self)
       return false;
-    }
+    std::lock_guard<std::mutex> guard(m_state.lock);
+    this->self = std::move(self);
+    ++m_state.protocol.reference_counter;
+    return true;
   }
 
   template<typename T>


### PR DESCRIPTION
foreach_connection() can race with connection destruction while the protocol handler remains in the raw-pointer map. Use the non-throwing weak_from_this().lock() in add_ref() and treat expired connections as unavailable.

This is an interim mitigation pending the broader connection lifetime fix in #7345.

Resolves #8341
Resolves #8907