### PR TITLE
cmake: add wire dependency for cryptonote_core RTTI linkage

### DIFF
--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(cryptonote_core
     ringct
     device
     hardforks
+    wire
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_SERIALIZATION_LIBRARY}


### PR DESCRIPTION
Reported by @SNeedlewoods 