### PR TITLE
general: replace `auto_scope_leave_caller` with `scope_guard`

### DIFF
--- a/contrib/epee/include/misc_language.h
+++ b/contrib/epee/include/misc_language.h
@@ -31,11 +31,7 @@
 #include <boost/utility/value_init.hpp>
 
 #include <algorithm>
-#include <functional>
-#include <utility>
 #include <vector>
-
-#include "scope_guard.h"
 
 namespace epee
 {
@@ -77,18 +73,6 @@ namespace misc_utils
   /************************************************************************/
   /*                                                                      */
   /************************************************************************/
-
-  /// name exists for backwards compatibility. if writing new code, you shouldn't
-  /// use this type unless you *need* the scope leaver to be polymorphic because the std::function
-  /// adds unnecessary overhead if you know the type of the functional object at compile-time
-  using auto_scope_leave_caller = scope_guard<std::function<void()>>;
-
-  // name exists for backwards compatibility
-  template<class t_scope_leave_handler>
-  auto_scope_leave_caller create_scope_leave_handler(t_scope_leave_handler &&f)
-  {
-    return auto_scope_leave_caller(std::forward<t_scope_leave_handler>(f));
-  }
 
   template<typename T> struct struct_init: T
   {

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -47,13 +47,11 @@
 #include <boost/thread/condition_variable.hpp> // TODO
 #include <boost/make_shared.hpp>
 #include <boost/thread.hpp>
-#include "warnings.h"
 #include "string_tools_lexical.h"
 #include "misc_language.h"
 #include "net/abstract_tcp_server2.h"
+#include "scope_guard.h"
 
-#include <sstream>
-#include <iomanip>
 #include <algorithm>
 #include <functional>
 #include <random>
@@ -1852,7 +1850,7 @@ namespace net_utils
     connections_.insert(new_connection_l);
     MDEBUG("connections_ size now " << connections_.size());
     connections_mutex.unlock();
-    epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ CRITICAL_REGION_LOCAL(connections_mutex); connections_.erase(new_connection_l); });
+    const scope_guard scope_exit_handler([&](){ CRITICAL_REGION_LOCAL(connections_mutex); connections_.erase(new_connection_l); });
     boost::asio::ip::tcp::socket&  sock_ = new_connection_l->socket();
 
     bool try_ipv6 = false;
@@ -1979,7 +1977,7 @@ namespace net_utils
     connections_.insert(new_connection_l);
     MDEBUG("connections_ size now " << connections_.size());
     connections_mutex.unlock();
-    epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ CRITICAL_REGION_LOCAL(connections_mutex); connections_.erase(new_connection_l); });
+    const scope_guard scope_exit_handler([&](){ CRITICAL_REGION_LOCAL(connections_mutex); connections_.erase(new_connection_l); });
     boost::asio::ip::tcp::socket&  sock_ = new_connection_l->socket();
     
     bool try_ipv6 = false;

--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -31,13 +31,12 @@
 #include <boost/smart_ptr/make_shared.hpp>
 
 #include <atomic>
-#include <deque>
 
 #include "levin_base.h"
 #include "buffer.h"
 #include "misc_language.h"
+#include "scope_guard.h"
 #include "syncobj.h"
-#include "time_helper.h"
 #include "int-util.h"
 
 #include <random>
@@ -381,8 +380,7 @@ public:
 
   void request_callback()
   {
-    misc_utils::auto_scope_leave_caller scope_exit_handler = misc_utils::create_scope_leave_handler(
-      boost::bind(&async_protocol_handler::finish_outer_call, this));
+    const scope_guard scope_exit_handler(boost::bind(&async_protocol_handler::finish_outer_call, this));
 
     m_pservice_endpoint->request_callback();
   }
@@ -614,8 +612,7 @@ public:
   template<class callback_t>
   bool async_invoke(int command, message_writer in_msg, const callback_t &cb, std::chrono::milliseconds timeout = LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED)
   {
-    misc_utils::auto_scope_leave_caller scope_exit_handler = misc_utils::create_scope_leave_handler(
-      boost::bind(&async_protocol_handler::finish_outer_call, this));
+    const scope_guard scope_exit_handler(boost::bind(&async_protocol_handler::finish_outer_call, this));
 
     if(timeout == LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED)
       timeout = m_config.m_invoke_timeout;
@@ -662,9 +659,7 @@ public:
       \return 1 on success */
   int send(byte_slice message)
   {
-    const misc_utils::auto_scope_leave_caller scope_exit_handler = misc_utils::create_scope_leave_handler(
-      boost::bind(&async_protocol_handler::finish_outer_call, this)
-    );
+    const scope_guard scope_exit_handler(boost::bind(&async_protocol_handler::finish_outer_call, this));
 
     if (!send_message(std::move(message)))
     {
@@ -693,7 +688,7 @@ void async_protocol_handler_config<t_connection_context>::delete_connections(siz
 {
   std::vector<typename connections_map::mapped_type> connections;
 
-  auto scope_exit_handler = misc_utils::create_scope_leave_handler([&connections]{
+  const scope_guard scope_exit_handler([&connections]{
     for (auto &aph: connections)
       aph->finish_outer_call();
   });
@@ -772,7 +767,7 @@ bool async_protocol_handler_config<t_connection_context>::foreach_connection(con
 {
   std::vector<typename connections_map::mapped_type> conn;
 
-  auto scope_exit_handler = misc_utils::create_scope_leave_handler([&conn]{
+  const scope_guard scope_exit_handler([&conn]{
     for (auto &aph: conn)
       aph->finish_outer_call();
   });
@@ -797,7 +792,7 @@ bool async_protocol_handler_config<t_connection_context>::for_connection(const b
   async_protocol_handler<t_connection_context>* aph = nullptr;
   if (find_and_lock_connection(connection_id, aph) != LEVIN_OK)
     return false;
-  auto scope_exit_handler = misc_utils::create_scope_leave_handler(
+  const scope_guard scope_exit_handler(
     boost::bind(&async_protocol_handler<t_connection_context>::finish_outer_call, aph));
   if(!cb(aph->get_context_ref()))
     return false;
@@ -856,7 +851,7 @@ bool async_protocol_handler_config<t_connection_context>::close(boost::uuids::uu
   async_protocol_handler<t_connection_context>* aph = nullptr;
   if (find_and_lock_connection(connection_id, aph) != LEVIN_OK)
     return false;
-  auto scope_exit_handler = misc_utils::create_scope_leave_handler(
+  const scope_guard scope_exit_handler(
     boost::bind(&async_protocol_handler<t_connection_context>::finish_outer_call, aph));
   if (!aph->close(wait_for_shutdown))
     return false;

--- a/contrib/epee/include/net/net_helper.h
+++ b/contrib/epee/include/net/net_helper.h
@@ -43,9 +43,9 @@
 #include <boost/system/error_code.hpp>
 #include <boost/utility/string_ref.hpp>
 #include <functional>
-#include "net/net_utils_base.h"
 #include "net/net_ssl.h"
-#include "misc_language.h"
+
+#include "misc_log_ex.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "net"

--- a/contrib/epee/include/net/network_throttle.hpp
+++ b/contrib/epee/include/net/network_throttle.hpp
@@ -38,7 +38,6 @@
 #define INCLUDED_network_throttle_hpp
 
 #include <string>
-#include <vector>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 
@@ -46,24 +45,14 @@
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/thread/thread.hpp>
 
-#include "syncobj.h"
 
-#include "net/net_utils_base.h" 
-#include "misc_log_ex.h" 
 #include <boost/lambda/bind.hpp>
 #include <boost/lambda/lambda.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <boost/chrono.hpp>
 #include <boost/utility/value_init.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include "misc_language.h"
-#include <sstream>
-#include <iomanip>
-#include <algorithm>
 
-#include <memory>
-#include <mutex>
-#include <fstream>
 
 namespace epee
 {

--- a/contrib/epee/include/storages/http_abstract_invoke.h
+++ b/contrib/epee/include/storages/http_abstract_invoke.h
@@ -106,12 +106,12 @@ namespace epee
     template<class t_request, class t_response, class t_transport>
     bool invoke_http_json_rpc(const boost::string_ref uri, std::string method_name, const t_request& out_struct, t_response& result_struct, epee::json_rpc::error &error_struct, t_transport& transport, std::chrono::milliseconds timeout = std::chrono::seconds(15), const boost::string_ref http_method = "POST", const std::string& req_id = "0")
     {
-      epee::json_rpc::request<t_request> req_t = AUTO_VAL_INIT(req_t);
+      epee::json_rpc::request<t_request> req_t{};
       req_t.jsonrpc = "2.0";
       req_t.id = req_id;
       req_t.method = std::move(method_name);
       req_t.params = out_struct;
-      epee::json_rpc::response<t_response, epee::json_rpc::error> resp_t = AUTO_VAL_INIT(resp_t);
+      epee::json_rpc::response<t_response, epee::json_rpc::error> resp_t{};
       if(!epee::net_utils::invoke_http_json(uri, req_t, resp_t, transport, timeout, http_method))
       {
         error_struct = {};

--- a/contrib/epee/include/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/storages/levin_abstract_invoke2.h
@@ -29,7 +29,6 @@
 #include "portable_storage_template_helper.h"
 #include <boost/utility/string_ref.hpp>
 #include <boost/utility/value_init.hpp>
-#include <functional>
 #include "byte_slice.h"
 #include "span.h"
 #include "net/levin_base.h"
@@ -66,7 +65,7 @@ namespace epee
       stg.store_to_binary(to_send.buffer);
       int res = transport.invoke_async(command, std::move(to_send), conn_id, [cb, command](int code, const epee::span<const uint8_t> buff, typename t_transport::connection_context& context)->bool
       {
-        t_result result_struct = AUTO_VAL_INIT(result_struct);
+        t_result result_struct{};
         if( code <=0 )
         {
           if (!buff.empty())

--- a/contrib/epee/include/storages/portable_storage_from_bin.h
+++ b/contrib/epee/include/storages/portable_storage_from_bin.h
@@ -28,7 +28,6 @@
 
 #pragma once 
 
-#include "misc_language.h"
 #include "misc_log_ex.h"
 #include "portable_storage_base.h"
 #include "portable_storage_bin_utils.h"

--- a/contrib/epee/include/storages/portable_storage_from_json.h
+++ b/contrib/epee/include/storages/portable_storage_from_json.h
@@ -29,7 +29,8 @@
 #include <boost/utility/string_ref.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include "parserse_base_utils.h"
-#include "file_io_utils.h"
+
+#include "misc_log_ex.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "serialization"

--- a/contrib/epee/include/storages/portable_storage_to_bin.h
+++ b/contrib/epee/include/storages/portable_storage_to_bin.h
@@ -28,7 +28,6 @@
 
 #pragma once 
 
-#include "misc_language.h"
 #include "portable_storage_base.h"
 #include "portable_storage_bin_utils.h"
 #include "misc_log_ex.h"

--- a/contrib/epee/include/storages/portable_storage_to_json.h
+++ b/contrib/epee/include/storages/portable_storage_to_json.h
@@ -28,7 +28,6 @@
 
 #pragma once 
 
-#include "misc_language.h"
 #include "portable_storage_base.h"
 #include "parserse_base_utils.h"
 

--- a/contrib/epee/include/storages/portable_storage_val_converters.h
+++ b/contrib/epee/include/storages/portable_storage_val_converters.h
@@ -30,8 +30,6 @@
 
 #include <boost/regex.hpp>
 
-#include "misc_language.h"
-#include "portable_storage_base.h"
 #include "parserse_base_utils.h"
 #include "warnings.h"
 #include "misc_log_ex.h"
@@ -39,7 +37,10 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/numeric/conversion/bounds.hpp>
 #include <typeinfo>
+
+#ifndef HAVE_STRPTIME
 #include <iomanip>
+#endif
 
 namespace epee
 {

--- a/contrib/epee/src/connection_basic.cpp
+++ b/contrib/epee/src/connection_basic.cpp
@@ -34,12 +34,9 @@
 
 #include "net/connection_basic.hpp"
 
-#include "net/net_utils_base.h" 
 #include "misc_log_ex.h" 
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread/thread.hpp>
-#include "misc_language.h"
-#include <iomanip>
 
 #include <boost/asio/basic_socket.hpp>
 

--- a/contrib/epee/src/net_helper.cpp
+++ b/contrib/epee/src/net_helper.cpp
@@ -1,5 +1,7 @@
 #include "net/net_helper.h"
 
+#include "net/net_utils_base.h"
+
 namespace epee
 {
 namespace net_utils

--- a/contrib/epee/src/network_throttle-detail.cpp
+++ b/contrib/epee/src/network_throttle-detail.cpp
@@ -33,17 +33,11 @@
 /* rfree: implementation for throttle details */
 
 #include <string>
-#include <vector>
-#include <atomic>
-
-#include <memory>
 
 #include "syncobj.h"
 
-#include "net/net_utils_base.h" 
 #include "misc_log_ex.h" 
 #include <boost/chrono.hpp>
-#include "misc_language.h"
 #include <fstream>
 #include <iomanip>
 #include <algorithm>
@@ -52,7 +46,6 @@
 
 #include <boost/asio/basic_socket.hpp>
 #include <boost/asio/ip/unicast.hpp>
-#include "net/abstract_tcp_server2.h"
 
 // TODO:
 #include "net/network_throttle-detail.hpp"

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -43,6 +43,7 @@
 #include "common/pruning.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "crypto/crypto.h"
+#include "misc_language.h"
 #include "profile_tools.h"
 #include "ringct/rctOps.h"
 

--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -35,6 +35,7 @@
 #include "common/pruning.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "blockchain_db/lmdb/db_lmdb.h"
+#include "scope_guard.h"
 #include "version.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -169,7 +170,7 @@ static uint32_t get_blockchain_db_version(MDB_env *env)
   MDB_val v;
   uint32_t db_version = std::numeric_limits<uint32_t>::max();
 
-  const epee::misc_utils::auto_scope_leave_caller txn_dtor = epee::misc_utils::create_scope_leave_handler([&](){
+  const epee::scope_guard txn_dtor([&](){
     if (tx_active) mdb_txn_abort(txn);
   });
 
@@ -209,7 +210,7 @@ static void copy_table(MDB_env *env0, MDB_env *env1, const char *table, unsigned
 
   MINFO("Copying " << table);
 
-  epee::misc_utils::auto_scope_leave_caller txn_dtor = epee::misc_utils::create_scope_leave_handler([&](){
+  const epee::scope_guard txn_dtor([&](){
     if (tx_active1) mdb_txn_abort(txn1);
     if (tx_active0) mdb_txn_abort(txn0);
   });
@@ -304,7 +305,7 @@ static void prune(MDB_env *env0, MDB_env *env1)
 
   MGINFO("Creating pruned txs_prunable");
 
-  epee::misc_utils::auto_scope_leave_caller txn_dtor = epee::misc_utils::create_scope_leave_handler([&](){
+  const epee::scope_guard txn_dtor([&](){
     if (tx_active1) mdb_txn_abort(txn1);
     if (tx_active0) mdb_txn_abort(txn0);
   });

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -27,17 +27,17 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "common/dns_utils.h"
+#include "common/threadpool.h"
+#include "crypto/crypto.h"
 // check local first (in the event of static or in-source compilation of libunbound)
-#include "misc_language.h"
+#include "misc_log_ex.h"
+#include "scope_guard.h"
 #include "unbound.h"
 
 #include <deque>
 #include <set>
 #include <stdlib.h>
 #include <cstring>
-#include "include_base_utils.h"
-#include "common/threadpool.h"
-#include "crypto/crypto.h"
 #include <boost/thread/mutex.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/optional.hpp>
@@ -271,8 +271,7 @@ std::vector<std::string> DNSResolver::get_record(const std::string& url, int rec
   
   ub_result *result;
   // Make sure we are cleaning after result.
-  epee::misc_utils::auto_scope_leave_caller scope_exit_handler =
-    epee::misc_utils::create_scope_leave_handler([&](){
+  const epee::scope_guard scope_exit_handler([&](){
     ub_resolve_free(result);
   });
   

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -46,7 +46,6 @@
 #include "cryptonote_config.h"
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
-#include "misc_language.h"
 #include "ringct/rctTypes.h"
 #include "device/device.hpp"
 #include "cryptonote_basic/fwd.h"

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -28,15 +28,11 @@
 //
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
-#include "include_base_utils.h"
-using namespace epee;
-
 #include "cryptonote_basic_impl.h"
 #include "string_tools.h"
 #include "serialization/binary_utils.h"
 #include "cryptonote_format_utils.h"
 #include "cryptonote_config.h"
-#include "misc_language.h"
 #include "common/base58.h"
 #include "crypto/hash.h"
 #include "int-util.h"
@@ -44,6 +40,8 @@ using namespace epee;
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "cn"
+
+using namespace epee;
 
 namespace cryptonote {
 

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -266,7 +266,7 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool generate_key_image_helper(const account_keys& ack, const std::unordered_map<crypto::public_key, subaddress_index>& subaddresses, const crypto::public_key& out_key, const crypto::public_key& tx_public_key, const std::vector<crypto::public_key>& additional_tx_public_keys, size_t real_output_index, keypair& in_ephemeral, crypto::key_image& ki, hw::device &hwdev)
   {
-    crypto::key_derivation recv_derivation = AUTO_VAL_INIT(recv_derivation);
+    crypto::key_derivation recv_derivation{};
     bool r = hwdev.generate_key_derivation(tx_public_key, ack.m_view_secret_key, recv_derivation);
     if (!r)
     {
@@ -277,7 +277,7 @@ namespace cryptonote
     std::vector<crypto::key_derivation> additional_recv_derivations;
     for (size_t i = 0; i < additional_tx_public_keys.size(); ++i)
     {
-      crypto::key_derivation additional_recv_derivation = AUTO_VAL_INIT(additional_recv_derivation);
+      crypto::key_derivation additional_recv_derivation{};
       r = hwdev.generate_key_derivation(additional_tx_public_keys[i], ack.m_view_secret_key, additional_recv_derivation);
       if (!r)
       {

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -35,7 +35,6 @@
 #include "syncobj.h"
 #include "cryptonote_basic_impl.h"
 #include "cryptonote_format_utils.h"
-#include "cryptonote_core/cryptonote_tx_utils.h"
 #include "file_io_utils.h"
 #include "common/command_line.h"
 #include "common/util.h"

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -35,28 +35,25 @@
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/format.hpp>
 
-#include "include_base_utils.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "tx_pool.h"
 #include "blockchain.h"
 #include "blockchain_db/blockchain_db.h"
 #include "cryptonote_basic/events.h"
 #include "cryptonote_config.h"
-#include "cryptonote_basic/miner.h"
 #include "hardforks/hardforks.h"
 #include "misc_language.h"
 #include "profile_tools.h"
-#include "file_io_utils.h"
 #include "int-util.h"
 #include "common/threadpool.h"
 #include "warnings.h"
 #include "crypto/hash.h"
 #include "cryptonote_core.h"
-#include "ringct/rctSigs.h"
 #include "common/perf_timer.h"
 #include "common/notify.h"
 #include "common/varint.h"
 #include "common/pruning.h"
+#include "scope_guard.h"
 #include "time_helper.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -1539,7 +1536,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
   seed_hash = crypto::null_hash;
 
   m_tx_pool.lock();
-  const auto unlock_guard = epee::misc_utils::create_scope_leave_handler([&]() { m_tx_pool.unlock(); });
+  const epee::scope_guard unlock_guard([&]() { m_tx_pool.unlock(); });
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
   if (m_btc_valid && !from_block) {
     // The pool cookie is atomic. The lack of locking is OK, as if it changes
@@ -4394,7 +4391,7 @@ leave:
 bool Blockchain::prune_blockchain(uint32_t pruning_seed)
 {
   m_tx_pool.lock();
-  epee::misc_utils::auto_scope_leave_caller unlocker = epee::misc_utils::create_scope_leave_handler([&](){m_tx_pool.unlock();});
+  const epee::scope_guard unlocker([&](){m_tx_pool.unlock();});
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
 
   return m_db->prune_blockchain(pruning_seed);
@@ -4403,7 +4400,7 @@ bool Blockchain::prune_blockchain(uint32_t pruning_seed)
 bool Blockchain::update_blockchain_pruning()
 {
   m_tx_pool.lock();
-  epee::misc_utils::auto_scope_leave_caller unlocker = epee::misc_utils::create_scope_leave_handler([&](){m_tx_pool.unlock();});
+  const epee::scope_guard unlocker([&](){m_tx_pool.unlock();});
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
 
   return m_db->update_pruning();
@@ -4412,7 +4409,7 @@ bool Blockchain::update_blockchain_pruning()
 bool Blockchain::check_blockchain_pruning()
 {
   m_tx_pool.lock();
-  epee::misc_utils::auto_scope_leave_caller unlocker = epee::misc_utils::create_scope_leave_handler([&](){m_tx_pool.unlock();});
+  const epee::scope_guard unlocker([&](){m_tx_pool.unlock();});
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
 
   return m_db->check_pruning();

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -32,6 +32,7 @@
 #include <boost/uuid/nil_generator.hpp>
 
 #include "misc_log_ex.h"
+#include "scope_guard.h"
 #include "string_tools.h"
 using namespace epee;
 
@@ -40,20 +41,16 @@ using namespace epee;
 #include "common/util.h"
 #include "common/updates.h"
 #include "common/download.h"
-#include "common/threadpool.h"
 #include "common/command_line.h"
 #include "cryptonote_basic/events.h"
 #include "warnings.h"
 #include "crypto/crypto.h"
 #include "cryptonote_config.h"
-#include "misc_language.h"
 #include "file_io_utils.h"
 #include <csignal>
 #include "checkpoints/checkpoints.h"
 #include "ringct/rctTypes.h"
 #include "blockchain_db/blockchain_db.h"
-#include "ringct/rctSigs.h"
-#include "rpc/zmq_pub.h"
 #include "common/notify.h"
 #include "hardforks/hardforks.h"
 #include "tx_verification_utils.h"
@@ -1468,7 +1465,7 @@ namespace cryptonote
     // Match each call to prepare_handle_incoming_block_no_preprocess() with a call to
     // cleanup_handle_incoming_blocks()
     m_blockchain_storage.prepare_handle_incoming_block_no_preprocess(block_total_bytes);
-    const auto auto_cleanup = epee::misc_utils::create_scope_leave_handler([this](){
+    const epee::scope_guard auto_cleanup([this](){
       this->m_blockchain_storage.cleanup_handle_incoming_blocks();
     });
 

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -30,8 +30,6 @@
 
 #include <optional>
 #include <unordered_set>
-#include <random>
-#include "include_base_utils.h"
 #include "misc_log_ex.h"
 #include "string_tools.h"
 using namespace epee;
@@ -45,7 +43,9 @@ using namespace epee;
 #include "crypto/crypto.h"
 #include "crypto/hash.h"
 #include "crypto/wire.h"
+#include "misc_language.h"
 #include "ringct/rctSigs.h"
+#include "scope_guard.h"
 #include "serialization/wire.h"
 
 using namespace crypto;
@@ -668,7 +668,7 @@ namespace cryptonote
   {
     hw::device &hwdev = sender_account_keys.get_device();
     hwdev.open_tx(tx_key);
-    const auto auto_close_tx = epee::misc_utils::create_scope_leave_handler([&hwdev](){
+    const epee::scope_guard auto_close_tx([&hwdev](){
       hwdev.close_tx();
     });
     {

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -79,7 +79,7 @@ namespace cryptonote
     bool is_subaddress;
     bool is_integrated;
 
-    tx_destination_entry() : amount(0), addr(AUTO_VAL_INIT(addr)), is_subaddress(false), is_integrated(false) { }
+    tx_destination_entry() : amount(0), addr(), is_subaddress(false), is_integrated(false) { }
     tx_destination_entry(uint64_t a, const account_public_address &ad, bool is_subaddress) : amount(a), addr(ad), is_subaddress(is_subaddress), is_integrated(false) { }
     tx_destination_entry(const std::string &o, uint64_t a, const account_public_address &ad, bool is_subaddress) : original(o), amount(a), addr(ad), is_subaddress(is_subaddress), is_integrated(false) { }
 

--- a/src/cryptonote_protocol/block_queue.cpp
+++ b/src/cryptonote_protocol/block_queue.cpp
@@ -32,7 +32,9 @@
 #include <unordered_map>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid_hash.hpp>
 #include "string_tools.h"
+#include "cryptonote_config.h"
 #include "cryptonote_protocol_defs.h"
 #include "common/pruning.h"
 #include "block_queue.h"
@@ -488,7 +490,7 @@ bool block_queue::has_spans(const boost::uuids::uuid &connection_id) const
 float block_queue::get_speed(const boost::uuids::uuid &connection_id) const
 {
   boost::unique_lock<boost::recursive_mutex> lock(mutex);
-  std::unordered_map<boost::uuids::uuid, float, boost::hash<boost::uuids::uuid>> speeds;
+  std::unordered_map<boost::uuids::uuid, float> speeds;
   for (const auto &span: blocks)
   {
     if (span.blocks.empty())

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -30,10 +30,12 @@
 
 #pragma once
 
-#include <list>
-#include "serialization/keyvalue_serialization.h"
-#include "cryptonote_basic/cryptonote_basic.h"
+#include "crypto/hash.h"
 #include "cryptonote_basic/blobdatatype.h"
+#include "misc_language.h"
+#include "serialization/keyvalue_serialization.h"
+
+#include <list>
 
 namespace cryptonote
 {

--- a/src/cryptonote_protocol/cryptonote_protocol_handler-base.cpp
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler-base.cpp
@@ -30,26 +30,17 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <string>
-#include <vector>
-
-#include <memory>
-
 #include "syncobj.h"
 
-#include "net/net_utils_base.h" 
 #include "misc_log_ex.h" 
 #include <boost/chrono.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread/thread.hpp> 
-#include "misc_language.h"
 #include <algorithm>
 
 
 #include "cryptonote_protocol_handler.h"
 #include "net/network_throttle.hpp"
-
-#include "cryptonote_core/cryptonote_core.h" // e.g. for the send_stop_signal()
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "net.cn"

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -644,7 +644,7 @@ namespace cryptonote
     // validating the next block. Needs more research into if this is a DoS vector or not. Invalid
     // block validation will cause disconnects and bans, so it might not be that bad.
     m_core.pause_mine();
-    const auto resume_mine_on_leave = epee::misc_utils::create_scope_leave_handler([this](){ m_core.resume_mine(); });
+    const epee::scope_guard resume_mine_on_leave([this](){ m_core.resume_mine(); });
 
     // This set allows us to quickly sanity check that the block binds all txs contained in this
     // fluffy payload, which means that no extra stowaway txs can be harbored. In the case of a
@@ -1362,7 +1362,7 @@ namespace cryptonote
         m_core.pause_mine();
         m_add_timer.resume();
         bool starting = true;
-        epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([this, &starting]() {
+        const epee::scope_guard scope_exit_handler([this, &starting]() {
           m_add_timer.pause();
           m_core.resume_mine();
           if (!starting)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -242,7 +242,7 @@ bool t_daemon::run(bool interactive)
     if (shutdown)
       this->stop_p2p();
   });
-  epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){
+  const epee::scope_guard scope_exit_handler([&](){
     stop = true;
     stop_thread.join();
   });

--- a/src/daemonizer/posix_fork.cpp
+++ b/src/daemonizer/posix_fork.cpp
@@ -5,8 +5,8 @@
 //
 
 #include "daemonizer/posix_fork.h"
-#include "misc_language.h"
 #include "misc_log_ex.h"
+#include "scope_guard.h"
 
 #include <cerrno>
 #include <cstdlib>
@@ -50,8 +50,7 @@ void fork(const std::string & pidfile)
       pid_fd = -1;
     }
   };
-  epee::misc_utils::auto_scope_leave_caller pid_fd_guard =
-    epee::misc_utils::create_scope_leave_handler(close_pid_fd);
+  const epee::scope_guard pid_fd_guard(std::forward<decltype(close_pid_fd) const &&>(close_pid_fd));
   if (! pidfile.empty ())
   {
     struct stat st;

--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -180,7 +180,7 @@ namespace trezor {
 
     bool device_trezor::get_public_address_with_no_passphrase(cryptonote::account_public_address &pubkey) {
       m_reply_with_empty_passphrase = true;
-      const auto empty_passphrase_reverter = epee::misc_utils::create_scope_leave_handler([&]() {
+      const epee::scope_guard empty_passphrase_reverter([&]() {
         m_reply_with_empty_passphrase = false;
       });
 

--- a/src/device_trezor/device_trezor_base.cpp
+++ b/src/device_trezor/device_trezor_base.cpp
@@ -370,7 +370,7 @@ namespace trezor {
     {
       require_connected();
       auto initMsg = std::make_shared<messages::management::Initialize>();
-      const auto data_cleaner = epee::misc_utils::create_scope_leave_handler([&]() {
+      const epee::scope_guard data_cleaner([&]() {
         if (initMsg->has_session_id())
           memwipe(&(*initMsg->mutable_session_id())[0], initMsg->mutable_session_id()->size());
       });
@@ -459,7 +459,7 @@ namespace trezor {
         m.set_allocated_pin(new std::string(pin->data(), pin->size()));
       }
 
-      const auto data_cleaner = epee::misc_utils::create_scope_leave_handler([&]() {
+      const epee::scope_guard data_cleaner([&]() {
         if (m.has_pin())
           memwipe(&(*m.mutable_pin())[0], m.mutable_pin()->size());
       });
@@ -503,7 +503,7 @@ namespace trezor {
         }
       }
 
-      const auto data_cleaner = epee::misc_utils::create_scope_leave_handler([&]() {
+      const epee::scope_guard data_cleaner([&]() {
         if (m.has_passphrase())
           memwipe(&(*m.mutable_passphrase())[0], m.mutable_passphrase()->size());
       });

--- a/src/device_trezor/trezor/transport.hpp
+++ b/src/device_trezor/trezor/transport.hpp
@@ -39,6 +39,7 @@
 #include <typeinfo>
 #include <type_traits>
 #include "net/http_client.h"
+#include "scope_guard.h"
 
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
@@ -86,7 +87,7 @@ namespace trezor {
     additional_params.push_back(std::make_pair("Content-Type","application/json; charset=utf-8"));
 
     const http::http_response_info* pri = nullptr;
-    const auto data_cleaner = epee::misc_utils::create_scope_leave_handler([&]() {
+    const epee::scope_guard data_cleaner([&]() {
       if (!req_param.empty()) {
         memwipe(&req_param[0], req_param.size());
       }

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -40,8 +40,8 @@
 #include <cstdint>
 #include <vector>
 #include <unordered_map>
+#include "scope_guard.h"
 #include "wipeable_string.h"
-#include "misc_language.h"
 #include "int-util.h"
 #include "mnemonics/electrum-words.h"
 #include <boost/crc.hpp>
@@ -291,7 +291,8 @@ namespace crypto
       }
 
       std::vector<uint32_t> matched_indices;
-      auto wiper = epee::misc_utils::create_scope_leave_handler([&](){memwipe(matched_indices.data(), matched_indices.size() * sizeof(matched_indices[0]));});
+      const epee::scope_guard wiper([&](){
+        memwipe(matched_indices.data(), matched_indices.size() * sizeof(matched_indices[0]));});
       Language::Base *language;
       if (!find_seed_language(seed, has_checksum, matched_indices, &language))
       {

--- a/src/multisig/multisig_account_kex_impl.cpp
+++ b/src/multisig/multisig_account_kex_impl.cpp
@@ -272,10 +272,7 @@ namespace multisig
       // note: must be mul8 (cofactor), otherwise it is possible to leak to a malicious participant if the local
       //       base_privkey is a multiple of 8 or not
       // note2: avoid making temporaries that won't be memwiped
-      rct::key derivation_rct;
-      auto a_wiper = epee::misc_utils::create_scope_leave_handler([&]{
-        memwipe(&derivation_rct, sizeof(rct::key));
-      });
+      tools::scrubbed<rct::key> derivation_rct;
 
       rct::scalarmultKey(derivation_rct, rct::pk2rct(pubkey_and_origins.first), rct::sk2rct(base_privkey));
       rct::scalarmultKey(derivation_rct, derivation_rct, rct::EIGHT);

--- a/src/multisig/multisig_tx_builder_ringct.cpp
+++ b/src/multisig/multisig_tx_builder_ringct.cpp
@@ -28,7 +28,6 @@
 
 #include "multisig_tx_builder_ringct.h"
 
-#include "int-util.h"
 #include "memwipe.h"
 
 #include "cryptonote_basic/cryptonote_basic.h"
@@ -41,6 +40,7 @@
 #include "ringct/bulletproofs.h"
 #include "ringct/bulletproofs_plus.h"
 #include "ringct/rctSigs.h"
+#include "scope_guard.h"
 
 #include <boost/multiprecision/cpp_int.hpp>
 
@@ -253,7 +253,7 @@ static void make_tx_secret_key_seed(const crypto::secret_key& tx_secret_key_entr
 
   rct::keyV hash_context;
   hash_context.reserve(2 + sources.size());
-  auto hash_context_wiper = epee::misc_utils::create_scope_leave_handler([&]{
+  const epee::scope_guard hash_context_wiper([&]{
       memwipe(hash_context.data(), hash_context.size() * sizeof(rct::key));
     });
   hash_context.emplace_back();
@@ -281,7 +281,7 @@ static void make_tx_secret_keys(const crypto::secret_key& tx_secret_key_seed,
 
   rct::keyV hash_context;
   hash_context.resize(2);
-  auto hash_context_wiper = epee::misc_utils::create_scope_leave_handler([&]{
+  const epee::scope_guard hash_context_wiper([&]{
       memwipe(hash_context.data(), hash_context.size() * sizeof(rct::key));
     });
   hash_context[0] = rct::sk2rct(tx_secret_key_seed);
@@ -663,7 +663,7 @@ static bool set_tx_rct_signatures(
 
   // make pseudo-output commitments
   rct::keyV a;  //pseudo-output commitment blinding factors
-  auto a_wiper = epee::misc_utils::create_scope_leave_handler([&]{
+  const epee::scope_guard a_wiper([&]{
     memwipe(static_cast<rct::key *>(a.data()), a.size() * sizeof(rct::key));
   });
   if (not reconstruction) {
@@ -749,10 +749,7 @@ static bool set_tx_rct_signatures(
     }
 
     rct::key D;
-    rct::key z;
-    auto z_wiper = epee::misc_utils::create_scope_leave_handler([&]{
-      memwipe(static_cast<rct::key *>(&z), sizeof(rct::key));
-    });
+    tools::scrubbed<rct::key> z;
     if (not reconstruction) {
       sc_sub(z.bytes, sources[i].mask.bytes, a[i].bytes);  //commitment to zero privkey
       ge_p3 H_p3;
@@ -877,7 +874,7 @@ bool tx_builder_ringct_t::init(
 
   // get secret keys for signing input CLSAGs (multisig: or for the initial partial signature)
   rct::keyV input_secret_keys;
-  auto input_secret_keys_wiper = epee::misc_utils::create_scope_leave_handler([&]{
+  const epee::scope_guard input_secret_keys_wiper([&]{
     memwipe(static_cast<rct::key *>(input_secret_keys.data()), input_secret_keys.size() * sizeof(rct::key));
   });
   if (not compute_keys_for_sources(account_keys, sources, subaddr_account, subaddr_minor_indices, input_secret_keys))
@@ -891,7 +888,7 @@ bool tx_builder_ringct_t::init(
   rct::keyV output_public_keys;
   rct::keyV output_amount_secret_keys;
   std::vector<crypto::view_tag> view_tags;
-  auto output_amount_secret_keys_wiper = epee::misc_utils::create_scope_leave_handler([&]{
+  const epee::scope_guard output_amount_secret_keys_wiper([&]{
     memwipe(static_cast<rct::key *>(output_amount_secret_keys.data()), output_amount_secret_keys.size() * sizeof(rct::key));
   });
   if (not compute_keys_for_destinations(account_keys,
@@ -947,10 +944,7 @@ bool tx_builder_ringct_t::first_partial_sign(
   if (source >= num_sources)
     return false;
   rct::key c;
-  rct::key alpha_combined;
-  auto alpha_combined_wiper = epee::misc_utils::create_scope_leave_handler([&]{
-    memwipe(static_cast<rct::key *>(&alpha_combined), sizeof(rct::key));
-  });
+  tools::scrubbed<rct::key> alpha_combined;
   if (not CLSAG_contexts[source].combine_alpha_and_compute_challenge(
     total_alpha_G,
     total_alpha_H,
@@ -993,10 +987,7 @@ bool tx_builder_ringct_t::next_partial_sign(
     return false;
   for (std::size_t i = 0; i < num_sources; ++i) {
     rct::key c;
-    rct::key alpha_combined;
-    auto alpha_combined_wiper = epee::misc_utils::create_scope_leave_handler([&]{
-      memwipe(static_cast<rct::key *>(&alpha_combined), sizeof(rct::key));
-    });
+    tools::scrubbed<rct::key> alpha_combined;
     if (not CLSAG_contexts[i].combine_alpha_and_compute_challenge(
       total_alpha_G[i],
       total_alpha_H[i],
@@ -1011,10 +1002,7 @@ bool tx_builder_ringct_t::next_partial_sign(
     rct::key mu_C;
     if (not CLSAG_contexts[i].get_mu(mu_P, mu_C))
       return false;
-    rct::key w;
-    auto w_wiper = epee::misc_utils::create_scope_leave_handler([&]{
-      memwipe(static_cast<rct::key *>(&w), sizeof(rct::key));
-    });
+    tools::scrubbed<rct::key> w;
     sc_mul(w.bytes, mu_P.bytes, x.bytes);
 
     // include local signer's response:

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1153,7 +1153,7 @@ namespace nodetool
     bool r = epee::net_utils::async_invoke_remote_command2<typename COMMAND_HANDSHAKE::response>(context_, COMMAND_HANDSHAKE::ID, arg, zone.m_net_server.get_config_object(),
       [this, &pi, &ev, &hsh_result, &just_take_peerlist, &context_, &timeout](int code, const typename COMMAND_HANDSHAKE::response& rsp, p2p_connection_context& context)
     {
-      epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ev.raise();});
+      const epee::scope_guard scope_exit_handler([&](){ev.raise();});
 
       if(code < 0)
       {

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -33,15 +33,14 @@
 #include <atomic>
 
 #include "misc_log_ex.h"
-#include "misc_language.h"
 #include "common/perf_timer.h"
 #include "common/threadpool.h"
-#include "common/util.h"
 #include "bulletproofs.h"
 #include "bulletproofs_plus.h"
 #include "cryptonote_config.h"
 #include "device/device.hpp"
 #include "fcmp_pp/fcmp_pp_crypto.h"
+#include "scope_guard.h"
 #include "serialization/crypto.h"
 
 using namespace crypto;
@@ -180,7 +179,7 @@ namespace rct {
     //Borromean (c.f. gmax/andytoshi's paper)
     boroSig genBorromean(const key64 x, const key64 P1, const key64 P2, const bits indices) {
         key64 L[2], alpha;
-        auto wiper = epee::misc_utils::create_scope_leave_handler([&](){memwipe(alpha, sizeof(alpha));});
+        const epee::scope_guard wiper([&](){memwipe(alpha, sizeof(alpha));});
         key c;
         int naught = 0, prime = 0, ii = 0, jj=0;
         boroSig bb;
@@ -397,7 +396,7 @@ namespace rct {
         vector<geDsmp> Ip(dsRows);
         rv.II = keyV(dsRows);
         keyV alpha(rows);
-        auto wiper = epee::misc_utils::create_scope_leave_handler([&](){memwipe(alpha.data(), alpha.size() * sizeof(alpha[0]));});
+        const epee::scope_guard wiper([&](){memwipe(alpha.data(), alpha.size() * sizeof(alpha[0]));});
         keyV aG(rows);
         rv.ss = keyM(cols, aG);
         keyV aHP(dsRows);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -31,7 +31,6 @@
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/filesystem.hpp>
-#include "include_base_utils.h"
 #include "string_tools.h"
 using namespace epee;
 
@@ -48,7 +47,6 @@ using namespace epee;
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "cryptonote_basic/merge_mining.h"
 #include "cryptonote_core/tx_sanity_check.h"
-#include "misc_language.h"
 #include "net/local_ip.h"
 #include "net/parse.h"
 #include "storages/http_abstract_invoke.h"

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -110,7 +110,7 @@ using tools::fee_priority;
   m_wallet->stop(); \
   boost::unique_lock<boost::mutex> lock(m_idle_mutex); \
   m_idle_cond.notify_all(); \
-  epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ \
+  const epee::scope_guard scope_exit_handler([&](){ \
     /* m_idle_mutex is still locked here */ \
     m_auto_refresh_enabled.store(auto_refresh_enabled, std::memory_order_relaxed); \
     m_idle_cond.notify_one(); \
@@ -1425,7 +1425,7 @@ bool simple_wallet::import_multisig_main(const std::vector<std::string> &args, b
   try
   {
     m_in_manual_refresh.store(true, std::memory_order_relaxed);
-    epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
+    const epee::scope_guard scope_exit_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
     size_t n_outputs = m_wallet->import_multisig(info);
     // Clear line "Height xxx of xxx"
     std::cout << "\r                                                                \r";
@@ -3851,7 +3851,7 @@ static bool datestr_to_int(const std::string &heightstr, uint16_t &year, uint8_t
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::init(const boost::program_options::variables_map& vm)
 {
-  epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){
+  const epee::scope_guard scope_exit_handler([&](){
     m_electrum_seed.wipe();
   });
 
@@ -5605,7 +5605,7 @@ bool simple_wallet::refresh_main(uint64_t start_height, enum ResetType reset, bo
   try
   {
     m_in_manual_refresh.store(true, std::memory_order_relaxed);
-    epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
+    const epee::scope_guard scope_exit_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
     // For manual refresh don't allow incremental checking of the pool: Because we did not process the txs
     // for us in the pool during automatic refresh we could miss some of them if we checked the pool
     // incrementally here
@@ -6268,7 +6268,7 @@ bool simple_wallet::on_command(bool (simple_wallet::*cmd)(const std::vector<std:
   m_last_activity_time = time(NULL);
 
   m_in_command = true;
-  epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){
+  const epee::scope_guard scope_exit_handler([&](){
     m_last_activity_time = time(NULL);
     m_in_command = false;
   });
@@ -8402,7 +8402,7 @@ bool simple_wallet::get_transfers(std::vector<std::string>& local_args, std::vec
     try
     {
       m_in_manual_refresh.store(true, std::memory_order_relaxed);
-      epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
+      const epee::scope_guard scope_exit_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
 
       std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> process_txs;
       m_wallet->update_pool_state(process_txs);
@@ -8890,7 +8890,7 @@ bool simple_wallet::rescan_blockchain(const std::vector<std::string> &args_)
   }
 
   m_in_manual_refresh.store(true, std::memory_order_relaxed);
-  epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
+  const epee::scope_guard scope_exit_handler([&](){m_in_manual_refresh.store(false, std::memory_order_relaxed);});
   return refresh_main(start_height, reset_type, true);
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -65,7 +65,7 @@ using namespace cryptonote;
     m_refreshCV.notify_one(); \
     boost::mutex::scoped_lock lock(m_refreshMutex); \
     boost::mutex::scoped_lock lock2(m_refreshMutex2); \
-    epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){ \
+    const epee::scope_guard scope_exit_handler([&](){ \
         /* m_refreshMutex's still locked here */ \
         if (refresh_enabled) \
             startRefresh(); \

--- a/src/wallet/ringdb.cpp
+++ b/src/wallet/ringdb.cpp
@@ -32,7 +32,7 @@
 #include <boost/filesystem.hpp>
 #include "common/util.h"
 #include "misc_log_ex.h"
-#include "misc_language.h"
+#include "scope_guard.h"
 #include "wallet_errors.h"
 #include "ringdb.h"
 #include "cryptonote_config.h"
@@ -217,7 +217,7 @@ ringdb::ringdb(std::string filename, const std::string &genesis):
 
   dbr = mdb_txn_begin(env, NULL, 0, &txn);
   THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
-  epee::misc_utils::auto_scope_leave_caller txn_dtor = epee::misc_utils::create_scope_leave_handler([&](){if (tx_active) mdb_txn_abort(txn);});
+  const epee::scope_guard txn_dtor([&](){if (tx_active) mdb_txn_abort(txn);});
   tx_active = true;
 
   dbr = mdb_dbi_open(txn, ("rings-" + genesis).c_str(), MDB_CREATE, &dbi_rings);
@@ -254,7 +254,7 @@ bool ringdb::add_rings(const crypto::chacha_key &chacha_key, const cryptonote::t
   THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to set env map size");
   dbr = mdb_txn_begin(env, NULL, 0, &txn);
   THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
-  epee::misc_utils::auto_scope_leave_caller txn_dtor = epee::misc_utils::create_scope_leave_handler([&](){if (tx_active) mdb_txn_abort(txn);});
+  const epee::scope_guard txn_dtor([&](){if (tx_active) mdb_txn_abort(txn);});
   tx_active = true;
 
   for (const auto &in: tx.vin)
@@ -285,7 +285,7 @@ bool ringdb::remove_rings(const crypto::chacha_key &chacha_key, const std::vecto
   THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to set env map size");
   dbr = mdb_txn_begin(env, NULL, 0, &txn);
   THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
-  epee::misc_utils::auto_scope_leave_caller txn_dtor = epee::misc_utils::create_scope_leave_handler([&](){if (tx_active) mdb_txn_abort(txn);});
+  const epee::scope_guard txn_dtor([&](){if (tx_active) mdb_txn_abort(txn);});
   tx_active = true;
 
   for (const crypto::key_image &key_image: key_images)
@@ -342,7 +342,7 @@ bool ringdb::get_rings(const crypto::chacha_key &chacha_key, const std::vector<c
   THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to set env map size: " + std::string(mdb_strerror(dbr)));
   dbr = mdb_txn_begin(env, NULL, 0, &txn);
   THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
-  epee::misc_utils::auto_scope_leave_caller txn_dtor = epee::misc_utils::create_scope_leave_handler([&](){if (tx_active) mdb_txn_abort(txn);});
+  const epee::scope_guard txn_dtor([&](){if (tx_active) mdb_txn_abort(txn);});
   tx_active = true;
 
   for (size_t i = 0; i < key_images.size(); ++i)
@@ -405,7 +405,7 @@ bool ringdb::set_rings(const crypto::chacha_key &chacha_key, const std::vector<s
   THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to set env map size: " + std::string(mdb_strerror(dbr)));
   dbr = mdb_txn_begin(env, NULL, 0, &txn);
   THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to create LMDB transaction: " + std::string(mdb_strerror(dbr)));
-  epee::misc_utils::auto_scope_leave_caller txn_dtor = epee::misc_utils::create_scope_leave_handler([&](){if (tx_active) mdb_txn_abort(txn);});
+  const epee::scope_guard txn_dtor([&](){if (tx_active) mdb_txn_abort(txn);});
   tx_active = true;
 
   for (const auto &e: rings)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3779,7 +3779,7 @@ void wallet2::update_pool_state_by_pool_query(std::vector<std::tuple<cryptonote:
   MTRACE("update_pool_state_by_pool_query start");
   process_txs.clear();
 
-  auto keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this]() {
+  const epee::scope_guard keys_reencryptor([&, this]() {
     m_encrypt_keys_after_refresh.reset();
   });
 
@@ -3853,7 +3853,7 @@ void wallet2::update_pool_state_by_pool_query(std::vector<std::tuple<cryptonote:
 void wallet2::update_pool_state_from_pool_data(bool incremental, const std::vector<crypto::hash> &removed_pool_txids, const std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> &added_pool_txs, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> &process_txs, bool refreshed)
 {
   MTRACE("update_pool_state_from_pool_data start");
-  auto keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this]() {
+  const epee::scope_guard keys_reencryptor([&, this]() {
     m_encrypt_keys_after_refresh.reset();
   });
 
@@ -4110,11 +4110,11 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
   // subsequent pulls in this refresh.
   start_height = 0;
 
-  auto keys_reencryptor = epee::misc_utils::create_scope_leave_handler([&, this]() {
+  const epee::scope_guard keys_reencryptor([&, this]() {
     m_encrypt_keys_after_refresh.reset();
   });
 
-  auto scope_exit_handler_hwdev = epee::misc_utils::create_scope_leave_handler([&](){hwdev.computing_key_images(false);});
+  const epee::scope_guard scope_exit_handler_hwdev([&](){hwdev.computing_key_images(false);});
 
   std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> process_pool_txs;
   // Getting and processing the pool state has moved down into method 'pull_blocks' to
@@ -8315,7 +8315,7 @@ bool wallet2::sign_multisig_tx(multisig_tx_set &exported_txs_inout, std::vector<
       {
         rct::keyM local_nonces_k(sd.selected_transfers.size(), rct::keyV(multisig::signing::kAlphaComponents));
         rct::key skey = rct::zero();
-        auto wiper = epee::misc_utils::create_scope_leave_handler([&]{
+        const epee::scope_guard wiper([&]{
           for (auto& e: local_nonces_k)
             memwipe(e.data(), e.size() * sizeof(rct::key));
           memwipe(&skey, sizeof(rct::key));
@@ -9999,7 +9999,7 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
       //            because LR nonces can only be used for one tx attempt.
       for (std::size_t j = 0; j < num_sources; ++j) {
         rct::keyV alpha(num_alpha_components);
-        auto alpha_wiper = epee::misc_utils::create_scope_leave_handler([&]{
+        const epee::scope_guard alpha_wiper([&]{
           memwipe(static_cast<rct::key *>(alpha.data()), alpha.size() * sizeof(rct::key));
         });
         for (std::size_t m = 0; m < num_alpha_components; ++m) {
@@ -13552,7 +13552,7 @@ void wallet2::process_background_cache(const background_sync_data_t &background_
   // We expect the spend key to be in a decrypted state while
   // m_processing_background_cache is true
   m_processing_background_cache = true;
-  auto done_processing = epee::misc_utils::create_scope_leave_handler([&, this]() {
+  const epee::scope_guard done_processing([&, this]() {
     m_processing_background_cache = false;
   });
 
@@ -14790,7 +14790,7 @@ T wallet2::decrypt(const std::string &ciphertext, const crypto::secret_key &skey
       error::wallet_internal_error, "Failed to authenticate ciphertext");
   }
   std::unique_ptr<char[]> buffer{new char[ciphertext.size() - prefix_size]};
-  auto wiper = epee::misc_utils::create_scope_leave_handler([&]() { memwipe(buffer.get(), ciphertext.size() - prefix_size); });
+  const epee::scope_guard wiper([&]() { memwipe(buffer.get(), ciphertext.size() - prefix_size); });
   crypto::chacha20(ciphertext.data() + sizeof(iv), ciphertext.size() - prefix_size, key, iv, buffer.get());
   return T(buffer.get(), ciphertext.size() - prefix_size);
 }

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -35,8 +35,6 @@
 #include <cstdint>
 #include <chrono>
 #include <cstring>
-#include "include_base_utils.h"
-using namespace epee;
 
 #include "version.h"
 #include "wallet_rpc_server.h"
@@ -49,7 +47,6 @@ using namespace epee;
 #include "cryptonote_basic/account.h"
 #include "multisig/multisig.h"
 #include "wallet_rpc_server_commands_defs.h"
-#include "misc_language.h"
 #include "string_coding.h"
 #include "string_tools.h"
 #include "crypto/hash.h"
@@ -135,6 +132,8 @@ using namespace epee;
       return false; \
     } \
   } while (0)
+
+using namespace epee;
 
 namespace
 {
@@ -3519,7 +3518,7 @@ namespace tools
       return false;
     }
 
-    cryptonote::COMMAND_RPC_START_MINING::request daemon_req = AUTO_VAL_INIT(daemon_req); 
+    cryptonote::COMMAND_RPC_START_MINING::request daemon_req{};
     daemon_req.miner_address = m_wallet->get_account().get_public_address_str(m_wallet->nettype());
     daemon_req.threads_count        = req.threads_count;
     daemon_req.do_background_mining = req.do_background_mining;

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -43,19 +43,17 @@
 #include <boost/serialization/unordered_map.hpp>
 #include <boost/functional/hash.hpp>
 
-#include "include_base_utils.h"
 #include "chaingen_serialization.h"
 #include "common/command_line.h"
 #include "common/threadpool.h"
+#include "misc_log_ex.h"
 
 #include "cryptonote_basic/account_boost_serialization.h"
 #include "cryptonote_basic/cryptonote_basic.h"
-#include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "cryptonote_protocol/enums.h"
 #include "cryptonote_basic/cryptonote_boost_serialization.h"
-#include "misc_language.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "tests.core"
@@ -596,7 +594,7 @@ public:
   {
     log_event("cryptonote::transaction");
 
-    cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+    cryptonote::tx_verification_context tvc{};
     size_t pool_size = m_c.get_pool_transactions_count();
     m_c.handle_incoming_tx(t_serializable_object_to_blob(tx), tvc, m_tx_relay, false);
     bool tx_added = pool_size + 1 == m_c.get_pool_transactions_count();
@@ -611,7 +609,7 @@ public:
 
     std::vector<cryptonote::blobdata> tx_blobs;
     std::vector<cryptonote::tx_verification_context> tvcs;
-     cryptonote::tx_verification_context tvc0 = AUTO_VAL_INIT(tvc0);
+     cryptonote::tx_verification_context tvc0{};
     for (const auto &tx: txs)
     {
       tx_blobs.emplace_back(t_serializable_object_to_blob(tx));
@@ -630,7 +628,7 @@ public:
   {
     log_event("cryptonote::block");
 
-    cryptonote::block_verification_context bvc = AUTO_VAL_INIT(bvc);
+    cryptonote::block_verification_context bvc{};
     cryptonote::blobdata bd = t_serializable_object_to_blob(b);
     std::vector<cryptonote::block> pblocks;
     cryptonote::block_complete_entry bce;
@@ -665,7 +663,7 @@ public:
   {
     log_event("serialized_block");
 
-    cryptonote::block_verification_context bvc = AUTO_VAL_INIT(bvc);
+    cryptonote::block_verification_context bvc{};
     std::vector<cryptonote::block> pblocks;
     cryptonote::block_complete_entry bce;
     bce.pruned = false;
@@ -695,7 +693,7 @@ public:
   {
     log_event("serialized_transaction");
 
-    cryptonote::tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+    cryptonote::tx_verification_context tvc{};
     size_t pool_size = m_c.get_pool_transactions_count();
     m_c.handle_incoming_tx(sr_tx.data, tvc, m_tx_relay, false);
     bool tx_added = pool_size + 1 == m_c.get_pool_transactions_count();

--- a/tests/core_tests/chaingen_serialization.h
+++ b/tests/core_tests/chaingen_serialization.h
@@ -36,6 +36,7 @@
 #include <boost/filesystem/operations.hpp>
 
 #include "common/util.h"
+#include "misc_log_ex.h"
 
 namespace tools
 {

--- a/tests/fuzz/block.cpp
+++ b/tests/fuzz/block.cpp
@@ -37,6 +37,6 @@ BEGIN_INIT_SIMPLE_FUZZER()
 END_INIT_SIMPLE_FUZZER()
 
 BEGIN_SIMPLE_FUZZER()
-  cryptonote::block b = AUTO_VAL_INIT(b);
+  cryptonote::block b{};
   parse_and_validate_block_from_blob(std::string((const char*)buf, len), b);
 END_SIMPLE_FUZZER()

--- a/tests/fuzz/bulletproof.cpp
+++ b/tests/fuzz/bulletproof.cpp
@@ -38,6 +38,6 @@ END_INIT_SIMPLE_FUZZER()
 
 BEGIN_SIMPLE_FUZZER()
   binary_archive<false> ba{{buf, len}};
-  rct::Bulletproof proof = AUTO_VAL_INIT(proof);
+  rct::Bulletproof proof{};
   ::serialization::serialize(ba, proof);
 END_SIMPLE_FUZZER()

--- a/tests/fuzz/transaction.cpp
+++ b/tests/fuzz/transaction.cpp
@@ -37,6 +37,6 @@ BEGIN_INIT_SIMPLE_FUZZER()
 END_INIT_SIMPLE_FUZZER()
 
 BEGIN_SIMPLE_FUZZER()
-  cryptonote::transaction tx = AUTO_VAL_INIT(tx);
+  cryptonote::transaction tx{};
   parse_and_validate_tx_from_blob(std::string((const char*)buf, len), tx);
 END_SIMPLE_FUZZER()

--- a/tests/performance_tests/performance_tests.h
+++ b/tests/performance_tests/performance_tests.h
@@ -38,7 +38,6 @@
 #include <boost/chrono.hpp>
 #include <boost/regex.hpp>
 
-#include "misc_language.h"
 #include "stats.h"
 #include "common/perf_timer.h"
 #include "common/timings.h"

--- a/tests/trezor/daemon.cpp
+++ b/tests/trezor/daemon.cpp
@@ -233,7 +233,7 @@ bool mock_daemon::run_main()
     this->stop_p2p();
   });
 
-  epee::misc_utils::auto_scope_leave_caller scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&](){
+  const epee::scope_guard scope_exit_handler([&](){
     m_stopped = true;
     stop_thread.join();
   });

--- a/tests/unit_tests/block_reward.cpp
+++ b/tests/unit_tests/block_reward.cpp
@@ -31,6 +31,7 @@
 #include "gtest/gtest.h"
 
 #include "cryptonote_basic/cryptonote_basic_impl.h"
+#include "misc_language.h"
 
 using namespace cryptonote;
 

--- a/tests/unit_tests/epee_boosted_tcp_server.cpp
+++ b/tests/unit_tests/epee_boosted_tcp_server.cpp
@@ -217,7 +217,7 @@ TEST(test_epee_connection, test_lifetime)
 
   boost::asio::post(io_context, [&io_context, &work, &endpoint, &server]{
     shared_state_ptr shared_state;
-    auto scope_exit_handler = epee::misc_utils::create_scope_leave_handler([&work, &shared_state]{
+    const epee::scope_guard scope_exit_handler([&work, &shared_state]{
       work.reset();
       if (shared_state)
         shared_state->set_handler(nullptr, nullptr);

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -378,7 +378,7 @@ TEST(ban, file_banlist)
 
   const auto node_dir = create_temp_dir();
   ASSERT_TRUE(!node_dir.empty());
-  auto auto_remove_node_dir = epee::misc_utils::create_scope_leave_handler([&node_dir](){
+  const epee::scope_guard auto_remove_node_dir([&node_dir](){
       boost::filesystem::remove_all(node_dir);
     });
 
@@ -1310,7 +1310,7 @@ TEST(regtest, isolates_p2p_state_from_mainnet_data_dir)
 {
   const path_t dir = create_temp_dir("regtest-%%%%%%%%%%%%%%%%");
   ASSERT_TRUE(!dir.empty());
-  auto cleanup = epee::misc_utils::create_scope_leave_handler([&dir]{
+  const epee::scope_guard cleanup([&dir]{
     remove_tree(dir);
   });
 

--- a/tests/unit_tests/test_tx_utils.cpp
+++ b/tests/unit_tests/test_tx_utils.cpp
@@ -137,7 +137,7 @@ TEST(parse_tx_extra, handles_pub_key_and_padding)
 
 TEST(parse_and_validate_tx_extra, is_valid_tx_extra_parsed)
 {
-  cryptonote::transaction tx = AUTO_VAL_INIT(tx);
+  cryptonote::transaction tx;
   cryptonote::account_base acc;
   acc.generate();
   cryptonote::blobdata b = "dsdsdfsdfsf";
@@ -147,7 +147,7 @@ TEST(parse_and_validate_tx_extra, is_valid_tx_extra_parsed)
 }
 TEST(parse_and_validate_tx_extra, fails_on_big_extra_nonce)
 {
-  cryptonote::transaction tx = AUTO_VAL_INIT(tx);
+  cryptonote::transaction tx;
   cryptonote::account_base acc;
   acc.generate();
   cryptonote::blobdata b(TX_EXTRA_NONCE_MAX_COUNT + 1, 0);
@@ -155,7 +155,7 @@ TEST(parse_and_validate_tx_extra, fails_on_big_extra_nonce)
 }
 TEST(parse_and_validate_tx_extra, fails_on_wrong_size_in_extra_nonce)
 {
-  cryptonote::transaction tx = AUTO_VAL_INIT(tx);
+  cryptonote::transaction tx;
   tx.extra.resize(20, 0);
   tx.extra[0] = TX_EXTRA_NONCE;
   tx.extra[1] = 255;


### PR DESCRIPTION
And replace unused inclusions of `misc_language.h`.

Reduces `monerod` binary size by ~142KB when linking dynamically on my machine. Also reduces number of allocations done for lambdas passed to `std::function()` which cannot fit in SSO buffer.