### PR TITLE
cryptonote_core: cache NIC verified HF version in mempool

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -172,9 +172,12 @@ struct txpool_tx_meta_t
   uint8_t is_forwarding: 1;
   uint8_t bf_padding: 3;
 
-  uint8_t padding[44]; // til 160 bytes
+  uint8_t padding[43]; // til 159 bytes
 
-  // If non-null, this verification ID is set for this tx only when some mixring passed ver_input_proofs_rings()
+  //! If non-zero, this is set to the HF major version for which this tx passes ver_non_input_consensus()
+  uint8_t nic_verified_hf_version;
+
+  //! If non-null, this verification ID is set for this tx only when some mixring passed ver_input_proofs_rings()
   crypto::hash valid_input_verification_id;
 
   // 192 bytes total
@@ -192,6 +195,7 @@ struct txpool_tx_meta_t
   }
 };
 static_assert(sizeof(txpool_tx_meta_t) == 192, "possible DB migration needed for changes to txpool_tx_meta_t");
+static_assert(offsetof(txpool_tx_meta_t, nic_verified_hf_version) == 159, "NIC verified HF version wrong offset");
 static_assert(offsetof(txpool_tx_meta_t, valid_input_verification_id) == 160, "verif ID wrong alignment");
 
 #define DBF_SAFE       1

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -194,6 +194,7 @@
 #define HF_VERSION_BULLETPROOF_PLUS             15
 #define HF_VERSION_VIEW_TAGS                    15
 #define HF_VERSION_2021_SCALING                 15
+#define MAX_HF_VERSION                          16
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 #define CRYPTONOTE_SCALING_2021_FEE_ROUNDING_PLACES 2

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1671,9 +1671,8 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
 
   CHECK_AND_ASSERT_MES(diffic, false, "difficulty overhead.");
 
-  size_t txs_weight;
-  uint64_t fee;
-  if (!m_tx_pool.fill_block_template(b, median_weight, already_generated_coins, txs_weight, fee, expected_reward, b.major_version))
+  std::vector<tx_block_template_backlog_entry> selected_backlog;
+  if (!m_tx_pool.get_block_template_backlog(median_weight, already_generated_coins, b.major_version, selected_backlog))
   {
     return false;
   }
@@ -1731,6 +1730,21 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
       ", fee " << fee);
 #endif
 
+  // collect TXID list and total stats
+  uint64_t txs_weight = 0;
+  uint64_t fee = 0;
+  b.tx_hashes.reserve(selected_backlog.size());
+  for (const tx_block_template_backlog_entry &e : selected_backlog)
+  {
+    CHECK_AND_ASSERT_MES(std::numeric_limits<uint64_t>::max() - e.weight >= txs_weight,
+      false, "Overflow in block weight calculation");
+    CHECK_AND_ASSERT_MES(std::numeric_limits<uint64_t>::max() - e.fee >= fee,
+      false, "Overflow in block total fee calculation");
+    txs_weight += e.weight;
+    fee += e.fee;
+    b.tx_hashes.push_back(e.id);
+  }
+
   /*
    two-phase miner transaction generation: we don't know exact block weight until we prepare block, but we don't know reward until we know
    block weight, so first miner transaction generated with fake amount of money, and with phase we know think we know expected block weight
@@ -1738,18 +1752,33 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
   //make blocks coin-base tx looks close to real coinbase tx to get truthful blob weight
   uint8_t hf_version = b.major_version;
   size_t max_outs = hf_version >= 4 ? 1 : 11;
-  bool r = construct_miner_tx(height, median_weight, already_generated_coins, txs_weight, fee, miner_address, b.miner_tx, ex_nonce, max_outs, hf_version);
-  CHECK_AND_ASSERT_MES(r, false, "Failed to construct miner tx, first chance");
-  cumulative_weight = txs_weight + get_transaction_weight(b.miner_tx);
+  cumulative_weight = txs_weight;
 #if defined(DEBUG_CREATE_BLOCK_TEMPLATE)
   MDEBUG("Creating block template: miner tx weight " << get_transaction_weight(b.miner_tx) <<
       ", cumulative weight " << cumulative_weight);
 #endif
   for (size_t try_count = 0; try_count != 10; ++try_count)
   {
-    r = construct_miner_tx(height, median_weight, already_generated_coins, cumulative_weight, fee, miner_address, b.miner_tx, ex_nonce, max_outs, hf_version);
+    const bool miner_tx_made = construct_miner_tx(height, median_weight, already_generated_coins,
+      cumulative_weight, fee, miner_address, b.miner_tx, ex_nonce, max_outs, hf_version);
 
-    CHECK_AND_ASSERT_MES(r, false, "Failed to construct miner tx, second chance");
+    // On miner tx creation failure, if we have txs to pop, try that...
+    if (!miner_tx_made)
+    {
+      CHECK_AND_ASSERT_MES(!b.tx_hashes.empty(),
+        false, "Failed to create miner transaction, but have no non-miner txs to pop");
+      b.tx_hashes.pop_back();
+      assert(selected_backlog.size() == b.tx_hashes.size());
+      const tx_block_template_backlog_entry &backlog_entry = selected_backlog.back();
+      assert(txs_weight >= backlog_entry.weight);
+      txs_weight -= backlog_entry.weight;
+      assert(fee >= backlog_entry.fee);
+      fee -= backlog_entry.fee;
+      selected_backlog.pop_back();
+      cumulative_weight = txs_weight;
+      continue;
+    }
+
     size_t coinbase_weight = get_transaction_weight(b.miner_tx);
     if (coinbase_weight > cumulative_weight - txs_weight)
     {
@@ -1791,6 +1820,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
         ", cumulative weight " << cumulative_weight << " is now good");
 #endif
 
+    expected_reward = get_outs_money_amount(b.miner_tx);
     if (!from_block)
       cache_block_template(b, miner_address, ex_nonce, diffic, height, expected_reward, cumulative_weight, seed_height, seed_hash, pool_cookie);
     return true;
@@ -1823,9 +1853,7 @@ bool Blockchain::get_miner_data(uint8_t& major_version, uint64_t& height, crypto
   median_weight = m_current_block_cumul_weight_median;
   already_generated_coins = m_db->get_block_already_generated_coins(height - 1);
 
-  m_tx_pool.get_block_template_backlog(tx_backlog);
-
-  return true;
+  return m_tx_pool.get_block_template_backlog(median_weight, already_generated_coins, major_version, tx_backlog);
 }
 //------------------------------------------------------------------
 // for an alternate chain, get the timestamps from the main chain to complete
@@ -5562,8 +5590,8 @@ bool Blockchain::for_all_outputs(uint64_t amount, std::function<bool(uint64_t he
 
 void Blockchain::invalidate_block_template_cache()
 {
-  MDEBUG("Invalidating block template cache");
-  m_btc_valid = false;
+  if (std::exchange(m_btc_valid, false))
+    MDEBUG("Invalidating block template cache");
 }
 
 void Blockchain::cache_block_template(const block &b, const cryptonote::account_public_address &address, const blobdata &nonce, const difficulty_type &diff, uint64_t height, uint64_t expected_reward, uint64_t cumulative_weight, uint64_t seed_height, const crypto::hash &seed_hash, uint64_t pool_cookie)
@@ -5592,7 +5620,14 @@ void Blockchain::send_miner_notifications(uint64_t height, const crypto::hash &s
   const uint64_t median_weight = m_current_block_cumul_weight_median;
 
   std::vector<tx_block_template_backlog_entry> tx_backlog;
-  m_tx_pool.get_block_template_backlog(tx_backlog);
+  if (!m_tx_pool.get_block_template_backlog(median_weight, already_generated_coins, major_version, tx_backlog))
+  {
+    MERROR("Could not retreive mempool's block template backlog for block " << height
+      << ": median weight " << median_weight << " already generated coins "
+      << already_generated_coins << " major version " << major_version
+      << ". Miner notifications will not be sent.");
+    return;
+  }
 
   for (const auto& notifier : m_miner_notifiers)
   {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -86,6 +86,9 @@ DISABLE_VS_WARNINGS(4267)
 // used to overestimate the block reward when estimating a per kB to use
 #define BLOCK_REWARD_OVERESTIMATE (10 * 1000000000000)
 
+/// @brief Parameter for block template backlog fetching: targets total weight 112.5% of the block's limit
+#define DEFAULT_RPC_TX_BACKLOG_OVERPICK 0.125f
+
 //------------------------------------------------------------------
 Blockchain::Blockchain(tx_memory_pool& tx_pool) :
   m_db(), m_tx_pool(tx_pool), m_hardfork(NULL), m_timestamps_and_difficulties_height(0), m_reset_timestamps_and_difficulties_height(true), m_current_block_cumul_weight_limit(0), m_current_block_cumul_weight_median(0),
@@ -1672,7 +1675,8 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
   CHECK_AND_ASSERT_MES(diffic, false, "difficulty overhead.");
 
   std::vector<tx_block_template_backlog_entry> selected_backlog;
-  if (!m_tx_pool.get_block_template_backlog(median_weight, already_generated_coins, b.major_version, selected_backlog))
+  if (!m_tx_pool.get_block_template_backlog(median_weight, already_generated_coins,
+    b.major_version, /*overpick=*/0, selected_backlog))
   {
     return false;
   }
@@ -1853,7 +1857,8 @@ bool Blockchain::get_miner_data(uint8_t& major_version, uint64_t& height, crypto
   median_weight = m_current_block_cumul_weight_median;
   already_generated_coins = m_db->get_block_already_generated_coins(height - 1);
 
-  return m_tx_pool.get_block_template_backlog(median_weight, already_generated_coins, major_version, tx_backlog);
+  return m_tx_pool.get_block_template_backlog(median_weight, already_generated_coins, major_version,
+    DEFAULT_RPC_TX_BACKLOG_OVERPICK, tx_backlog);
 }
 //------------------------------------------------------------------
 // for an alternate chain, get the timestamps from the main chain to complete
@@ -5618,14 +5623,16 @@ void Blockchain::send_miner_notifications(uint64_t height, const crypto::hash &s
   const uint8_t major_version = m_hardfork->get_ideal_version(height);
   const difficulty_type diff = get_difficulty_for_next_block();
   const uint64_t median_weight = m_current_block_cumul_weight_median;
+  const float overpick = DEFAULT_RPC_TX_BACKLOG_OVERPICK;
 
   std::vector<tx_block_template_backlog_entry> tx_backlog;
-  if (!m_tx_pool.get_block_template_backlog(median_weight, already_generated_coins, major_version, tx_backlog))
+  if (!m_tx_pool.get_block_template_backlog(median_weight, already_generated_coins, major_version,
+    overpick, tx_backlog))
   {
     MERROR("Could not retreive mempool's block template backlog for block " << height
       << ": median weight " << median_weight << " already generated coins "
       << already_generated_coins << " major version " << major_version
-      << ". Miner notifications will not be sent.");
+      << " overpick ratio " << overpick << ". Miner notifications will not be sent.");
     return;
   }
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -719,13 +719,6 @@ block Blockchain::pop_block_from_blockchain(bool keep_txs)
   m_tx_pool.on_blockchain_dec(top_block_height, top_block_hash);
   invalidate_block_template_cache();
 
-  const uint8_t new_hf_version = get_current_hard_fork_version();
-  if (new_hf_version != previous_hf_version)
-  {
-    MINFO("Validating txpool for v" << (unsigned)new_hf_version);
-    m_tx_pool.validate(new_hf_version);
-  }
-
   return popped_block;
 }
 //------------------------------------------------------------------
@@ -3910,11 +3903,13 @@ bool Blockchain::flush_txes_from_pool(const std::vector<crypto::hash> &txids)
     cryptonote::blobdata txblob;
     size_t tx_weight;
     uint64_t fee;
+    uint8_t nic_verified_hf_version;
     crypto::hash valid_input_verification_id;
     bool relayed, do_not_relay, double_spend_seen, pruned;
     MINFO("Removing txid " << txid << " from the pool");
     if (m_tx_pool.have_tx(txid, relay_category::all) && !m_tx_pool.take_tx(txid, tx, txblob,
-      tx_weight, fee, valid_input_verification_id, relayed, do_not_relay, double_spend_seen, pruned))
+      tx_weight, fee, nic_verified_hf_version, valid_input_verification_id, relayed, do_not_relay,
+      double_spend_seen, pruned))
     {
       MERROR("Failed to remove txid " << txid << " from the pool");
       res = false;
@@ -4098,8 +4093,8 @@ leave:
   size_t cumulative_block_weight = coinbase_weight;
 
   std::vector<std::pair<transaction, blobdata>> txs;
-  //                          txid     weight mempool?  verID
-  std::vector<std::tuple<crypto::hash, size_t, bool, crypto::hash>> txs_meta;
+  //                          txid     weight mempool? NIC HF  verID
+  std::vector<std::tuple<crypto::hash, size_t, bool, uint8_t, crypto::hash>> txs_meta;
 
   // This will be the data sent to the ZMQ pool listeners for txs which skipped the mempool
   std::vector<txpool_event> txpool_events;
@@ -4124,7 +4119,8 @@ leave:
       const crypto::hash &txid = std::get<0>(txs_meta[i]);
       const blobdata &tx_blob = txs[i].second;
       const size_t tx_weight = std::get<1>(txs_meta[i]);
-      const crypto::hash &valid_input_verification_id = std::get<3>(txs_meta[i]);
+      const uint8_t nic_verified_hf_version = std::get<3>(txs_meta[i]);
+      const crypto::hash &valid_input_verification_id = std::get<4>(txs_meta[i]);
 
       // We assume that if they were in a block, the transactions are already known to the network
       // as a whole. However, if we had mined that block, that might not be always true. Unlikely
@@ -4135,7 +4131,7 @@ leave:
       // version, we can return it without re-verifying the consensus rules on it.
       cryptonote::tx_verification_context tvc{};
       if (!m_tx_pool.add_tx(tx, txid, tx_blob, tx_weight, tvc, relay_method::block, true,
-          hf_version, hf_version, valid_input_verification_id))
+          hf_version, nic_verified_hf_version, valid_input_verification_id))
         MERROR("Failed to return taken transaction with hash: " << txid << " to tx_pool");
     }
   };
@@ -4187,6 +4183,7 @@ leave:
     blobdata &txblob = txs.back().second;
     size_t tx_weight{};
     uint64_t fee{};
+    uint8_t nic_verified_hf_version{};
     crypto::hash valid_input_verification_id{};
     bool pruned{};
 
@@ -4198,7 +4195,7 @@ leave:
      */
     bool _unused1, _unused2, _unused3;
     const bool found_tx_in_pool{
-        m_tx_pool.take_tx(tx_id, tx, txblob, tx_weight, fee, valid_input_verification_id,
+        m_tx_pool.take_tx(tx_id, tx, txblob, tx_weight, fee, nic_verified_hf_version, valid_input_verification_id,
           _unused1, _unused2, _unused3, pruned, /*suppress_missing_msgs=*/true)
       };
     bool find_tx_failure{!found_tx_in_pool};
@@ -4211,6 +4208,7 @@ leave:
         txblob = std::move(extra_txs_it->second.second);
         tx_weight = tx.pruned ? get_pruned_transaction_weight(tx) : get_transaction_weight(tx, txblob.size());
         fee = get_tx_fee(tx);
+        nic_verified_hf_version = fast_check ? 0 : hf_version; // see above invocation of ver_non_input_consensus()
         pruned = tx.pruned;
         extra_block_txs.erase(extra_txs_it);
         txpool_events.emplace_back(txpool_event{tx, tx_id, txblob.size(), tx_weight, true});
@@ -4244,7 +4242,7 @@ leave:
     // add the transaction to the temp list of transactions, so we can either
     // store the list of transactions all at once or return the ones we've
     // taken from the tx_pool back to it if the block fails verification.
-    txs_meta.emplace_back(tx_id, tx_weight, found_tx_in_pool, valid_input_verification_id);
+    txs_meta.emplace_back(tx_id, tx_weight, found_tx_in_pool, nic_verified_hf_version, valid_input_verification_id);
     TIME_MEASURE_START(dd);
 
     // FIXME: the storage should not be responsible for validation.
@@ -4268,15 +4266,33 @@ leave:
     if (!fast_check)
 #endif
     {
-      // validate that transaction inputs and the keys spending them are correct.
-      tx_verification_context tvc;
-      if(!check_tx_inputs(tx, tvc, valid_input_verification_id))
-      {
-        MERROR_VER("Block with id: " << id  << " has at least one transaction (id: " << tx_id << ") with wrong inputs.");
+      tx_verification_context tvc{};
+      bool valid = true;
 
+      // we may need to check NIC rules again after handling alt blocks or after upgrading fork versions
+      assert(hf_version);
+      if (nic_verified_hf_version != hf_version)
+      {
+        if (!ver_non_input_consensus(tx, tvc, hf_version))
+        {
+          valid = false;
+          MERROR_VER("Block with id: " << id  << " has at least one transaction (id: "
+            << tx_id << ") which breaks non-input consensus rules.");
+        }
+      }
+
+      // validate that transaction inputs and the keys spending them are correct.
+      if (valid && !check_tx_inputs(tx, tvc, valid_input_verification_id))
+      {
+        valid = false;
+        MERROR_VER("Block with id: " << id  << " has at least one transaction (id: " << tx_id << ") with wrong inputs.");
+      }
+
+      if (!valid || tvc.m_verifivation_failed)
+      {
         //TODO: why is this done?  make sure that keeping invalid blocks makes sense.
         add_block_as_invalid(bl, id);
-        MERROR_VER("Block with id " << id << " added as invalid because of wrong inputs in transactions");
+        MERROR_VER("Block with id " << id << " added as invalid because of one or more invalid transactions");
         bvc.m_verifivation_failed = true;
         return_txs_to_pool();
         return false;
@@ -4391,19 +4407,6 @@ leave:
   m_tx_pool.on_blockchain_inc(new_height, id);
   get_difficulty_for_next_block(); // just to cache it
   invalidate_block_template_cache();
-
-  const uint8_t new_hf_version = get_current_hard_fork_version();
-  if (new_hf_version != hf_version)
-  {
-    // the genesis block is added before everything's setup, and the txpool is empty
-    // when we start from scratch, so we skip this
-    const bool is_genesis_block = new_height == 1;
-    if (!is_genesis_block)
-    {
-      MGINFO("Validating txpool for v" << (unsigned)new_hf_version);
-      m_tx_pool.validate(new_hf_version);
-    }
-  }
 
   const crypto::hash seedhash = get_block_id_by_height(crypto::rx_seedheight(new_height));
 

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -1519,9 +1519,13 @@ namespace cryptonote
   bool tx_memory_pool::get_block_template_backlog(size_t median_weight,
     uint64_t already_generated_coins,
     uint8_t version/*AKA hf_version*/,
+    float overpick,
     std::vector<tx_block_template_backlog_entry> &selected_backlog)
   {
     selected_backlog.clear();
+
+    CHECK_AND_ASSERT_MES(overpick >= 0, false, "Block template blocklog overpick cannot be negative");
+    CHECK_AND_ASSERT_MES(overpick <= 100, false, "Block template blocklog overpick should be less than 10000%");
 
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     CRITICAL_REGION_LOCAL1(m_blockchain);
@@ -1540,7 +1544,9 @@ namespace cryptonote
     static_assert(MAX_HF_VERSION == 16, "Check below weights and limits");
     const size_t max_total_weight_pre_v5 = (130 * median_weight) / 100;
     const size_t max_total_weight_v5 = 2 * median_weight;
-    const size_t max_total_weight = version >= 5 ? max_total_weight_v5 : max_total_weight_pre_v5;
+    const size_t consensus_max_total_weight = version >= 5 ? max_total_weight_v5 : max_total_weight_pre_v5;
+    const size_t max_total_weight = consensus_max_total_weight
+      + static_cast<size_t>(overpick * consensus_max_total_weight);
     const uint64_t reference_tx_weight = DYNAMIC_FEE_REFERENCE_TRANSACTION_WEIGHT;
     constexpr size_t min_tx_size_approx = 1200;
 
@@ -1580,7 +1586,7 @@ namespace cryptonote
         continue;
       }
 
-      // Can not exceed maximum block weight
+      // Cannot exceed max weight limit we set (may be greater than the block weight limit, depending on `overpick`)
       if (max_total_weight < total_weight + meta.weight)
       {
         LOG_PRINT_L2("  would exceed maximum block weight");
@@ -1590,8 +1596,7 @@ namespace cryptonote
           break; // stop searching once the block is reasonably full, since next txs will have worse fee per weight
       }
 
-      // start using the optimal filling algorithm from v5
-      if (version >= 5)
+      if (0 == overpick)
       {
         // If we're getting lower coinbase tx,
         // stop including more tx
@@ -1605,16 +1610,6 @@ namespace cryptonote
         if (coinbase < best_coinbase)
         {
           LOG_PRINT_L2("  would decrease coinbase to " << print_money(coinbase));
-          break;
-        }
-      }
-      else
-      {
-        // If we've exceeded the penalty free weight,
-        // stop including more tx
-        if (total_weight > median_weight)
-        {
-          LOG_PRINT_L2("  would exceed median block weight");
           break;
         }
       }
@@ -1651,7 +1646,7 @@ namespace cryptonote
         continue;
       }
 
-      // test key images do not conflict w/ other txs' key images in the template
+      // Test key images do not conflict w/ other txs' key images in the template
       std::unordered_set<crypto::key_image> tx_k_images;
       const auto tx_ki_range = m_spent_key_images.right.equal_range(txid);
       bool has_ki_conflict = false;

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -107,11 +107,6 @@ namespace cryptonote
       return d;
     }
 
-    uint64_t template_accept_threshold(uint64_t amount)
-    {
-      return amount * ACCEPT_THRESHOLD;
-    }
-
     // external lock must be held for the comparison+set to work properly
     void set_if_less(std::atomic<time_t>& next_check, const time_t candidate) noexcept
     {
@@ -478,24 +473,33 @@ namespace cryptonote
     for(const auto& in: tx.vin)
     {
       CHECKED_GET_SPECIFIC_VARIANT(in, const txin_to_key, txin, false);
-      std::unordered_set<crypto::hash>& kei_image_set = m_spent_key_images[txin.k_image];
+      auto txs_for_ki = m_spent_key_images.left.equal_range(txin.k_image);
+
+      //! @TODO: does a linear search to find a matching tx for given KI. Fine in 99% of cases, but may be DDoS-able
+      bool this_tx_for_ki_existed = false;
+      size_t n_txs_for_ki = 0;
+      for (auto it = txs_for_ki.first; it != txs_for_ki.second; ++it, ++n_txs_for_ki)
+        if (it->second == id)
+          this_tx_for_ki_existed = true;
+      const bool other_tx_for_ki_existed = n_txs_for_ki > 1 || (n_txs_for_ki == 1 && !this_tx_for_ki_existed);
 
       // Only allow multiple txes per key-image if kept-by-block. Only allow
       // the same txid if going from local/stem->fluff.
 
       if (tx_relay != relay_method::block)
       {
-        const bool one_txid =
-          (kei_image_set.empty() || (kei_image_set.size() == 1 && *(kei_image_set.cbegin()) == id));
-        CHECK_AND_ASSERT_MES(one_txid, false, "internal error: tx_relay=" << unsigned(tx_relay)
-                                           << ", kei_image_set.size()=" << kei_image_set.size() << ENDL << "txin.k_image=" << txin.k_image << ENDL
+        CHECK_AND_ASSERT_MES(!other_tx_for_ki_existed, false, "internal error: tx_relay=" << unsigned(tx_relay)
+                                           << ", n_txs_for_ki=" << n_txs_for_ki << ENDL << "txin.k_image=" << txin.k_image << ENDL
                                            << "tx_id=" << id);
       }
 
-      const bool new_or_previously_private =
-        kei_image_set.insert(id).second ||
-        !m_blockchain.txpool_tx_matches_category(id, relay_category::legacy);
-      CHECK_AND_ASSERT_MES(new_or_previously_private, false, "internal error: try to insert duplicate iterator in key_image set");
+      if (this_tx_for_ki_existed)
+      {
+        const bool previously_private = !m_blockchain.txpool_tx_matches_category(id, relay_category::legacy);
+        CHECK_AND_ASSERT_MES(previously_private, false, "internal error: try to insert duplicate iterator in key_image set");
+      }
+      else
+        m_spent_key_images.insert(key_images_container::value_type(txin.k_image, id));
     }
     ++m_cookie;
     return true;
@@ -508,28 +512,12 @@ namespace cryptonote
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     CRITICAL_REGION_LOCAL1(m_blockchain);
-    // ND: Speedup
-    for(const txin_v& vi: tx.vin)
-    {
-      CHECKED_GET_SPECIFIC_VARIANT(vi, const txin_to_key, txin, false);
-      auto it = m_spent_key_images.find(txin.k_image);
-      CHECK_AND_ASSERT_MES(it != m_spent_key_images.end(), false, "failed to find transaction input in key images. img=" << txin.k_image << ENDL
-                                    << "transaction id = " << actual_hash);
-      std::unordered_set<crypto::hash>& key_image_set =  it->second;
-      CHECK_AND_ASSERT_MES(key_image_set.size(), false, "empty key_image set, img=" << txin.k_image << ENDL
-        << "transaction id = " << actual_hash);
 
-      auto it_in_set = key_image_set.find(actual_hash);
-      CHECK_AND_ASSERT_MES(it_in_set != key_image_set.end(), false, "transaction id not found in key_image set, img=" << txin.k_image << ENDL
-        << "transaction id = " << actual_hash);
-      key_image_set.erase(it_in_set);
-      if(!key_image_set.size())
-      {
-        //it is now empty hash container for this key_image
-        m_spent_key_images.erase(it);
-      }
+    const size_t n_kis_erased = m_spent_key_images.right.erase(actual_hash);
+    CHECK_AND_ASSERT_MES(n_kis_erased == tx.vin.size(), false,
+      "Erased wrong number of TXID<->KI entries in in-memory cache for TXID" << actual_hash
+      << ". Expected " << tx.vin.size() << " vs actual " << n_kis_erased);
 
-    }
     ++m_cookie;
     return true;
   }
@@ -1091,67 +1079,6 @@ namespace cryptonote
     }, false, category);
   }
   //------------------------------------------------------------------
-  void tx_memory_pool::get_block_template_backlog(std::vector<tx_block_template_backlog_entry>& backlog, bool include_sensitive) const
-  {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
-
-    std::vector<tx_block_template_backlog_entry> tmp;
-    uint64_t total_weight = 0;
-
-    // First get everything from the mempool, filter it later
-    m_blockchain.for_all_txpool_txes([&tmp, &total_weight](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref*){
-      tmp.emplace_back(tx_block_template_backlog_entry{txid, meta.weight, meta.fee});
-      total_weight += meta.weight;
-      return true;
-    }, false, include_sensitive ? relay_category::all : relay_category::broadcasted);
-
-    // Limit backlog to 112.5% of current median weight. This is enough to mine a full block with the optimal block reward
-    const uint64_t median_weight = m_blockchain.get_current_cumulative_block_weight_median();
-    const uint64_t max_backlog_weight = median_weight + (median_weight / 8);
-
-    // If the total weight is too high, choose the best paying transactions
-    if (total_weight > max_backlog_weight)
-      std::stable_sort(tmp.begin(), tmp.end(), [](const auto& a, const auto& b){ return a.fee * b.weight > b.fee * a.weight; });
-
-    backlog.clear();
-    uint64_t w = 0;
-
-    std::unordered_set<crypto::key_image> k_images;
-
-    for (const tx_block_template_backlog_entry& e : tmp)
-    {
-      try
-      {
-        txpool_tx_meta_t meta;
-        if (!m_blockchain.get_txpool_tx_meta(e.id, meta))
-          continue;
-
-        cryptonote::blobdata txblob;
-        if (!m_blockchain.get_txpool_tx_blob(e.id, txblob, relay_category::all))
-          continue;
-
-        cryptonote::transaction tx;
-        if (is_transaction_ready_to_go(meta, e.id, txblob, tx))
-        {
-          if (have_key_images(k_images, tx))
-            continue;
-          append_key_images(k_images, tx);
-
-          backlog.push_back(e);
-          w += e.weight;
-          if (w > max_backlog_weight)
-            break;
-        }
-      }
-      catch (const std::exception &e)
-      {
-        MERROR("Failed to check transaction readiness: " << e.what());
-        // continue, not fatal
-      }
-    }
-  }
-  //------------------------------------------------------------------
   void tx_memory_pool::get_transaction_stats(struct txpool_stats& stats, bool include_sensitive) const
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
@@ -1279,13 +1206,16 @@ namespace cryptonote
       return true;
     }, true, category);
 
-    for (const key_images_container::value_type& kee : m_spent_key_images) {
-      const crypto::key_image& k_image = kee.first;
-      const std::unordered_set<crypto::hash>& kei_image_set = kee.second;
+    for (auto ki_it = m_spent_key_images.left.begin(); ki_it != m_spent_key_images.left.end();) {
+      const crypto::key_image& k_image = ki_it->first;
+      const auto ki_range = m_spent_key_images.left.equal_range(k_image);
+      assert(ki_range.first == ki_it);
+      assert(ki_range.first != ki_range.second);
       spent_key_image_info ki;
       ki.id_hash = epee::string_tools::pod_to_hex(k_image);
-      for (const crypto::hash& tx_id_hash : kei_image_set)
+      for (; ki_it != ki_range.second; ++ki_it)
       {
+        const crypto::hash &tx_id_hash = ki_it->second;
         if (m_blockchain.txpool_tx_matches_category(tx_id_hash, category))
           ki.txs_hashes.push_back(epee::string_tools::pod_to_hex(tx_id_hash));
       }
@@ -1332,17 +1262,22 @@ namespace cryptonote
       return true;
     }, true, relay_category::broadcasted);
 
-    for (const key_images_container::value_type& kee : m_spent_key_images) {
+    for (auto ki_it = m_spent_key_images.left.begin(); ki_it != m_spent_key_images.left.end();) {
+      const crypto::key_image& k_image = ki_it->first;
+      const auto ki_range = m_spent_key_images.left.equal_range(k_image);
+      assert(ki_range.first == ki_it);
+      assert(ki_range.first != ki_range.second);
       std::vector<crypto::hash> tx_hashes;
-      const std::unordered_set<crypto::hash>& kei_image_set = kee.second;
-      for (const crypto::hash& tx_id_hash : kei_image_set)
+      for (; ki_it != ki_range.second; ++ki_it)
       {
+        const crypto::hash &tx_id_hash = ki_it->second;
         if (m_blockchain.txpool_tx_matches_category(tx_id_hash, relay_category::broadcasted))
           tx_hashes.push_back(tx_id_hash);
       }
 
       if (!tx_hashes.empty())
-        key_image_infos[kee.first] = std::move(tx_hashes);
+        key_image_infos[k_image] = std::move(tx_hashes);
+
     }
     return true;
   }
@@ -1357,12 +1292,9 @@ namespace cryptonote
     for (const auto& image : key_images)
     {
       bool is_spent = false;
-      const auto found = m_spent_key_images.find(image);
-      if (found != m_spent_key_images.end())
-      {
-        for (const crypto::hash& tx_hash : found->second)
-          is_spent |= m_blockchain.txpool_tx_matches_category(tx_hash, relay_category::broadcasted);
-      }
+      const auto ki_range = m_spent_key_images.left.equal_range(image);
+      for (auto ki_it = ki_range.first; ki_it != ki_range.second; ++ki_it)
+        is_spent |= m_blockchain.txpool_tx_matches_category(ki_it->second, relay_category::broadcasted);
       spent.push_back(is_spent);
     }
 
@@ -1422,14 +1354,13 @@ namespace cryptonote
   bool tx_memory_pool::have_tx_keyimg_as_spent(const crypto::key_image& key_im, const crypto::hash& txid) const
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
-    const auto found = m_spent_key_images.find(key_im);
-    if (found != m_spent_key_images.end() && !found->second.empty())
+    const auto ki_range = m_spent_key_images.left.equal_range(key_im);
+    for (auto ki_it = ki_range.first; ki_it != ki_range.second; ++ki_it)
     {
       // If another tx is using the key image, always return as spent.
       // See `insert_key_images`.
-      if (1 < found->second.size() || *(found->second.cbegin()) != txid)
+      if (ki_it->second != txid || m_blockchain.txpool_tx_matches_category(txid, relay_category::legacy))
         return true;
-      return m_blockchain.txpool_tx_matches_category(txid, relay_category::legacy);
     }
     return false;
   }
@@ -1469,27 +1400,23 @@ namespace cryptonote
     return ret;
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::is_transaction_ready_to_go(txpool_tx_meta_t& txd, const crypto::hash &txid, const cryptonote::blobdata_ref& txblob, transaction &tx) const
+  bool tx_memory_pool::is_transaction_ready_to_go(txpool_tx_meta_t& txd, const crypto::hash &txid) const
   {
-    struct transaction_parser
+    // NOTE: needs blockchain lock to be held
+
+    auto lazy_tx = [this, &txid, tx = transaction(), parsed = false]() mutable
+      -> transaction&
     {
-      transaction_parser(const cryptonote::blobdata_ref &txblob, const crypto::hash &txid, transaction &tx): txblob(txblob), txid(txid), tx(tx), parsed(false) {}
-      cryptonote::transaction &operator()()
+      if (!parsed)
       {
-        if (!parsed)
-        {
-          if (!parse_and_validate_tx_from_blob(txblob, tx))
-            throw std::runtime_error("failed to parse transaction blob");
-          tx.set_hash(txid);
-          parsed = true;
-        }
-        return tx;
+        const cryptonote::blobdata txblob = this->m_blockchain.get_txpool_tx_blob(txid, relay_category::all);
+        if (!parse_and_validate_tx_from_blob(txblob, tx))
+          throw std::runtime_error("failed to parse transaction blob");
+        tx.set_hash(txid);
+        parsed = true;
       }
-      const cryptonote::blobdata_ref &txblob;
-      const crypto::hash &txid;
-      transaction &tx;
-      bool parsed;
-    } lazy_tx(txblob, txid, tx);
+      return tx;
+    };
 
     const std::uint64_t top_block_height{m_blockchain.get_current_blockchain_height() - 1};
     const crypto::hash top_block_hash{m_blockchain.get_block_id_by_height(top_block_height)};
@@ -1514,33 +1441,6 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::is_transaction_ready_to_go(txpool_tx_meta_t& txd, const crypto::hash &txid, const cryptonote::blobdata& txblob, transaction &tx) const
-  {
-    return is_transaction_ready_to_go(txd, txid, cryptonote::blobdata_ref{txblob.data(), txblob.size()}, tx);
-  }
-  //---------------------------------------------------------------------------------
-  bool tx_memory_pool::have_key_images(const std::unordered_set<crypto::key_image>& k_images, const transaction_prefix& tx)
-  {
-    for(size_t i = 0; i!= tx.vin.size(); i++)
-    {
-      CHECKED_GET_SPECIFIC_VARIANT(tx.vin[i], const txin_to_key, itk, false);
-      if(k_images.count(itk.k_image))
-        return true;
-    }
-    return false;
-  }
-  //---------------------------------------------------------------------------------
-  bool tx_memory_pool::append_key_images(std::unordered_set<crypto::key_image>& k_images, const transaction_prefix& tx)
-  {
-    for(size_t i = 0; i!= tx.vin.size(); i++)
-    {
-      CHECKED_GET_SPECIFIC_VARIANT(tx.vin[i], const txin_to_key, itk, false);
-      auto i_res = k_images.insert(itk.k_image);
-      CHECK_AND_ASSERT_MES(i_res.second, false, "internal error: key images pool cache - inserted duplicate image in set: " << itk.k_image);
-    }
-    return true;
-  }
-  //---------------------------------------------------------------------------------
   void tx_memory_pool::mark_double_spend(const transaction &tx)
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
@@ -1550,11 +1450,10 @@ namespace cryptonote
     for(size_t i = 0; i!= tx.vin.size(); i++)
     {
       CHECKED_GET_SPECIFIC_VARIANT(tx.vin[i], const txin_to_key, itk, void());
-      const key_images_container::const_iterator it = m_spent_key_images.find(itk.k_image);
-      if (it != m_spent_key_images.end())
+      const auto ki_range = m_spent_key_images.left.equal_range(itk.k_image);
+      for (auto ki_it = ki_range.first; ki_it != ki_range.second; ++ki_it)
       {
-        for (const crypto::hash &txid: it->second)
-        {
+          const crypto::hash &txid = ki_it->second;
           txpool_tx_meta_t meta;
           if (!m_blockchain.get_txpool_tx_meta(txid, meta))
           {
@@ -1577,7 +1476,6 @@ namespace cryptonote
               // continue, not fatal
             }
           }
-        }
       }
     }
     lock.commit();
@@ -1618,14 +1516,19 @@ namespace cryptonote
   }
   //---------------------------------------------------------------------------------
   //TODO: investigate whether boolean return is appropriate
-  bool tx_memory_pool::fill_block_template(block &bl, size_t median_weight, uint64_t already_generated_coins, size_t &total_weight, uint64_t &fee, uint64_t &expected_reward, uint8_t version)
+  bool tx_memory_pool::get_block_template_backlog(size_t median_weight,
+    uint64_t already_generated_coins,
+    uint8_t version/*AKA hf_version*/,
+    std::vector<tx_block_template_backlog_entry> &selected_backlog)
   {
+    selected_backlog.clear();
+
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     CRITICAL_REGION_LOCAL1(m_blockchain);
 
     uint64_t best_coinbase = 0, coinbase = 0;
-    total_weight = 0;
-    fee = 0;
+    uint64_t total_weight = 0;
+    uint64_t fee = 0;
     
     //baseline empty block
     if (!get_block_reward(median_weight, total_weight, already_generated_coins, best_coinbase, version))
@@ -1634,10 +1537,15 @@ namespace cryptonote
       return false;
     }
 
+    static_assert(MAX_HF_VERSION == 16, "Check below weights and limits");
+    const size_t max_total_weight_pre_v5 = (130 * median_weight) / 100;
+    const size_t max_total_weight_v5 = 2 * median_weight;
+    const size_t max_total_weight = version >= 5 ? max_total_weight_v5 : max_total_weight_pre_v5;
+    const uint64_t reference_tx_weight = DYNAMIC_FEE_REFERENCE_TRANSACTION_WEIGHT;
+    constexpr size_t min_tx_size_approx = 1200;
 
-    size_t max_total_weight_pre_v5 = (130 * median_weight) / 100 - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE;
-    size_t max_total_weight_v5 = 2 * median_weight - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE;
-    size_t max_total_weight = version >= 5 ? max_total_weight_v5 : max_total_weight_pre_v5;
+    selected_backlog.reserve(std::min<size_t>(2 * median_weight / min_tx_size_approx, CRYPTONOTE_MAX_TX_PER_BLOCK));
+
     std::unordered_set<crypto::key_image> k_images;
 
     LOG_PRINT_L2("Filling block template, median weight " << median_weight << ", " << m_txs_by_fee_and_receive_time.size() << " txes in the pool");
@@ -1647,16 +1555,19 @@ namespace cryptonote
     auto sorted_it = m_txs_by_fee_and_receive_time.begin();
     for (; sorted_it != m_txs_by_fee_and_receive_time.end(); ++sorted_it)
     {
+      const crypto::hash &txid = sorted_it->get_right();
       txpool_tx_meta_t meta;
-      if (!m_blockchain.get_txpool_tx_meta(sorted_it->get_right(), meta))
+      if (!m_blockchain.get_txpool_tx_meta(txid, meta))
       {
         static bool warned = false;
         if (!warned)
-          MERROR("  failed to find tx meta: " << sorted_it->get_right() << " (will only print once)");
+          MERROR("  failed to find tx meta: " << txid << " (will only print once)");
         warned = true;
         continue;
       }
-      LOG_PRINT_L2("Considering " << sorted_it->get_right() << ", weight " << meta.weight << ", current block weight " << total_weight << "/" << max_total_weight << ", current coinbase " << print_money(best_coinbase) << ", relay method " << (unsigned)meta.get_relay_method());
+      LOG_PRINT_L2("Considering " << txid << ", weight " << meta.weight << ", current block weight "
+        << total_weight << "/" << max_total_weight << ", current coinbase "
+        << print_money(best_coinbase) << ", relay method " << (unsigned)meta.get_relay_method());
 
       if (!meta.matches(relay_category::legacy) && !(m_mine_stem_txes && meta.get_relay_method() == relay_method::stem))
       {
@@ -1673,7 +1584,10 @@ namespace cryptonote
       if (max_total_weight < total_weight + meta.weight)
       {
         LOG_PRINT_L2("  would exceed maximum block weight");
-        continue;
+        if (selected_backlog.empty() || total_weight + reference_tx_weight < max_total_weight)
+          continue; // there is much room, so even though this tx would breach the limit, maybe next txs will fit
+        else
+          break; // stop searching once the block is reasonably full, since next txs will have worse fee per weight
       }
 
       // start using the optimal filling algorithm from v5
@@ -1685,13 +1599,13 @@ namespace cryptonote
         if(!get_block_reward(median_weight, total_weight + meta.weight, already_generated_coins, block_reward, version))
         {
           LOG_PRINT_L2("  would exceed maximum block weight");
-          continue;
+          break;
         }
         coinbase = block_reward + fee + meta.fee;
-        if (coinbase < template_accept_threshold(best_coinbase))
+        if (coinbase < best_coinbase)
         {
           LOG_PRINT_L2("  would decrease coinbase to " << print_money(coinbase));
-          continue;
+          break;
         }
       }
       else
@@ -1705,11 +1619,6 @@ namespace cryptonote
         }
       }
 
-      // "local" and "stem" txes are filtered above
-      cryptonote::blobdata txblob = m_blockchain.get_txpool_tx_blob(sorted_it->get_right(), relay_category::all);
-
-      cryptonote::transaction tx;
-
       // Skip transactions that are not ready to be
       // included into the blockchain or that are
       // missing key images
@@ -1717,7 +1626,7 @@ namespace cryptonote
       bool ready = false;
       try
       {
-        ready = is_transaction_ready_to_go(meta, sorted_it->get_right(), txblob, tx);
+        ready = is_transaction_ready_to_go(meta, txid);
       }
       catch (const std::exception &e)
       {
@@ -1727,37 +1636,52 @@ namespace cryptonote
       if (memcmp(&original_meta, &meta, sizeof(meta)))
       {
         try
-	{
-	  m_blockchain.update_txpool_tx(sorted_it->get_right(), meta);
-	}
+        {
+          m_blockchain.update_txpool_tx(txid, meta);
+        }
         catch (const std::exception &e)
-	{
-	  MERROR("Failed to update tx meta: " << e.what());
-	  // continue, not fatal
-	}
+        {
+          MERROR("Failed to update tx meta: " << e.what());
+          // continue, not fatal
+        }
       }
       if (!ready)
       {
         LOG_PRINT_L2("  not ready to go");
         continue;
       }
-      if (have_key_images(k_images, tx))
+
+      // test key images do not conflict w/ other txs' key images in the template
+      std::unordered_set<crypto::key_image> tx_k_images;
+      const auto tx_ki_range = m_spent_key_images.right.equal_range(txid);
+      bool has_ki_conflict = false;
+      for (auto ki_it = tx_ki_range.first; ki_it != tx_ki_range.second; ++ki_it)
+      {
+        const crypto::key_image &ki = ki_it->second;
+        if (k_images.count(ki))
+        {
+          has_ki_conflict = true;
+          break;
+        }
+        tx_k_images.insert(ki_it->second);
+      }
+
+      if (has_ki_conflict)
       {
         LOG_PRINT_L2("  key images already seen");
         continue;
       }
 
-      bl.tx_hashes.push_back(sorted_it->get_right());
+      selected_backlog.push_back(tx_block_template_backlog_entry{txid, meta.weight, meta.fee});
       total_weight += meta.weight;
       fee += meta.fee;
       best_coinbase = coinbase;
-      append_key_images(k_images, tx);
+      k_images.merge(tx_k_images);
       LOG_PRINT_L2("  added, new block weight " << total_weight << "/" << max_total_weight << ", coinbase " << print_money(best_coinbase));
     }
     lock.commit();
 
-    expected_reward = best_coinbase;
-    LOG_PRINT_L2("Block template filled with " << bl.tx_hashes.size() << " txes, weight "
+    LOG_PRINT_L2("Block template backlog filled with " << selected_backlog.size() << " txes, weight "
         << total_weight << "/" << max_total_weight << ", coinbase " << print_money(best_coinbase)
         << " (including " << print_money(fee) << " in fees)");
     return true;

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -158,6 +158,7 @@ namespace cryptonote
       tvc.m_verifivation_failed = true; // should already be set, but just in case
       return false;
     }
+    nic_verified_hf_version = version;
 
     uint64_t fee;
     bool fee_good = false;
@@ -220,6 +221,7 @@ namespace cryptonote
     crypto::hash max_used_block_id = null_hash;
     uint64_t max_used_block_height = 0;
     cryptonote::txpool_tx_meta_t meta{};
+    meta.nic_verified_hf_version = nic_verified_hf_version;
     meta.valid_input_verification_id = valid_input_verification_id;
     const bool ch_inp_res = check_tx_inputs([&tx]()->cryptonote::transaction&{ return tx; }, id,
       meta.valid_input_verification_id, max_used_block_height, max_used_block_id, tvc, kept_by_block);
@@ -527,6 +529,7 @@ namespace cryptonote
     cryptonote::blobdata &txblob,
     size_t& tx_weight,
     uint64_t& fee,
+    uint8_t &nic_verified_hf_version,
     crypto::hash &valid_input_verification_id,
     bool &relayed,
     bool &do_not_relay,
@@ -573,6 +576,7 @@ namespace cryptonote
       do_not_relay = meta.do_not_relay;
       double_spend_seen = meta.double_spend_seen;
       pruned = meta.pruned;
+      nic_verified_hf_version = meta.nic_verified_hf_version;
       valid_input_verification_id = meta.valid_input_verification_id;
       sensitive = !meta.matches(relay_category::broadcasted);
 
@@ -1425,6 +1429,22 @@ namespace cryptonote
       return false; // we are already sure that this tx isn't passing for this exact chain
 
     tx_verification_context tvc{};
+
+    // try verify non-input consensus rules if not already verified for this HF version
+    const uint8_t hf_version = m_blockchain.get_current_hard_fork_version();
+    if (txd.nic_verified_hf_version != hf_version)
+    {
+      if (!ver_non_input_consensus(lazy_tx(), tvc, hf_version))
+      {
+        txd.last_failed_height = top_block_height;
+        txd.last_failed_id = top_block_hash;
+        return false;
+      }
+      // set NIC verified HF version on success
+      txd.nic_verified_hf_version = hf_version;
+    }
+
+    // try verify input consensus rules using potentially cached verID, setting verID on success
     if (!check_tx_inputs([&lazy_tx]()->cryptonote::transaction&{ return lazy_tx(); },
       txid,
       txd.valid_input_verification_id,
@@ -1553,6 +1573,7 @@ namespace cryptonote
     selected_backlog.reserve(std::min<size_t>(2 * median_weight / min_tx_size_approx, CRYPTONOTE_MAX_TX_PER_BLOCK));
 
     std::unordered_set<crypto::key_image> k_images;
+    std::deque<crypto::hash> pool_txs_to_remove;
 
     LOG_PRINT_L2("Filling block template, median weight " << median_weight << ", " << m_txs_by_fee_and_receive_time.size() << " txes in the pool");
 
@@ -1643,6 +1664,11 @@ namespace cryptonote
       if (!ready)
       {
         LOG_PRINT_L2("  not ready to go");
+        if (!meta.kept_by_block)
+        {
+          LOG_PRINT_L2("  and will be removed from the mempool");
+          pool_txs_to_remove.push_back(sorted_it->get_right());
+        }
         continue;
       }
 
@@ -1674,6 +1700,25 @@ namespace cryptonote
       k_images.merge(tx_k_images);
       LOG_PRINT_L2("  added, new block weight " << total_weight << "/" << max_total_weight << ", coinbase " << print_money(best_coinbase));
     }
+
+    // Remove txs from the mempool which weren't ready and weren't kept-by-block.
+    // This will save us time making block templates later
+    for (const crypto::hash &pool_tx_to_remove : pool_txs_to_remove)
+    {
+      cryptonote::transaction tx;
+      cryptonote::blobdata tx_blob;
+      size_t tx_weight;
+      uint64_t tx_fee;
+      uint8_t nic_verified_hf_version;
+      crypto::hash valid_input_verification_id;
+      bool relayed, do_not_relay, double_spend_seen, pruned;
+      const bool removed = take_tx(pool_tx_to_remove, tx, tx_blob, tx_weight,
+        tx_fee, nic_verified_hf_version, valid_input_verification_id, relayed,
+        do_not_relay, double_spend_seen, pruned);
+      if (!removed)
+        MERROR("Failed to remove TX " << pool_tx_to_remove << " from the mempool during block template construction");
+    }
+
     lock.commit();
 
     LOG_PRINT_L2("Block template backlog filled with " << selected_backlog.size() << " txes, weight "
@@ -1722,14 +1767,15 @@ namespace cryptonote
         cryptonote::transaction tx;
         cryptonote::blobdata blob;
         bool relayed, do_not_relay, double_spend_seen, pruned;
+        uint8_t nic_verified_hf_version;
         crypto::hash valid_input_verification_id;
-        if (!take_tx(e.txid, tx, blob, weight, fee, valid_input_verification_id, relayed, do_not_relay, double_spend_seen, pruned))
+        if (!take_tx(e.txid, tx, blob, weight, fee, nic_verified_hf_version, valid_input_verification_id, relayed, do_not_relay, double_spend_seen, pruned))
           MERROR("Failed to get tx " << e.txid << " from txpool for re-validation");
 
         cryptonote::tx_verification_context tvc{};
         relay_method tx_relay = e.meta.get_relay_method();
         if (!add_tx(tx, e.txid, blob, e.meta.weight, tvc, tx_relay, relayed, version,
-          /*nic_verified_hf_version=*/0, valid_input_verification_id))
+          nic_verified_hf_version, valid_input_verification_id))
         {
           MINFO("Failed to re-validate tx " << e.txid << " for v" << (unsigned)version << ", dropped");
           continue;

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -158,15 +158,16 @@ namespace cryptonote
      * @brief takes a transaction with the given hash from the pool
      *
      * @param id the hash of the transaction
-     * @param tx return-by-reference the transaction taken
-     * @param txblob return-by-reference the transaction as a blob
-     * @param tx_weight return-by-reference the transaction's weight
+     * @param tx the transaction taken
+     * @param txblob the transaction as a blob
+     * @param tx_weight the transaction's weight
      * @param fee the transaction fee
-     * @param[out] valid_input_verification_id return-by-reference was a previously valid verID if non-null
-     * @param[out] relayed return-by-reference was transaction relayed to us by the network?
-     * @param[out] do_not_relay return-by-reference is transaction not to be relayed to the network?
-     * @param[out] double_spend_seen return-by-reference was a double spend seen for that transaction?
-     * @param[out] pruned return-by-reference is the tx pruned
+     * @param[out] nic_verified_hf_version if non-zero, was a HF version for which ver_non_input_consensus() passed
+     * @param[out] valid_input_verification_id was a previously valid verID if non-null
+     * @param[out] relayed was transaction relayed to us by the network?
+     * @param[out] do_not_relay is transaction not to be relayed to the network?
+     * @param[out] double_spend_seen was a double spend seen for that transaction?
+     * @param[out] pruned is the tx pruned
      * @param[out] suppress_missing_msgs suppress warning msgs when txid is missing (optional, defaults to `false`)
      *
      * @return true unless the transaction cannot be found in the pool
@@ -176,6 +177,7 @@ namespace cryptonote
       cryptonote::blobdata &txblob,
       size_t& tx_weight,
       uint64_t& fee,
+      uint8_t &nic_verified_hf_version,
       crypto::hash &valid_input_verification_id,
       bool &relayed,
       bool &do_not_relay,

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -263,15 +263,22 @@ namespace cryptonote
      * @param median_weight the current median block weight used for penalty calculations
      * @param already_generated_coins the current total number of coins "minted"
      * @param hf_version the current hard fork version
+     * @param overpick if >0, the ratio over the hard weight limit for which to limit total weight of `selected_backlog`
      * @param[out] selected_backlog potential (TXID, weight, fee) tuples, in descending preference order
      *
-     * Not all transactions in the pool will be returned for performance and/or consensus reasons.
-     * If there are too many transactions in the pool, only the highest-paying transactions
-     * will be returned - but enough for the miner to create a full block. Transactions which do not
-     * pass validation rules for the next block are also filtered out. However, @warning,
-     * `selected_backlog` may also contain *too many entries*, such that block weight limit is
-     * surpassed after including the coinbase transaction. In this case, it is a good idea to pop
-     * candidates from the back of the list until the weight is within the limit.
+     * Not all transactions in the pool will be returned for performance, consensus, and/or
+     * profitability reasons. If there are too many transactions in the pool, only the
+     * highest-paying / oldest transactions will be returned - but enough for the miner to create a
+     * full block. Transactions which do not pass validation rules for the next block are also
+     * filtered out. However, @warning, `selected_backlog` may also contain *too many entries*, even
+     * when `overpick_ratio` == 0, such that block weight limit is surpassed after including the
+     * coinbase transaction. In this case, it is a good idea to pop candidates from the back of the
+     * list until the weight is within the limit.
+     *
+     * The target limit is calculated as (1 + `overpick`) * theoretical block weight limit. So for
+     * example, an `overpick` value of 0.1 will try to fill `selected_backlog` so that it's total
+     * weight is 110% of the block weight limit. When `overpick` > 0, entries in `selected_backlog`
+     * may not be net profitable to include in the block, even if they fit within the block.
      *
      * This function *may* do some upkeep on the mempool, including updating transaction
      * verification metadata, and removing stale unverifiable transactions.
@@ -281,6 +288,7 @@ namespace cryptonote
     bool get_block_template_backlog(size_t median_weight,
       uint64_t already_generated_coins,
       uint8_t hf_version,
+      float overpick,
       std::vector<tx_block_template_backlog_entry> &selected_backlog);
 
     /**

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -41,6 +41,7 @@
 #include <boost/bimap.hpp>
 #include <boost/bimap/set_of.hpp>
 #include <boost/bimap/multiset_of.hpp>
+#include <boost/bimap/unordered_multiset_of.hpp>
 
 #include "span.h"
 #include "string_tools.h"
@@ -259,17 +260,28 @@ namespace cryptonote
     /**
      * @brief Chooses transactions for a block to include
      *
-     * @param bl return-by-reference the block to fill in with transactions
-     * @param median_weight the current median block weight
+     * @param median_weight the current median block weight used for penalty calculations
      * @param already_generated_coins the current total number of coins "minted"
-     * @param total_weight return-by-reference the total weight of the new block
-     * @param fee return-by-reference the total of fees from the included transactions
-     * @param expected_reward return-by-reference the total reward awarded to the miner finding this block, including transaction fees
-     * @param version hard fork version to use for consensus rules
+     * @param hf_version the current hard fork version
+     * @param[out] selected_backlog potential (TXID, weight, fee) tuples, in descending preference order
      *
-     * @return true
+     * Not all transactions in the pool will be returned for performance and/or consensus reasons.
+     * If there are too many transactions in the pool, only the highest-paying transactions
+     * will be returned - but enough for the miner to create a full block. Transactions which do not
+     * pass validation rules for the next block are also filtered out. However, @warning,
+     * `selected_backlog` may also contain *too many entries*, such that block weight limit is
+     * surpassed after including the coinbase transaction. In this case, it is a good idea to pop
+     * candidates from the back of the list until the weight is within the limit.
+     *
+     * This function *may* do some upkeep on the mempool, including updating transaction
+     * verification metadata, and removing stale unverifiable transactions.
+     *
+     * @return true on success
      */
-    bool fill_block_template(block &bl, size_t median_weight, uint64_t already_generated_coins, size_t &total_weight, uint64_t &fee, uint64_t &expected_reward, uint8_t version);
+    bool get_block_template_backlog(size_t median_weight,
+      uint64_t already_generated_coins,
+      uint8_t hf_version,
+      std::vector<tx_block_template_backlog_entry> &selected_backlog);
 
     /**
      * @brief get a list of all transactions in the pool
@@ -297,19 +309,6 @@ namespace cryptonote
      *
      */
     void get_transaction_backlog(std::vector<tx_backlog_entry>& backlog, bool include_sensitive = false) const;
-
-    /**
-     * @brief get (hash, weight, fee) for transactions in the pool - the minimum required information to create a block template
-     *
-     * Not all transactions in the pool will be returned for performance reasons
-     * If there are too many transactions in the pool, only the highest-paying transactions
-     * will be returned - but enough for the miner to create a full block
-     *
-     * @param backlog return-by-reference that data
-     * @param include_sensitive return stempool, anonymity-pool, and unrelayed txes
-     *
-     */
-    void get_block_template_backlog(std::vector<tx_block_template_backlog_entry>& backlog, bool include_sensitive = false) const;
 
     /**
      * @brief get a summary statistics of all transaction hashes in the pool
@@ -584,37 +583,14 @@ namespace cryptonote
     bool remove_transaction_keyimages(const transaction_prefix& tx, const crypto::hash &txid);
 
     /**
-     * @brief check if any of a transaction's spent key images are present in a given set
-     *
-     * @param kic the set of key images to check against
-     * @param tx the transaction to check
-     *
-     * @return true if any key images present in the set, otherwise false
-     */
-    static bool have_key_images(const std::unordered_set<crypto::key_image>& kic, const transaction_prefix& tx);
-
-    /**
-     * @brief append the key images from a transaction to the given set
-     *
-     * @param kic the set of key images to append to
-     * @param tx the transaction
-     *
-     * @return false if any append fails, otherwise true
-     */
-    static bool append_key_images(std::unordered_set<crypto::key_image>& kic, const transaction_prefix& tx);
-
-    /**
      * @brief check if a transaction is a valid candidate for inclusion in a block
      *
      * @param txd the transaction to check (and info about it)
      * @param txid the txid of the transaction to check
-     * @param txblob the transaction blob to check
-     * @param tx the parsed transaction, if successful
      *
      * @return true if the transaction is good to go, otherwise false
      */
-    bool is_transaction_ready_to_go(txpool_tx_meta_t& txd, const crypto::hash &txid, const cryptonote::blobdata_ref &txblob, transaction&tx) const;
-    bool is_transaction_ready_to_go(txpool_tx_meta_t& txd, const crypto::hash &txid, const cryptonote::blobdata &txblob, transaction&tx) const;
+    bool is_transaction_ready_to_go(txpool_tx_meta_t& txd, const crypto::hash &txid) const;
 
     /**
      * @brief mark all transactions double spending the one passed
@@ -634,14 +610,17 @@ namespace cryptonote
 
     //TODO: confirm the below comments and investigate whether or not this
     //      is the desired behavior
-    //! map key images to transactions which spent them
+    //! map key images to transactions which spent them, and vice versa
     /*! this seems odd, but it seems that multiple transactions can exist
      *  in the pool which both have the same spent key.  This would happen
      *  in the event of a reorg where someone creates a new/different
      *  transaction on the assumption that the original will not be in a
      *  block again.
      */
-    typedef std::unordered_map<crypto::key_image, std::unordered_set<crypto::hash>> key_images_container;
+    typedef boost::bimap<
+        boost::bimaps::unordered_multiset_of<crypto::key_image>,
+        boost::bimaps::unordered_multiset_of<crypto::hash>
+      > key_images_container;
 
 #if defined(DEBUG_CREATE_BLOCK_TEMPLATE)
 public:


### PR DESCRIPTION
Stores a 1 byte field in the mempool meta, `nic_verified_hf_version` which
specifies for which HF version this tx has passed `ver_non_input_consensus()`.
This is checked while handling both alt chains and main chains, and thus allows
us to skip the expensive full mempool revalidation on fork change.

Resolves #10142

Depends on #10915 