### PR TITLE
tests: enable temporary libunbound debug logging

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -357,6 +357,11 @@ DNSResolver DNSResolver::create()
   return DNSResolver();
 }
 
+void DNSResolver::set_debug_level(int level)
+{
+  ub_ctx_debuglevel(m_data->m_ub_context, level);
+}
+
 namespace dns_utils
 {
 

--- a/src/common/dns_utils.h
+++ b/src/common/dns_utils.h
@@ -144,6 +144,8 @@ public:
    */
   static DNSResolver create();
 
+  void set_debug_level(int level);
+
 private:
 
   /**

--- a/tests/unit_tests/address_from_url.cpp
+++ b/tests/unit_tests/address_from_url.cpp
@@ -109,7 +109,9 @@ TEST(AddressFromURL, Failure)
 {
   bool dnssec_result = false;
 
+  tools::DNSResolver::instance().set_debug_level(4);
   std::vector<std::string> addresses = tools::dns_utils::addresses_from_url("example.veryinvalid", dnssec_result);
+  tools::DNSResolver::instance().set_debug_level(0);
 
   // for a non-existing domain such as "example.invalid", the non-existence is proved with NSEC records
   ASSERT_TRUE(dnssec_result);


### PR DESCRIPTION
To be reverted once we have the debug info.