### PR TITLE
cryptonote_protocol: remove dead code

### DIFF
--- a/src/cryptonote_protocol/block_queue.cpp
+++ b/src/cryptonote_protocol/block_queue.cpp
@@ -182,14 +182,6 @@ uint64_t block_queue::get_next_needed_height(uint64_t blockchain_height) const
   return covered_until;
 }
 
-void block_queue::print() const
-{
-  boost::unique_lock<boost::recursive_mutex> lock(mutex);
-  MDEBUG("Block queue has " << blocks.size() << " spans");
-  for (const auto &span: blocks)
-    MDEBUG("  " << span.start_block_height << " - " << (span.start_block_height+span.nblocks-1) << " (" << span.nblocks << ") - " << (span.blocks.empty() ? "scheduled" : "filled    ") << "  " << span.connection_id << " (" << ((unsigned)(span.rate*10/1024.f))/10.f << " kB/s)");
-}
-
 std::string block_queue::get_overview(uint64_t blockchain_height) const
 {
   boost::unique_lock<boost::recursive_mutex> lock(mutex);
@@ -430,22 +422,6 @@ size_t block_queue::get_data_size() const
   return size;
 }
 
-size_t block_queue::get_num_filled_spans_prefix() const
-{
-  boost::unique_lock<boost::recursive_mutex> lock(mutex);
-
-  if (blocks.empty())
-    return 0;
-  block_map::const_iterator i = blocks.begin();
-  size_t size = 0;
-  while (i != blocks.end() && !i->blocks.empty())
-  {
-    ++i;
-    ++size;
-  }
-  return size;
-}
-
 size_t block_queue::get_num_filled_spans() const
 {
   boost::unique_lock<boost::recursive_mutex> lock(mutex);
@@ -454,35 +430,6 @@ size_t block_queue::get_num_filled_spans() const
   if (!span.blocks.empty())
     ++size;
   return size;
-}
-
-crypto::hash block_queue::get_last_known_hash(const boost::uuids::uuid &connection_id) const
-{
-  boost::unique_lock<boost::recursive_mutex> lock(mutex);
-  crypto::hash hash = crypto::null_hash;
-  uint64_t highest_height = 0;
-  for (const auto &span: blocks)
-  {
-    if (span.connection_id != connection_id)
-      continue;
-    uint64_t h = span.start_block_height + span.nblocks - 1;
-    if (h > highest_height && span.hashes.size() == span.nblocks)
-    {
-      hash = span.hashes.back();
-      highest_height = h;
-    }
-  }
-  return hash;
-}
-
-bool block_queue::has_spans(const boost::uuids::uuid &connection_id) const
-{
-  for (const auto &span: blocks)
-  {
-    if (span.connection_id == connection_id)
-      return true;
-  }
-  return false;
 }
 
 float block_queue::get_speed(const boost::uuids::uuid &connection_id) const
@@ -519,31 +466,6 @@ float block_queue::get_speed(const boost::uuids::uuid &connection_id) const
   const float speed = conn_rate / best_rate;
   MTRACE(" Relative speed for " << connection_id << ": " << speed << " (" << conn_rate << "/" << best_rate);
   return speed;
-}
-
-float block_queue::get_download_rate(const boost::uuids::uuid &connection_id) const
-{
-  boost::unique_lock<boost::recursive_mutex> lock(mutex);
-  float conn_rate = -1.f;
-  for (const auto &span: blocks)
-  {
-    if (span.blocks.empty())
-      continue;
-    if (span.connection_id != connection_id)
-      continue;
-    // note that the average below does not average over the whole set, but over the
-    // previous pseudo average and the latest rate: this gives much more importance
-    // to the latest measurements, which is fine here
-    if (conn_rate < 0.f)
-      conn_rate = span.rate;
-    else
-      conn_rate = (conn_rate + span.rate) / 2;
-  }
-
-  if (conn_rate < 0)
-    conn_rate = 0.0f;
-  MTRACE("Download rate for " << connection_id << ": " << conn_rate << " b/s");
-  return conn_rate;
 }
 
 bool block_queue::foreach(std::function<bool(const span&)> f) const

--- a/src/cryptonote_protocol/block_queue.h
+++ b/src/cryptonote_protocol/block_queue.h
@@ -78,9 +78,7 @@ namespace cryptonote
     bool remove_span(uint64_t start_block_height, std::vector<crypto::hash> *hashes = NULL);
     void remove_spans(const boost::uuids::uuid &connection_id, uint64_t start_block_height);
     uint64_t get_max_block_height() const;
-    void print() const;
     std::string get_overview(uint64_t blockchain_height) const;
-    bool has_unpruned_height(uint64_t block_height, uint64_t blockchain_height, uint32_t pruning_seed) const;
     std::pair<uint64_t, uint64_t> reserve_span(uint64_t first_block_height, uint64_t last_block_height, uint64_t max_blocks, const boost::uuids::uuid &connection_id, const epee::net_utils::network_address &addr, bool sync_pruned_blocks, uint32_t local_pruning_seed, uint32_t pruning_seed, uint64_t blockchain_height, const std::vector<std::pair<crypto::hash, uint64_t>> &block_hashes, boost::posix_time::ptime time = boost::posix_time::microsec_clock::universal_time());
     uint64_t get_next_needed_height(uint64_t blockchain_height) const;
     std::pair<uint64_t, uint64_t> get_next_span_if_scheduled(std::vector<crypto::hash> &hashes, boost::uuids::uuid &connection_id, boost::posix_time::ptime &time) const;
@@ -90,12 +88,8 @@ namespace cryptonote
     bool has_next_span(const boost::uuids::uuid &connection_id, bool &filled, boost::posix_time::ptime &time) const;
     bool has_next_span(uint64_t height, bool &filled, boost::posix_time::ptime &time, boost::uuids::uuid &connection_id) const;
     size_t get_data_size() const;
-    size_t get_num_filled_spans_prefix() const;
     size_t get_num_filled_spans() const;
-    crypto::hash get_last_known_hash(const boost::uuids::uuid &connection_id) const;
-    bool has_spans(const boost::uuids::uuid &connection_id) const;
     float get_speed(const boost::uuids::uuid &connection_id) const;
-    float get_download_rate(const boost::uuids::uuid &connection_id) const;
     bool foreach(std::function<bool(const span&)> f) const;
     bool requested(const crypto::hash &hash) const;
     bool have(const crypto::hash &hash) const;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -55,7 +55,6 @@
 PUSH_WARNINGS
 DISABLE_VS_WARNINGS(4355)
 
-#define LOCALHOST_INT 2130706433
 #define CURRENCY_PROTOCOL_MAX_OBJECT_REQUEST_COUNT 100
 static_assert(CURRENCY_PROTOCOL_MAX_OBJECT_REQUEST_COUNT >= BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_PRE_V4, "Invalid CURRENCY_PROTOCOL_MAX_OBJECT_REQUEST_COUNT");
 
@@ -164,7 +163,6 @@ namespace cryptonote
     //bool get_payload_sync_data(HANDSHAKE_DATA::request& hshd, cryptonote_connection_context& context);
     bool should_drop_connection(cryptonote_connection_context& context, uint32_t next_stripe);
     bool request_missing_objects(cryptonote_connection_context& context, bool check_having_blocks, bool force_next_span = false);
-    size_t get_synchronizing_connections_count();
     bool on_connection_synchronized();
     bool should_download_next_span(cryptonote_connection_context& context, bool standby);
     bool should_ask_for_pruned_data(cryptonote_connection_context& context, uint64_t first_block_height, uint64_t nblocks, bool check_block_weights) const;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -77,7 +77,6 @@
 #define REQUEST_NEXT_SCHEDULED_SPAN_THRESHOLD (30 * 1000000) // microseconds
 #define IDLE_PEER_KICK_TIME (240 * 1000000) // microseconds
 #define NON_RESPONSIVE_PEER_KICK_TIME (20 * 1000000) // microseconds
-#define PASSIVE_PEER_KICK_TIME (60 * 1000000) // microseconds
 #define DROP_ON_SYNC_WEDGE_THRESHOLD (30 * 1000000000ull) // nanoseconds
 #define LAST_ACTIVITY_STALL_THRESHOLD (2.0f) // seconds
 #define DROP_PEERS_ON_SCORE -2
@@ -2473,18 +2472,6 @@ skip:
     }
 
     return true;
-  }
-  //------------------------------------------------------------------------------------------------------------------------
-  template<class t_core>
-  size_t t_cryptonote_protocol_handler<t_core>::get_synchronizing_connections_count()
-  {
-    size_t count = 0;
-    m_p2p->for_each_connection([&](cryptonote_connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)->bool{
-      if(context.m_state == cryptonote_connection_context::state_synchronizing)
-        ++count;
-      return true;
-    });
-    return count;
   }
   //------------------------------------------------------------------------------------------------------------------------
   template<class t_core>


### PR DESCRIPTION
block_queue:
- print(): added with two debug call sites in the sync-speedup rewrite (5be43fcdb, 2017-07-02); 08abb670e (2017-08-12) removed one call and Pruning (b750fb27b, 2018-04-29) removed the last; dead since.
- get_num_filled_spans_prefix(): added in 5be43fcdb (2017-07-02) without any caller; dead on arrival.
- get_last_known_hash(): added in 5be43fcdb with one caller in the protocol handler; 08abb670e (2017-08-12) removed that caller while reworking reorg handling; dead since.
- has_spans(): added in 7b7476075 (2017-08-16, kick idle synchronizing peers) without any caller; dead on arrival.
- get_download_rate(): added by Pruning (b750fb27b, 2018-04-29) without any caller; dead on arrival.
- has_unpruned_height(): declaration added by Pruning (b750fb27b); a definition never existed, so it was never callable.

cryptonote_protocol_handler:
- get_synchronizing_connections_count(): from the original 2014 import (296ae46ed, 2014-03-03); its only reference was already commented out in the import, and 8efa1313f (2014-03-20) deleted that comment. Never had a live caller in the repo's history.
- PASSIVE_PEER_KICK_TIME: added in 1ff638e92 (2017-10-19) with one use in the idle-peer kick threshold; Pruning (b750fb27b) removed the use, orphaning the macro.
- LOCALHOST_INT: added in ae2a50659 (2015-02-20) for numeric localhost comparisons, second use added in c511abf00; 072102cfd (2017-05-27, abstracted network addresses) removed both uses.