### PR TITLE
wallet: display private view keys for hardware wallets

### DIFF
--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -151,6 +151,7 @@ namespace hw {
         /* ======================================================================= */
         virtual bool  get_public_address(cryptonote::account_public_address &pubkey) = 0;
         virtual bool  get_secret_keys(crypto::secret_key &viewkey , crypto::secret_key &spendkey)  = 0;
+        virtual bool  get_cached_view_key(crypto::secret_key &viewkey_out) { return false; }
         virtual bool  generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key, uint64_t kdf_rounds) = 0;
 
         /* ======================================================================= */

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -657,6 +657,15 @@ namespace hw {
         return true;
     }
 
+    bool device_ledger::get_cached_view_key(crypto::secret_key &viewkey_out) {
+        AUTO_LOCK_CMD();
+
+        if (!this->soft_request_view_key()) return false;
+        viewkey_out = this->viewkey;
+
+        return true;
+    }
+
     bool  device_ledger::generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key, uint64_t kdf_rounds) {
         AUTO_LOCK_CMD();
 

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -224,6 +224,7 @@ namespace hw {
         /* ======================================================================= */
         bool  get_public_address(cryptonote::account_public_address &pubkey) override;
         bool  get_secret_keys(crypto::secret_key &viewkey , crypto::secret_key &spendkey) override;
+        bool  get_cached_view_key(crypto::secret_key &viewkey_out) override;
         bool  generate_chacha_key(const cryptonote::account_keys &keys, crypto::chacha_key &key, uint64_t kdf_rounds) override;
         void  display_address(const cryptonote::subaddress_index& index, const boost::optional<crypto::hash8> &payment_id) override;
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -829,13 +829,16 @@ bool simple_wallet::viewkey(const std::vector<std::string> &args/* = std::vector
 {
   // don't log
   PAUSE_READLINE();
-  if (m_wallet->key_on_device()) {
-    std::cout << "secret: On device. Not available" << std::endl;
-  } else {
-    SCOPED_WALLET_UNLOCK();
+  SCOPED_WALLET_UNLOCK();
+  crypto::secret_key viewkey = m_wallet->get_account().get_keys().m_view_secret_key;
+  bool available = viewkey != crypto::null_skey;
+  if (!available && m_wallet->key_on_device()) available = m_wallet->get_account().get_device().get_cached_view_key(viewkey);
+  if (available) {
     printf("secret: ");
-    print_secret_key(m_wallet->get_account().get_keys().m_view_secret_key);
+    print_secret_key(viewkey);
     putchar('\n');
+  } else {
+    std::cout << "secret: On device. Not available" << std::endl;
   }
   std::cout << "public: " << string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_account_address.m_view_public_key) << std::endl;
 


### PR DESCRIPTION
Enables displaying the private view keys of hardware wallets, namely for the `viewkey` command in the CLI wallet. Previously, this command would just display `On device. Not available` for *both* the private view and spend keys, the former of which is actually accessible.

This patch is tested and working for Trezor devices; Ledger devices have not been tested as I do not have access to one. The added function in `device.hpp` is called `get_cached_view_key` rather than just `get_view_key` due to a compiler warning.

cc @SNeedlewoods (sorry for the second ping of the day)