### PR TITLE
external: add mx25519

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 [submodule "external/gtest"]
 	path = external/gtest
 	url = https://github.com/google/googletest.git
+[submodule "external/mx25519"]
+	path = external/mx25519
+	url = https://github.com/tevador/mx25519.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,6 +385,7 @@ if(NOT MANUAL_SUBMODULES)
     endfunction ()
     
     message(STATUS "Checking submodules")
+    check_submodule(external/mx25519)
     check_submodule(external/rapidjson)
     check_submodule(external/randomx)
     check_submodule(external/supercop)
@@ -460,7 +461,13 @@ elseif(CMAKE_SYSTEM_NAME MATCHES ".*BSDI.*")
   set(BSDI TRUE)
 endif()
 
-include_directories(external/rapidjson/include external/easylogging++ src contrib/epee/include external external/supercop/include)
+include_directories(external/rapidjson/include
+  external/easylogging++
+  external/mx25519/include
+  src
+  contrib/epee/include
+  external
+  external/supercop/include)
 
 option(STATIC "Link libraries statically" OFF)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -30,5 +30,6 @@
 
 add_subdirectory(db_drivers)
 add_subdirectory(easylogging++)
+add_subdirectory(mx25519)
 add_subdirectory(qrcodegen)
 add_subdirectory(randomx EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Adds a submodule for https://github.com/tevador/mx25519, a pre-requisite for [`carrot_core`](#9559). Currently, the commit/branch points to the current `master` branch on tevador's repository, with the following PRs merged:
  - https://github.com/tevador/mx25519/pull/10
  - https://github.com/tevador/mx25519/pull/11
  - https://github.com/tevador/mx25519/pull/13
  - https://github.com/tevador/mx25519/pull/14
  - https://github.com/tevador/mx25519/pull/15
  - https://github.com/tevador/mx25519/pull/16
  - https://github.com/tevador/mx25519/pull/17