### PR TITLE
[DO NOT MERGE] cryptonote_core: explicitly require >0 coinbase outs

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1345,6 +1345,7 @@ bool Blockchain::prevalidate_miner_transaction(const block& b, uint64_t height, 
   LOG_PRINT_L3("Blockchain::" << __func__);
   CHECK_AND_ASSERT_MES(b.miner_tx.vin.size() == 1, false, "coinbase transaction in the block has no inputs");
   CHECK_AND_ASSERT_MES(b.miner_tx.vin[0].type() == typeid(txin_gen), false, "coinbase transaction in the block has the wrong type");
+  CHECK_AND_ASSERT_MES(!b.miner_tx.vout.empty(), false, "coinbase transaction in the block has no outputs");
   CHECK_AND_ASSERT_MES(b.miner_tx.version > 1 || hf_version < HF_VERSION_MIN_V2_COINBASE_TX, false, "Invalid coinbase transaction version");
 
   // for v2 txes (ringct), we only accept empty rct signatures for miner transactions,


### PR DESCRIPTION
Ignore the rest of this description, going to implement [this](https://github.com/monero-project/monero/pull/10941#issuecomment-5170476930).
____
Still TODO: make sure that **all** coinbase txs in the mainnet chain (and testnet/stagenet chains) have at least 1 out. Syncing from scratch with this change would suffice. If such a sync fails, then this PR would need to be modified.

This rule is an explicit requirement needed for FCMP++, but should already be implicitly enforced at consensus since `HF_VERSION_EXACT_COINBASE`.

Note: since `validate_miner_transaction` [since `HF_VERSION_EXACT_COINBASE` requires coinbase outs to sum to the expected block reward + fees from the block](https://github.com/monero-project/monero/blob/9e1a88ba83cf8adac52d4eb019ab1c0d5dfff934/src/cryptonote_core/blockchain.cpp#L1417-L1419), then so long as we can sync up to that fork height with this change, then this change should be fine to introduce.

For further context on why this is necessary for FCMP++ see https://github.com/seraphis-migration/monero/issues/389.