### PR TITLE
device_trezor: improve error message for view key export

### DIFF
--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -205,6 +205,8 @@ namespace trezor {
 
         return true;
 
+      } catch(const exc::proto::CancelledException &){
+        CHECK_AND_ASSERT_THROW_MES(false, "Key export rejected on device");
       } catch(std::exception const& e){
         MERROR("Get secret keys exception: " << e.what());
         return false;


### PR DESCRIPTION
Adds a more helpful error message when attempting to export view keys from a Trezor device. Tested and working on a Trezor Safe 3.

Before: `Error: failed to generate new wallet: Cannot get device secret`
After: `Error: failed to generate new wallet: Key export rejected on device`