### PR TITLE
cryptonote_core: remove dead code

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -463,16 +463,6 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
   return true;
 }
 //------------------------------------------------------------------
-bool Blockchain::init(BlockchainDB* db, HardFork*& hf, const network_type nettype, bool offline)
-{
-  if (hf != nullptr)
-    m_hardfork = hf;
-  bool res = init(db, nettype, offline, NULL);
-  if (hf == nullptr)
-    hf = m_hardfork;
-  return res;
-}
-//------------------------------------------------------------------
 bool Blockchain::store_blockchain()
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
@@ -2635,17 +2625,6 @@ bool Blockchain::get_transactions_blobs(const std::vector<crypto::hash>& txs_ids
     }
   }
   return true;
-}
-//------------------------------------------------------------------
-size_t get_transaction_version(const cryptonote::blobdata &bd)
-{
-  size_t version;
-  const char* begin = static_cast<const char*>(bd.data());
-  const char* end = begin + bd.size();
-  int read = tools::read_varint(begin, end, version);
-  if (read <= 0)
-    throw std::runtime_error("Internal error getting transaction version");
-  return version;
 }
 //------------------------------------------------------------------
 template<class t_ids_container, class t_tx_container, class t_missed_container>

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -134,18 +134,6 @@ namespace cryptonote
     bool init(BlockchainDB* db, const network_type nettype = MAINNET, bool offline = false, const cryptonote::test_options *test_options = NULL, difficulty_type fixed_difficulty = 0, const GetCheckpointsCallback& get_checkpoints = nullptr);
 
     /**
-     * @brief Initialize the Blockchain state
-     *
-     * @param db a pointer to the backing store to use for the blockchain
-     * @param hf a structure containing hardfork information
-     * @param nettype network type
-     * @param offline true if running offline, else false
-     *
-     * @return true on success, false if any initialization steps fail
-     */
-    bool init(BlockchainDB* db, HardFork*& hf, const network_type nettype = MAINNET, bool offline = false);
-
-    /**
      * @brief Uninitializes the blockchain state
      *
      * Saves to disk any state that needs to be maintained
@@ -1176,8 +1164,6 @@ namespace cryptonote
 
     // TODO: evaluate whether or not each of these typedefs are left over from blockchain_storage
     typedef std::unordered_set<crypto::key_image> key_images_container;
-
-    typedef std::vector<block_extended_info> blocks_container;
 
     typedef std::unordered_map<crypto::hash, block_extended_info> blocks_ext_by_hash;
 

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -395,16 +395,6 @@ namespace cryptonote
     top_id = m_blockchain_storage.get_tail_id(height);
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::get_blocks(uint64_t start_offset, size_t count, std::vector<std::pair<cryptonote::blobdata,block>>& blocks, std::vector<cryptonote::blobdata>& txs) const
-  {
-    return m_blockchain_storage.get_blocks(start_offset, count, blocks, txs);
-  }
-  //-----------------------------------------------------------------------------------------------
-  bool core::get_blocks(uint64_t start_offset, size_t count, std::vector<std::pair<cryptonote::blobdata,block>>& blocks) const
-  {
-    return m_blockchain_storage.get_blocks(start_offset, count, blocks);
-  }
-  //-----------------------------------------------------------------------------------------------
   bool core::get_blocks(uint64_t start_offset, size_t count, std::vector<block>& blocks) const
   {
     std::vector<std::pair<cryptonote::blobdata, cryptonote::block>> bs;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -332,20 +332,6 @@ namespace cryptonote
      void get_blockchain_top(uint64_t& height, crypto::hash& top_id) const;
 
      /**
-      * @copydoc Blockchain::get_blocks(uint64_t, size_t, std::vector<std::pair<cryptonote::blobdata,block>>&, std::vector<transaction>&) const
-      *
-      * @note see Blockchain::get_blocks(uint64_t, size_t, std::vector<std::pair<cryptonote::blobdata,block>>&, std::vector<transaction>&) const
-      */
-     bool get_blocks(uint64_t start_offset, size_t count, std::vector<std::pair<cryptonote::blobdata,block>>& blocks, std::vector<cryptonote::blobdata>& txs) const;
-
-     /**
-      * @copydoc Blockchain::get_blocks(uint64_t, size_t, std::vector<std::pair<cryptonote::blobdata,block>>&) const
-      *
-      * @note see Blockchain::get_blocks(uint64_t, size_t, std::vector<std::pair<cryptonote::blobdata,block>>&) const
-      */
-     bool get_blocks(uint64_t start_offset, size_t count, std::vector<std::pair<cryptonote::blobdata,block>>& blocks) const;
-
-     /**
       * @copydoc Blockchain::get_blocks(uint64_t, size_t, std::vector<std::pair<cryptonote::blobdata,block>>&) const
       *
       * @note see Blockchain::get_blocks(uint64_t, size_t, std::vector<std::pair<cryptonote::blobdata,block>>&) const
@@ -1056,8 +1042,6 @@ namespace cryptonote
 
      cryptonote_protocol_stub m_protocol_stub; //!< cryptonote protocol stub instance
 
-     epee::math_helper::once_a_time_seconds<60*60*12, false> m_store_blockchain_interval; //!< interval for manual storing of Blockchain, if enabled
-     epee::math_helper::once_a_time_seconds<60*60*2, true> m_fork_moaner; //!< interval for checking HardFork status
      epee::math_helper::once_a_time_seconds<60*60*12, true> m_check_updates_interval; //!< interval for checking for new versions
      epee::math_helper::once_a_time_seconds<60*10, true> m_check_disk_space_interval; //!< interval for checking for disk space
      epee::math_helper::once_a_time_seconds<90, false> m_block_rate_interval; //!< interval for checking block rate

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -371,18 +371,6 @@ namespace cryptonote
       nic_verified_hf_version, valid_input_verification_id);
   }
   //---------------------------------------------------------------------------------
-  size_t tx_memory_pool::get_txpool_weight() const
-  {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    return m_txpool_weight;
-  }
-  //---------------------------------------------------------------------------------
-  void tx_memory_pool::set_txpool_max_weight(size_t bytes)
-  {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    m_txpool_max_weight = bytes;
-  }
-  //---------------------------------------------------------------------------------
   void tx_memory_pool::reduce_txpool_weight(size_t weight)
   {
     if (weight > m_txpool_weight)

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -61,9 +61,6 @@ namespace cryptonote
   /*                                                                      */
   /************************************************************************/
 
-  //! pair of <transaction fee, transaction hash> for organization
-  typedef std::pair<std::pair<double, std::time_t>, crypto::hash> tx_by_fee_and_receive_time_entry;
-
   class txFeeCompare
   {
   public:
@@ -422,20 +419,6 @@ namespace cryptonote
       * @return the cookie
       */
     uint64_t cookie() const { return m_cookie; }
-
-    /**
-     * @brief get the cumulative txpool weight in bytes
-     *
-     * @return the cumulative txpool weight in bytes
-     */
-    size_t get_txpool_weight() const;
-
-    /**
-     * @brief set the max cumulative txpool weight in bytes
-     *
-     * @param bytes the max cumulative txpool weight in bytes
-     */
-    void set_txpool_max_weight(size_t bytes);
 
     /**
      * @brief reduce the cumulative txpool weight by the weight provided

--- a/src/cryptonote_core/tx_verification_utils.cpp
+++ b/src/cryptonote_core/tx_verification_utils.cpp
@@ -406,7 +406,6 @@ bool ver_mixed_rct_semantics(std::vector<const rct::rctSig*> rvv)
             // coinbase should not come here, so we reject for all other types
             MERROR("Unexpected Null rctSig type");
             return false;
-            break;
         case rct::RCTTypeSimple:
             if (!rct::verRctSemanticsSimple(rv))
             {
@@ -442,7 +441,6 @@ bool ver_mixed_rct_semantics(std::vector<const rct::rctSig*> rvv)
         default:
             MERROR("Unknown rct type: " << rv.type);
             return false;
-            break;
         }
 
         // Save this ring sig for later, as we will attempt simple RCT semantics batch verification


### PR DESCRIPTION
Never had a caller:
- Blockchain::init taking HardFork*&: added in 8f863e742, no caller in any revision since
- tx_memory_pool::get_txpool_weight, set_txpool_max_weight: added as get_txpool_size and set_txpool_max_size in bc61ae69b alongside --max-txpool-size, which is wired through tx_memory_pool::init instead; renamed size to weight in 5ffb2ff9b, still uncalled
- get_transaction_version: added in b750fb27b, no caller since

Dead when their last user went:
- core::get_blocks taking vector<pair<blobdata, block>>, both overloads: last caller removed in 9faef1f83; ed2c81ed9 later converted the already-dead signatures from std::list to std::vector. The vector<block> overload is still used by core_tests and is kept
- blocks_container: 9e82b694d removed the in-memory blockchain that used it
- tx_by_fee_and_receive_time_entry: 445319d3f replaced the sorted container it keyed with a boost::bimap
- m_store_blockchain_interval: its do_call went with the original blockchain_storage format in 9e82b694d
- m_fork_moaner: its do_call went with the "We are most likely forked" message in f0371210e

Also drops two break statements after a return in ver_mixed_rct_semantics and the doc comments belonging to the removed declarations.