### PR TITLE
dns_utils: update default public DNS resolvers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
     ccache --max-size=150M
   CTEST_EXCLUDE_SLOW: |
     cd build
-    env GTEST_FILTER="-select_outputs.*:DNSResolver.*:AddressFromURL.*" ctest --output-on-failure -E "functional_tests_rpc|core_tests|cnv4-jit|hash-variant2-int-sqrt|wide_difficulty"
+    env DNS_PUBLIC=tcp GTEST_FILTER="-select_outputs.*" ctest --output-on-failure -E "functional_tests_rpc|core_tests|cnv4-jit|hash-variant2-int-sqrt|wide_difficulty"
   USE_DEVICE_TREZOR_MANDATORY: ON
   INSTALL_RUST: |
     curl -O https://static.rust-lang.org/rustup/archive/1.29.0/x86_64-unknown-linux-gnu/rustup-init
@@ -248,7 +248,7 @@ jobs:
           ${{env.BUILD_DEFAULT}}
       - name: run tests except core_tests
         env:
-          DNS_PUBLIC: tcp://9.9.9.9
+          DNS_PUBLIC: tcp
         run: ctest --test-dir build --output-on-failure -E core_tests
       - name: use reduced slow-hash iterations for core_tests
         if: github.event_name == 'pull_request'

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -50,11 +50,11 @@ using namespace epee;
 
 static const char *DEFAULT_DNS_PUBLIC_ADDR[] =
 {
+  "9.9.9.10",           // Quad9 (unfiltered)
+  "149.112.112.10",     // Quad9 secondary
+  "76.76.2.0",          // Control D (unfiltered)
+  "76.76.10.0",         // Control D secondary
   "194.150.168.168",    // CCC (Germany)
-  "80.67.169.40",       // FDN (France)
-  "89.233.43.71",       // http://censurfridns.dk (Denmark)
-  "109.69.8.51",        // punCAT (Spain)
-  "193.58.251.251",     // SkyDNS (Russia)
 };
 
 static boost::mutex instance_lock;

--- a/tests/unit_tests/dns_resolver.cpp
+++ b/tests/unit_tests/dns_resolver.cpp
@@ -166,7 +166,7 @@ TEST(DNSResolver, Localhost)
 bool is_equal(const char *s, const std::vector<std::string> &v) { return v.size() == 1 && v[0] == s; }
 
 TEST(DNS_PUBLIC, empty) { EXPECT_TRUE(tools::dns_utils::parse_dns_public("").empty()); }
-TEST(DNS_PUBLIC, default) { EXPECT_TRUE(tools::dns_utils::parse_dns_public("tcp").size() > 0); }
+TEST(DNS_PUBLIC, default) { EXPECT_GT(tools::dns_utils::parse_dns_public("tcp").size(), 1); }
 TEST(DNS_PUBLIC, invalid_scheme) { EXPECT_TRUE(tools::dns_utils::parse_dns_public("invalid").empty()); }
 TEST(DNS_PUBLIC, invalid_ip_alpha) { EXPECT_TRUE(tools::dns_utils::parse_dns_public("tcp://invalid").empty()); }
 TEST(DNS_PUBLIC, invalid_ip_num1) { EXPECT_TRUE(tools::dns_utils::parse_dns_public("tcp://3").empty()); }


### PR DESCRIPTION
This should also fix flaky DNS tests on CI by setting `DNS_PUBLIC=tcp` env var, which uses the resolvers in `DEFAULT_DNS_PUBLIC_ADDR` with fallback support. I also removed skipping DNS related tests from macOS and Windows.

Related: https://github.com/monero-project/monero/issues/10445