### PR TITLE
p2p: remove dead code

### DIFF
--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -67,20 +67,6 @@ namespace
         return 0;
     }
 
-    template<typename T>
-    epee::net_utils::network_address get_address(const boost::string_ref value)
-    {
-        expect<T> address = T::make(value);
-        if (!address)
-        {
-            MERROR(
-                "Failed to parse " << epee::net_utils::zone_to_string(T::get_zone()) << " address \"" << value << "\": " << address.error().message()
-            );
-            return {};
-        }
-        return {std::move(*address)};
-    }
-
     bool start_socks(std::shared_ptr<net::socks::client> client, const net::socks::endpoint& proxy, const epee::net_utils::network_address& remote)
     {
         CHECK_AND_ASSERT_MES(client != nullptr, false, "Unexpected null client");
@@ -296,7 +282,6 @@ namespace nodetool
                 return boost::none;
             }
 
-            // get_address returns default constructed address on error
             if (inbounds.back().our_address == epee::net_utils::network_address{})
                 return boost::none;
 

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -129,8 +129,6 @@ namespace nodetool
                      public epee::net_utils::i_connection_filter,
                      public epee::net_utils::i_connection_limit
   {
-    struct by_conn_id{};
-    struct by_peer_id{};
     struct by_addr{};
 
     typedef p2p_connection_context_t<typename t_payload_net_handler::connection_context> p2p_connection_context;
@@ -265,7 +263,6 @@ namespace nodetool
     t_payload_net_handler& get_payload_object();
 
     // debug functions
-    bool log_peerlist();
     bool log_connections();
 
     // These functions only return information for the "public" zone
@@ -325,8 +322,6 @@ namespace nodetool
     int handle_ping(int command, COMMAND_PING::request& arg, COMMAND_PING::response& rsp, p2p_connection_context& context);
     int handle_get_support_flags(int command, COMMAND_REQUEST_SUPPORT_FLAGS::request& arg, COMMAND_REQUEST_SUPPORT_FLAGS::response& rsp, p2p_connection_context& context);
     bool init_config();
-    bool make_default_peer_id();
-    bool make_default_config();
     bool store_config();
 
 
@@ -349,14 +344,12 @@ namespace nodetool
     virtual bool is_host_limit(const epee::net_utils::network_address &address);
     //-----------------------------------------------------------------------------------------------
 
-    bool parse_peer_from_string(epee::net_utils::network_address& pe, const std::string& node_addr, uint16_t default_port = 0);
     bool handle_command_line(
         const boost::program_options::variables_map& vm
       );
     bool idle_worker();
     bool handle_remote_peerlist(const std::vector<peerlist_entry>& peerlist, const epee::net_utils::connection_context_base& context);
     bool get_local_node_data(basic_node_data& node_data, const network_zone& zone);
-    //bool get_local_handshake_data(handshake_data& hshd);
 
     bool sanitize_peerlist(std::vector<peerlist_entry>& local_peerlist);
 
@@ -400,9 +393,7 @@ namespace nodetool
     bool set_rate_limit(const boost::program_options::variables_map& vm, int64_t limit);
 
     bool has_too_many_connections(const epee::net_utils::network_address &address);
-    size_t get_incoming_connections_count();
     size_t get_incoming_connections_count(network_zone&);
-    size_t get_outgoing_connections_count();
     size_t get_outgoing_connections_count(network_zone&);
 
     bool check_connection_and_handshake_with_peer(const epee::net_utils::network_address& na, uint64_t last_seen_stamp);
@@ -428,16 +419,9 @@ namespace nodetool
       m_rpc_port = rpc_port;
     }
 
-    void set_rpc_credits_per_hash(uint32_t rpc_credits_per_hash)
-    {
-      m_rpc_credits_per_hash = rpc_credits_per_hash;
-    }
-
   private:
     std::string m_config_folder;
 
-    bool m_have_address;
-    bool m_first_connection_maker_call;
     uint32_t m_listening_port;
     uint32_t m_listening_port_ipv6;
     uint32_t m_external_port;
@@ -451,8 +435,6 @@ namespace nodetool
     std::atomic<bool> is_closing;
     std::atomic<bool> m_stop_signal_sent_once{false};
     std::unique_ptr<boost::thread> mPeersLoggerThread;
-    //critical_section m_connections_lock;
-    //connections_indexed_container m_connections;
 
     t_payload_net_handler& m_payload_handler;
     peerlist_storage m_peerlist_storage;
@@ -468,7 +450,6 @@ namespace nodetool
     std::vector<epee::net_utils::network_address> m_exclusive_peers;
     std::atomic_flag m_fallback_seed_nodes_added = ATOMIC_FLAG_INIT;
     std::vector<nodetool::peerlist_entry> m_command_line_peers;
-    uint64_t m_peer_livetime;
     //keep connections to initiate some interactions
 
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -126,7 +126,6 @@ namespace nodetool
     network_zone& public_zone = m_network_zones[epee::net_utils::zone::public_];
     public_zone.m_config.m_support_flags = P2P_SUPPORT_FLAGS;
     public_zone.m_config.m_peer_id = crypto::rand<uint64_t>();
-    m_first_connection_maker_call = true;
 
     CATCH_ENTRY_L0("node_server::init_config", false);
     return true;
@@ -934,9 +933,6 @@ namespace nodetool
     for(const auto& p: m_command_line_peers)
       m_network_zones.at(p.adr.get_zone()).m_peerlist.append_with_peer_white(p);
 
-    //only in case if we really sure that we have external visible ip
-    m_have_address = true;
-
     //configure self
 
     public_zone.m_net_server.set_threads_prefix("P2P"); // all zones use these threads/asio::io_service
@@ -999,7 +995,6 @@ namespace nodetool
       const network_zone& public_zone = m_network_zones.at(epee::net_utils::zone::public_);
       while (!is_closing && !public_zone.m_net_server.is_stop_signal_sent())
       { // main loop of thread
-        //number_of_peers = m_net_server.get_config_object().get_connections_count();
         for (auto& zone : m_network_zones)
         {
           unsigned int number_of_in_peers = 0;
@@ -2033,31 +2028,6 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
-  size_t node_server<t_payload_net_handler>::get_outgoing_connections_count()
-  {
-    size_t count = 0;
-    for(auto& zone : m_network_zones)
-      count += get_outgoing_connections_count(zone.second);
-    return count;
-  }
-  //-----------------------------------------------------------------------------------
-  template<class t_payload_net_handler>
-  size_t node_server<t_payload_net_handler>::get_incoming_connections_count()
-  {
-    size_t count = 0;
-    for (auto& zone : m_network_zones)
-    {
-      zone.second.m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context& cntxt)
-      {
-        if(cntxt.m_is_income)
-          ++count;
-        return true;
-      });
-    }
-    return count;
-  }
-  //-----------------------------------------------------------------------------------
-  template<class t_payload_net_handler>
   size_t node_server<t_payload_net_handler>::get_public_white_peers_count()
   {
     auto public_zone = m_network_zones.find(epee::net_utils::zone::public_);
@@ -2692,17 +2662,6 @@ namespace nodetool
     rsp.status = PING_OK_RESPONSE_STATUS_TEXT;
     rsp.peer_id = m_network_zones.at(context.m_remote_address.get_zone()).m_config.m_peer_id;
     return 1;
-  }
-  //-----------------------------------------------------------------------------------
-  template<class t_payload_net_handler>
-  bool node_server<t_payload_net_handler>::log_peerlist()
-  {
-    std::vector<peerlist_entry> pl_white;
-    std::vector<peerlist_entry> pl_gray;
-    for (auto& zone : m_network_zones)
-      zone.second.m_peerlist.get_peerlist(pl_gray, pl_white);
-    MINFO(ENDL << "Peerlist white:" << ENDL << print_peerlist_to_string(pl_white) << ENDL << "Peerlist gray:" << ENDL << print_peerlist_to_string(pl_gray) );
-    return true;
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -106,8 +106,6 @@ namespace nodetool
     bool get_peerlist_head(std::vector<peerlist_entry>& bs_head, bool anonymize, uint32_t depth = P2P_DEFAULT_PEERS_IN_HANDSHAKE);
     void get_peerlist(std::vector<peerlist_entry>& pl_gray, std::vector<peerlist_entry>& pl_white);
     void get_peerlist(peerlist_types& peers);
-    bool get_white_peer_by_index(peerlist_entry& p, size_t i);
-    bool get_gray_peer_by_index(peerlist_entry& p, size_t i);
     template<typename F> bool foreach(bool white, const F &f);
     void evict_host_from_peerlist(bool white, const peerlist_entry& pr);
     bool append_with_peer_white(const peerlist_entry& pr, bool trust_last_seen = false);
@@ -124,42 +122,7 @@ namespace nodetool
     
   private:
     struct by_time{};
-    struct by_id{};
     struct by_addr{};
-
-    struct modify_all_but_id
-    {
-      modify_all_but_id(const peerlist_entry& ple):m_ple(ple){}
-      void operator()(peerlist_entry& e)
-      {
-        e.id = m_ple.id;
-      }
-    private:
-      const peerlist_entry& m_ple;
-    };
-
-    struct modify_all
-    {
-      modify_all(const peerlist_entry& ple):m_ple(ple){}
-      void operator()(peerlist_entry& e)
-      {
-        e = m_ple;
-      }
-    private:
-      const peerlist_entry& m_ple;
-    };
-
-    struct modify_last_seen
-    {
-      modify_last_seen(time_t last_seen):m_last_seen(last_seen){}
-      void operator()(peerlist_entry& e)
-      {
-        e.last_seen = m_last_seen;
-      }
-    private:
-      time_t m_last_seen;
-    };
-
 
     typedef boost::multi_index_container<
       peerlist_entry,
@@ -240,28 +203,6 @@ namespace nodetool
   }
   //--------------------------------------------------------------------------------------------------
   inline
-  bool peerlist_manager::get_white_peer_by_index(peerlist_entry& p, size_t i)
-  {
-    CRITICAL_REGION_LOCAL(m_peerlist_lock);
-    if(i >= m_peers_white.size())
-      return false;
-
-    p = peerlist_manager::get_nth_latest_peer(m_peers_white, i);
-    return true;
-  }
-  //--------------------------------------------------------------------------------------------------
-  inline
-    bool peerlist_manager::get_gray_peer_by_index(peerlist_entry& p, size_t i)
-  {
-    CRITICAL_REGION_LOCAL(m_peerlist_lock);
-    if(i >= m_peers_gray.size())
-      return false;
-
-    p = peerlist_manager::get_nth_latest_peer(m_peers_gray, i);
-    return true;
-  }
-  //--------------------------------------------------------------------------------------------------
-  inline 
   bool peerlist_manager::is_host_allowed(const epee::net_utils::network_address &address)
   {
     //never allow loopback ip


### PR DESCRIPTION
Dead as of the Tor/network-zone rework 973403bc9:
- get_incoming_connections_count: callers moved to the network_zone& variant and to change_max_in_public_peers
- make_default_peer_id, make_default_config, parse_peer_from_string: definitions removed, declarations left behind
- by_id: its multi_index index was dropped
- get_address<T>: added by that commit, never instantiated

Dead when their last caller went:
- get_outgoing_connections_count: aa93e3886
- log_peerlist: 4f0e8cfa9
- get_white_peer_by_index, get_gray_peer_by_index: ae489ba6e
- set_rpc_credits_per_hash: 9b337ca01

Unused since the initial import 296ae46ed:
- by_conn_id, by_peer_id: multi_index tags never named in any index list
- modify_all, modify_all_but_id, modify_last_seen: multi_index functors never instantiated
- m_peer_livetime: never read or written
- m_have_address, m_first_connection_maker_call: assigned once, never read
- commented-out get_local_handshake_data, m_connections_lock and m_connections declarations

Also drops a commented-out number_of_peers assignment, stale since 32c0f908c removed that variable.