### PR TITLE
rpc: speed up mempool lookup in get_transactions

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -951,11 +951,14 @@ namespace cryptonote
       {
         // sort to match original request
         std::vector<std::tuple<crypto::hash, cryptonote::blobdata, crypto::hash, cryptonote::blobdata>> sorted_txs;
-        std::vector<std::pair<crypto::hash, tx_memory_pool::tx_details>>::const_iterator i;
+        const std::unordered_set<crypto::hash> missed_set(missed_txs.begin(), missed_txs.end());
+        const std::unordered_map<crypto::hash, tx_memory_pool::tx_details> pool_tx_map(pool_txs.begin(), pool_txs.end());
+        std::unordered_map<crypto::hash, tx_memory_pool::tx_details>::const_iterator i;
         unsigned txs_processed = 0;
+        missed_txs.clear();
         for (const crypto::hash &h: vh)
         {
-          if (std::find(missed_txs.begin(), missed_txs.end(), h) == missed_txs.end())
+          if (missed_set.find(h) == missed_set.end())
           {
             if (txs.size() == txs_processed)
             {
@@ -971,7 +974,7 @@ namespace cryptonote
             sorted_txs.push_back(std::move(txs[txs_processed]));
             ++txs_processed;
           }
-          else if ((i = std::find_if(pool_txs.begin(), pool_txs.end(), [h](const std::pair<crypto::hash, tx_memory_pool::tx_details> &pt) { return h == pt.first; })) != pool_txs.end())
+          else if ((i = pool_tx_map.find(h)) != pool_tx_map.end())
           {
             const tx_memory_pool::tx_details &td = i->second;
             std::stringstream ss;
@@ -985,10 +988,13 @@ namespace cryptonote
             const cryptonote::blobdata pruned = ss.str();
             const crypto::hash prunable_hash = td.tx.version == 1 ? crypto::null_hash : get_transaction_prunable_hash(td.tx);
             sorted_txs.push_back(std::make_tuple(h, pruned, prunable_hash, std::string(td.tx_blob, pruned.size())));
-            missed_txs.erase(std::find(missed_txs.begin(), missed_txs.end(), h));
             pool_tx_hashes.insert(h);
             per_tx_pool_tx_details.insert(std::make_pair(h, td));
             ++found_in_pool;
+          }
+          else
+          {
+            missed_txs.push_back(h);
           }
         }
         txs = sorted_txs;

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -33,6 +33,7 @@
 #include <chrono>
 #include <cstring>
 #include <stdexcept>
+#include <unordered_set>
 
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/utility/string_ref.hpp>
@@ -281,6 +282,7 @@ namespace rpc
     // if any missing from blockchain, check in tx pool
     if (!missed_vec.empty())
     {
+      std::unordered_set<crypto::hash> missed_set(missed_vec.begin(), missed_vec.end());
       std::vector<cryptonote::transaction> pool_txs;
 
       m_core.get_pool_transactions(pool_txs);
@@ -289,17 +291,15 @@ namespace rpc
       {
         crypto::hash h = get_transaction_hash(tx);
 
-        auto itr = std::find(missed_vec.begin(), missed_vec.end(), h);
-
-        if (itr != missed_vec.end())
+        if (missed_set.erase(h))
         {
           found_hashes.push_back(h);
           found_txs_vec.push_back(tx);
           heights.push_back(std::numeric_limits<uint64_t>::max());
           in_pool.push_back(true);
-          missed_vec.erase(itr);
         }
       }
+      missed_vec.assign(missed_set.begin(), missed_set.end());
     }
 
     for (size_t i=0; i < found_hashes.size(); i++)


### PR DESCRIPTION
Avoids a quadratic lookup for mempool transactions in `daemon_handler`.