### PR TITLE
wallet_api: return all unsigned tx recipients

### DIFF
--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -297,7 +297,9 @@ std::vector<std::string> UnsignedTransactionImpl::recipientAddress() const
           MERROR("empty destinations, skipped");
           continue;
         }
-        result.push_back(cryptonote::get_account_address_as_str(m_wallet.m_wallet->nettype(), utx.dests[0].is_subaddress, utx.dests[0].addr));
+        for (const auto &unsigned_dest : utx.dests) {
+            result.push_back(cryptonote::get_account_address_as_str(m_wallet.m_wallet->nettype(), unsigned_dest.is_subaddress, unsigned_dest.addr));
+        }
     }
     return result;
 }

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -140,6 +140,7 @@ struct UnsignedTransaction
     // returns a string with information about all transactions.
     virtual std::string confirmationMessage() const = 0;
     virtual std::vector<std::string> paymentId() const = 0;
+    // returns one address per destination, in the same order as amount().
     virtual std::vector<std::string> recipientAddress() const = 0;
     virtual uint64_t minMixinCount() const = 0;
     /*!

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -747,8 +747,6 @@ TEST_F(WalletTest1, WalletTransaction)
     ASSERT_TRUE(wmgr->closeWallet(wallet1));
 }
 
-
-
 TEST_F(WalletTest1, WalletTransactionWithMixin)
 {
 
@@ -957,12 +955,16 @@ TEST_F(WalletTest1, WalletTransactionMultDestWithPaymentId)
     ASSERT_TRUE(payment_id.length() == 16);
     Monero::Wallet * wallet_dst = wmgr->openWallet(CURRENT_DST_WALLET, TESTNET_WALLET_PASS, WALLET_NETWORK_TYPE);
     ASSERT_TRUE(wallet_dst != nullptr);
+    const std::string destination_address = wallet_dst->mainAddress();
     std::string integrated_address = wallet_dst->integratedAddress(payment_id);
     ASSERT_FALSE(integrated_address.empty());
     ASSERT_TRUE(wmgr->closeWallet(wallet_dst));
 
     const std::vector<std::string> destinations{integrated_address, wallet_src->mainAddress()};
+    const std::vector<std::string> recipient_addresses{destination_address, wallet_src->mainAddress()};
     const std::vector<uint64_t> amounts{AMOUNT_1XMR, AMOUNT_1XMR};
+    const std::string unsigned_tx_filename = "unsigned-multi-destination-with-payment-id";
+    boost::filesystem::remove(unsigned_tx_filename);
     Monero::PendingTransaction * tx = wallet_src->createTransactionMultDest(
             destinations, PAYMENT_ID_EMPTY, amounts, 1,
             Monero::PendingTransaction::Priority_Medium, 0, std::set<uint32_t>{});
@@ -971,6 +973,16 @@ TEST_F(WalletTest1, WalletTransactionMultDestWithPaymentId)
     std::cerr << "Transaction fee: " << Monero::Wallet::displayAmount(tx->fee()) << std::endl;
     std::cerr << "Transaction error: " << tx->errorString() << std::endl;
     ASSERT_TRUE(tx->status() == Monero::PendingTransaction::Status_Ok);
+    ASSERT_TRUE(tx->commit(unsigned_tx_filename)) << tx->errorString();
+
+    Monero::UnsignedTransaction * unsigned_transaction = wallet_src->loadUnsignedTx(unsigned_tx_filename);
+    ASSERT_EQ(Monero::UnsignedTransaction::Status_Ok, unsigned_transaction->status()) << unsigned_transaction->errorString();
+    ASSERT_EQ(1, unsigned_transaction->txCount());
+    EXPECT_EQ(amounts, unsigned_transaction->amount());
+    EXPECT_EQ(recipient_addresses, unsigned_transaction->recipientAddress());
+
+    delete unsigned_transaction;
+    boost::filesystem::remove(unsigned_tx_filename);
     ASSERT_TRUE(tx->commit());
     history->refresh();
     ASSERT_TRUE(count != history->count());


### PR DESCRIPTION
## what

return every destination from `UnsignedTransaction::recipientAddress()` instead of only the first destination in each transaction

keep the returned addresses aligned with `amount()` and add a libwallet API regression test covering a two-recipient unsigned transaction

## why

wallets using `recipientAddress()` to review pay-to-many unsigned transactions currently receive an incomplete recipient list

fixes #10919

## testing

- full build with `BUILD_TESTS=ON` and `BUILD_GUI_DEPS=ON`
- `libwallet_api_tests`
- targeted red/green check for `WalletTest1.WalletUnsignedTransactionReturnsAllRecipients`