### PR TITLE
epee: fix build with OpenSSL 4.0 [release-v0.18]

### DIFF
--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -174,8 +174,7 @@ bool create_rsa_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert)
     X509_free(cert);
     return false;
   }
-  X509_NAME *name = X509_get_subject_name(cert);
-  X509_set_issuer_name(cert, name);
+  X509_set_issuer_name(cert, X509_get_subject_name(cert));
 
   if (X509_sign(cert, pkey, EVP_sha256()) == 0)
   {


### PR DESCRIPTION
Backport of #10908 to `release-v0.18`.

OpenSSL 4.0 makes `X509_get_subject_name()` return a
`const X509_NAME *`.