### PR TITLE
dns_utils: replace flaky DNS provider

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -52,8 +52,8 @@ static const char *DEFAULT_DNS_PUBLIC_ADDR[] =
 {
   "9.9.9.10",           // Quad9 (unfiltered)
   "149.112.112.10",     // Quad9 secondary
-  "76.76.2.0",          // Control D (unfiltered)
-  "76.76.10.0",         // Control D secondary
+  "185.222.222.222",    // DNS.SB
+  "45.11.45.11",        // DNS.SB secondary
   "194.150.168.168",    // CCC (Germany)
 };
 


### PR DESCRIPTION
Control D frequently appears to fail lookups on CI.