### PR TITLE
dns_utils: list jurisdictions of providers

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -50,10 +50,10 @@ using namespace epee;
 
 static const char *DEFAULT_DNS_PUBLIC_ADDR[] =
 {
-  "9.9.9.10",           // Quad9 (unfiltered)
-  "149.112.112.10",     // Quad9 secondary
-  "185.222.222.222",    // DNS.SB
-  "45.11.45.11",        // DNS.SB secondary
+  "9.9.9.10",           // Quad9 unfiltered (Switzerland)
+  "149.112.112.10",     // Quad9 secondary (Switzerland)
+  "185.222.222.222",    // DNS.SB (Germany)
+  "45.11.45.11",        // DNS.SB secondary (Germany)
   "194.150.168.168",    // CCC (Germany)
 };
 


### PR DESCRIPTION
This was already done before the providers were changed a few days ago (see #10957).