### PR TITLE
device_trezor: reject incompatible firmware versions

### DIFF
--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -172,6 +172,8 @@ namespace trezor {
         pubkey = info.address;
         return true;
 
+      } catch(exc::FirmwareNotSupportedException const&){
+        throw;
       } catch(std::exception const& e){
         MERROR("Get public address exception: " << e.what());
         return false;
@@ -207,6 +209,8 @@ namespace trezor {
 
       } catch(const exc::proto::CancelledException &){
         CHECK_AND_ASSERT_THROW_MES(false, "Key export rejected on device");
+      } catch(exc::FirmwareNotSupportedException const&){
+        throw;
       } catch(std::exception const& e){
         MERROR("Get secret keys exception: " << e.what());
         return false;

--- a/src/device_trezor/device_trezor_base.cpp
+++ b/src/device_trezor/device_trezor_base.cpp
@@ -29,6 +29,7 @@
 
 #include "device_trezor_base.hpp"
 #include "memwipe.h"
+#include <algorithm>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -239,6 +240,12 @@ namespace trezor {
       // Hard requirement on initialized field, has to be there.
       if (!m_features->has_initialized() || !m_features->initialized()){
         throw exc::TrezorException("Device is not initialized");
+      }
+
+      // Reject firmware that doesn't have the Monero feature/capability
+      const auto& capabilities = m_features->capabilities();
+      if (std::find(capabilities.begin(), capabilities.end(), messages::management::Features::Capability_Monero) == capabilities.end()){
+        throw exc::FirmwareNotSupportedException();
       }
     }
 

--- a/src/device_trezor/trezor/exceptions.hpp
+++ b/src/device_trezor/trezor/exceptions.hpp
@@ -118,6 +118,12 @@ namespace exc {
     ProtocolException(): CommunicationException("Trezor protocol error"){}
   };
 
+  class FirmwareNotSupportedException: public TrezorException {
+  public:
+    using TrezorException::TrezorException;
+    FirmwareNotSupportedException(): TrezorException("Trezor firmware version does not support Monero"){}
+  };
+
   // Communication protocol namespace
   // Separated to distinguish between client and Trezor side exceptions.
 namespace proto {


### PR DESCRIPTION
Rejects Trezor firmware versions that don't support Monero, including the Bitcoin-only firmware. Tested on a Trezor Safe 3 with Bitcoin-only firmware installed.

Related: https://github.com/monero-project/monero-gui/issues/4105