### PR TITLE
device_trezor: validate bridge response size before parsing [release-v0.18]

### DIFF
--- a/src/device_trezor/trezor/transport.cpp
+++ b/src/device_trezor/trezor/transport.cpp
@@ -474,14 +474,14 @@ namespace trezor{
     }
 
     boost::optional<epee::wipeable_string> bin_data = m_response->parse_hexstr();
-    if (!bin_data){
+    if (!bin_data || bin_data->size() < PROTO_HEADER_SIZE){
       throw exc::CommunicationException("Response is not well hexcoded");
     }
 
     uint16_t msg_tag;
     uint32_t msg_len;
     deserialize_message_header(bin_data->data(), msg_tag, msg_len);
-    if (bin_data->size() != msg_len + 6){
+    if (bin_data->size() - PROTO_HEADER_SIZE != msg_len){
       throw exc::CommunicationException("Response is not well hexcoded");
     }
 


### PR DESCRIPTION
#10988 