### PR TITLE
simplewallet: use more straightforward device message

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5508,7 +5508,7 @@ boost::optional<epee::wipeable_string> simple_wallet::on_get_password(const char
 //----------------------------------------------------------------------------------------------------
 void simple_wallet::on_device_button_request(uint64_t code)
 {
-  message_writer(console_color_white, false) << tr("Device requires attention");
+  message_writer(console_color_white, false) << tr("Device requests confirmation");
 }
 //----------------------------------------------------------------------------------------------------
 boost::optional<epee::wipeable_string> simple_wallet::on_device_pin_request()


### PR DESCRIPTION
The wording "Device requires attention" may lead one to believe there's something wrong with the device, rather than it likely just needing some action to be confirmed.

Also, as @WeebDataHoarder pointed out on IRC, "requires is also weird verb there, as it could be understood that the requires comes from monero side, not device side".