### PR TITLE
depends: unbound: update to 1.25.2

### DIFF
--- a/contrib/depends/packages/unbound.mk
+++ b/contrib/depends/packages/unbound.mk
@@ -1,8 +1,8 @@
 package=unbound
-$(package)_version=1.25.1
+$(package)_version=1.25.2
 $(package)_download_path=https://www.nlnetlabs.nl/downloads/$(package)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=0fe8b6277b0959cfd17562debac0aa5f71e0b02dc4ffa9c60271c583edab586f
+$(package)_sha256_hash=0d92275c703d5f5f8baba3dab22117dd8c29b495588a5c229768ed6581566600
 $(package)_dependencies=openssl
 $(package)_patches=no-expat.patch
 


### PR DESCRIPTION
Security release.

https://github.com/NLnetLabs/unbound/releases/tag/release-1.25.2