### PR TITLE
lmdb: round map sizes up to page boundaries

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -561,7 +561,9 @@ void BlockchainLMDB::do_resize(uint64_t increase_size)
   if (increase_size > 0)
     new_mapsize = mei.me_mapsize + increase_size;
 
-  new_mapsize += (new_mapsize % mst.ms_psize);
+  const uint64_t remainder = new_mapsize % mst.ms_psize;
+  if (remainder)
+    new_mapsize += mst.ms_psize - remainder;
 
   mdb_txn_safe::prevent_new_txns();
 

--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -123,7 +123,9 @@ static void add_size(MDB_env *env, uint64_t bytes)
   mdb_env_stat(env, &mst);
 
   uint64_t new_mapsize = (uint64_t)mei.me_mapsize + bytes;
-  new_mapsize += (new_mapsize % mst.ms_psize);
+  const uint64_t remainder = new_mapsize % mst.ms_psize;
+  if (remainder)
+    new_mapsize += mst.ms_psize - remainder;
 
   int result = mdb_env_set_mapsize(env, new_mapsize);
   if (result)


### PR DESCRIPTION
Round requested LMDB map sizes upward to the next page boundary. This avoids producing incorrectly aligned map sizes when the requested size is not already page-aligned.