### PR TITLE
epee: fix build with OpenSSL 4.0

### DIFF
--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -174,8 +174,7 @@ bool create_rsa_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert)
     X509_free(cert);
     return false;
   }
-  X509_NAME *name = X509_get_subject_name(cert);
-  X509_set_issuer_name(cert, name);
+  X509_set_issuer_name(cert, X509_get_subject_name(cert));
 
   if (X509_sign(cert, pkey, EVP_sha256()) == 0)
   {


### PR DESCRIPTION
Fixes #10904.

OpenSSL 4.0 makes `X509_get_subject_name()` return a `const X509_NAME *`.

The certificate generation path only passes the returned subject name to `X509_set_issuer_name()`, which accepts a const name.  Preserve the const qualification instead of assigning it to a mutable pointer.

This fixes compilation with OpenSSL 4.0 without changing certificate generation behavior.

Tests:
- Built `gen_ssl_cert` against OpenSSL 3.6.3
- Generated and parsed a self-signed certificate with `monero-gen-ssl-cert`
- `git diff --check`