### PR TITLE
blockchain_prune: use per-table LMDB stats for resize estimation [release-v0.18]

### DIFF
--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -185,7 +185,7 @@ static void copy_table(MDB_env *env0, MDB_env *env1, const char *table, unsigned
   if (dbr) throw std::runtime_error("Failed to commit txn: " + std::string(mdb_strerror(dbr)));
   tx_active1 = false;
   MDB_stat stats;
-  dbr = mdb_env_stat(env0, &stats);
+  dbr = mdb_stat(txn0, dbi0, &stats);
   if (dbr) throw std::runtime_error("Failed to stat " + std::string(table) + " LMDB table: " + std::string(mdb_strerror(dbr)));
   check_resize(env1, (stats.ms_branch_pages + stats.ms_overflow_pages + stats.ms_leaf_pages) * stats.ms_psize);
   dbr = mdb_txn_begin(env1, NULL, 0, &txn1);


### PR DESCRIPTION
#10945