### PR TITLE
net/socks: fix misleading error code

### DIFF
--- a/src/net/socks.cpp
+++ b/src/net/socks.cpp
@@ -608,7 +608,7 @@ namespace socks
                         bytes = sizeof(v5_response_ipv6);
                     else
                     {
-                        self.done(socks::error::unexpected_version, self_);
+                        self.done(socks::error::address_type_not_supported, self_);
                         return;
                     }
                 }


### PR DESCRIPTION
When the SOCKS5 address type is `0x03` (domain name), `socks::error::unexpected_version` is returned. This doesn't make much sense, since the problem is the address type rather than the protocol version.