### PR TITLE
wallet2_api: skip the TLS handshake on Tor/I2P daemons

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -623,9 +623,10 @@ namespace tools
 
   bool is_privacy_preserving_network(const std::string &address)
   {
-    if (boost::ends_with(address, ".onion"))
+    // classic locale: a Turkish global locale would break the match
+    if (boost::iends_with(address, ".onion", std::locale::classic()))
       return true;
-    if (boost::ends_with(address, ".i2p"))
+    if (boost::iends_with(address, ".i2p", std::locale::classic()))
       return true;
     return false;
   }

--- a/src/wallet/api/CMakeLists.txt
+++ b/src/wallet/api/CMakeLists.txt
@@ -52,6 +52,7 @@ set(wallet_api_private_headers
   transaction_history.h
   pending_transaction.h
   common_defines.h
+  ssl_options.h
   address_book.h
   subaddress.h
   subaddress_account.h

--- a/src/wallet/api/ssl_options.h
+++ b/src/wallet/api/ssl_options.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <string>
+
+#include "net/net_ssl.h"
+
+namespace Monero {
+namespace Utils {
+
+epee::net_utils::ssl_options_t sslOptionsForDaemon(const std::string &daemon_address, bool use_ssl);
+
+}
+}

--- a/src/wallet/api/utils.cpp
+++ b/src/wallet/api/utils.cpp
@@ -32,6 +32,13 @@
 
 #include "include_base_utils.h"                     // LOG_PRINT_x
 #include "common/util.h"
+#include "net/net_parse_helpers.h"
+#include "ssl_options.h"
+
+#include <boost/algorithm/string/predicate.hpp>
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "WalletAPI"
 
 using namespace std;
 
@@ -46,6 +53,31 @@ bool isAddressLocal(const std::string &address)
         MERROR("error: " << e.what());
         return false;
     }
+}
+
+epee::net_utils::ssl_options_t sslOptionsForDaemon(const std::string &daemon_address, bool use_ssl)
+{
+    epee::net_utils::http::url_content parsed{};
+    if (!epee::net_utils::parse_url(daemon_address, parsed))
+        return epee::net_utils::ssl_support_t::e_ssl_support_autodetect;
+
+    // clearnet keeps autodetect: use_ssl defaults to false, honouring it would drop TLS to https daemons
+    if (!tools::is_privacy_preserving_network(parsed.host))
+        return epee::net_utils::ssl_support_t::e_ssl_support_autodetect;
+
+    const bool wants_ssl = use_ssl || boost::iequals(parsed.schema, "https", std::locale::classic());
+    if (!wants_ssl)
+    {
+        MINFO("TLS handshake skipped for Tor/I2P daemon " << parsed.host);
+        return epee::net_utils::ssl_support_t::e_ssl_support_disabled;
+    }
+
+    // no peer verification: this API cannot carry a CA or fingerprint yet, monerod's default
+    // certificate is self-signed, and a .onion/.i2p name is self-authenticating (has_strong_verification)
+    MINFO("TLS required for Tor/I2P daemon " << parsed.host << ", certificate verification off");
+    epee::net_utils::ssl_options_t options(epee::net_utils::ssl_support_t::e_ssl_support_enabled);
+    options.verification = epee::net_utils::ssl_verification_t::none;
+    return options;
 }
 
 void onStartup()

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -39,6 +39,7 @@
 #include "common_defines.h"
 #include "common/util.h"
 #include "multisig/multisig_account.h"
+#include "ssl_options.h"
 
 #include "mnemonics/electrum-words.h"
 #include "mnemonics/english.h"
@@ -2526,7 +2527,9 @@ void WalletImpl::pendingTxPostProcess(PendingTransactionImpl * pending)
 
 bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_address, uint64_t upper_transaction_size_limit, bool ssl)
 {
-    if (!m_wallet->init(daemon_address, m_daemon_login, proxy_address, upper_transaction_size_limit))
+    const bool trusted_daemon = Utils::isAddressLocal(daemon_address);
+
+    if (!m_wallet->init(daemon_address, m_daemon_login, proxy_address, upper_transaction_size_limit, trusted_daemon, Utils::sslOptionsForDaemon(daemon_address, ssl)))
        return false;
 
     // in case new wallet, this will force fast-refresh (pulling hashes instead of blocks)
@@ -2539,13 +2542,8 @@ bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_a
     if (m_rebuildWalletCache)
       LOG_PRINT_L2(__FUNCTION__ << ": Rebuilding wallet cache, fast refresh until block " << m_wallet->get_refresh_from_block_height());
 
-    if (Utils::isAddressLocal(daemon_address)) {
-        this->setTrustedDaemon(true);
-        m_refreshIntervalMillis = DEFAULT_REFRESH_INTERVAL_MILLIS;
-    } else {
-        this->setTrustedDaemon(false);
-        m_refreshIntervalMillis = DEFAULT_REMOTE_NODE_REFRESH_INTERVAL_MILLIS;
-    }
+    m_refreshIntervalMillis = trusted_daemon ? DEFAULT_REFRESH_INTERVAL_MILLIS
+                                             : DEFAULT_REMOTE_NODE_REFRESH_INTERVAL_MILLIS;
     return true;
 }
 

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -39,9 +39,12 @@
 #include "common_defines.h"
 #include "common/util.h"
 #include "multisig/multisig_account.h"
+#include "net/net_parse_helpers.h"
+#include "net/net_ssl.h"
 
 #include "mnemonics/electrum-words.h"
 #include "mnemonics/english.h"
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/format.hpp>
 #include <sstream>
 #include <unordered_map>
@@ -2520,9 +2523,28 @@ void WalletImpl::pendingTxPostProcess(PendingTransactionImpl * pending)
   pending->m_pending_tx = exported_txs.ptx;
 }
 
+static epee::net_utils::ssl_options_t ssl_options_for_daemon(const std::string &daemon_address, bool use_ssl)
+{
+    epee::net_utils::http::url_content parsed{};
+    if (!epee::net_utils::parse_url(daemon_address, parsed))
+        return epee::net_utils::ssl_support_t::e_ssl_support_autodetect;
+
+    // parse_url() reports the scheme as written, hence the case insensitive compare
+    const bool wants_ssl = use_ssl || boost::iequals(parsed.schema, "https");
+
+    // clearnet is deliberately left alone: acting on use_ssl there would cut off the
+    // https daemons reached today by callers that leave it at its default
+    if (!wants_ssl && tools::is_privacy_preserving_network(parsed.host))
+        return epee::net_utils::ssl_support_t::e_ssl_support_disabled;
+
+    return epee::net_utils::ssl_support_t::e_ssl_support_autodetect;
+}
+
 bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_address, uint64_t upper_transaction_size_limit, bool ssl)
 {
-    if (!m_wallet->init(daemon_address, m_daemon_login, proxy_address, upper_transaction_size_limit))
+    const bool trusted_daemon = Utils::isAddressLocal(daemon_address);
+
+    if (!m_wallet->init(daemon_address, m_daemon_login, proxy_address, upper_transaction_size_limit, trusted_daemon, ssl_options_for_daemon(daemon_address, ssl)))
        return false;
 
     // in case new wallet, this will force fast-refresh (pulling hashes instead of blocks)
@@ -2535,7 +2557,7 @@ bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_a
     if (m_rebuildWalletCache)
       LOG_PRINT_L2(__FUNCTION__ << ": Rebuilding wallet cache, fast refresh until block " << m_wallet->get_refresh_from_block_height());
 
-    if (Utils::isAddressLocal(daemon_address)) {
+    if (trusted_daemon) {
         this->setTrustedDaemon(true);
         m_refreshIntervalMillis = DEFAULT_REFRESH_INTERVAL_MILLIS;
     } else {

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -542,6 +542,9 @@ struct Wallet
      * \param upper_transaction_size_limit
      * \param daemon_username
      * \param daemon_password
+     * \param use_ssl - requires TLS, without certificate verification, for a .onion/.i2p
+     *                  daemon_address, as does addressing it https://; otherwise the
+     *                  handshake is skipped there. Clearnet autodetects either way.
      * \param lightWallet - deprecated
      * \param proxy_address - set proxy address, empty string to disable
      * \return  - true on success
@@ -1342,8 +1345,9 @@ struct WalletManager
     //! returns verbose error string regarding last error;
     virtual std::string errorString() const = 0;
 
-    //! set the daemon address (hostname and port)
-    virtual void setDaemonAddress(const std::string &address) = 0;
+    //! set the daemon address (hostname and port). The TLS handshake is skipped for
+    //! .onion/.i2p addresses unless use_ssl is set or the address is https:// (see Wallet::init's use_ssl).
+    virtual void setDaemonAddress(const std::string &address, bool use_ssl = false) = 0;
 
     //! returns whether the daemon can be reached, and its version number
     virtual bool connected(uint32_t *version = NULL) = 0;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -542,6 +542,9 @@ struct Wallet
      * \param upper_transaction_size_limit
      * \param daemon_username
      * \param daemon_password
+     * \param use_ssl - forces the TLS handshake attempt back on for a .onion/.i2p
+     *                  daemon_address, as does addressing it https://. Clearnet
+     *                  autodetects either way.
      * \param lightWallet - deprecated
      * \param proxy_address - set proxy address, empty string to disable
      * \return  - true on success

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -32,6 +32,7 @@
 #include "wallet_manager.h"
 #include "wallet.h"
 #include "common_defines.h"
+#include "ssl_options.h"
 #include "common/dns_utils.h"
 #include "common/util.h"
 #include "common/updates.h"
@@ -227,9 +228,9 @@ std::string WalletManagerImpl::errorString() const
     return m_errorString;
 }
 
-void WalletManagerImpl::setDaemonAddress(const std::string &address)
+void WalletManagerImpl::setDaemonAddress(const std::string &address, bool use_ssl)
 {
-    m_http_client.set_server(address, boost::none);
+    m_http_client.set_server(address, boost::none, Utils::sslOptionsForDaemon(address, use_ssl));
 }
 
 bool WalletManagerImpl::connected(uint32_t *version)

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -81,7 +81,7 @@ public:
     bool queryWalletDevice(Wallet::Device& device_type, const std::string &keys_file_name, const std::string &password, uint64_t kdf_rounds = 1) const override;
     std::vector<std::string> findWallets(const std::string &path) override;
     std::string errorString() const override;
-    void setDaemonAddress(const std::string &address) override;
+    void setDaemonAddress(const std::string &address, bool use_ssl = false) override;
     bool connected(uint32_t *version = NULL) override;
     uint64_t blockchainHeight() override;
     uint64_t blockchainTargetHeight() override;

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -34,6 +34,7 @@
 #include "wallet/wallet2.h"
 #include "include_base_utils.h"
 #include "common/util.h"
+#include "net/net_ssl.h"
 
 #include <boost/chrono/chrono.hpp>
 #include <boost/filesystem.hpp>
@@ -67,6 +68,7 @@ const char * WALLET_NAME_WITH_DIR_NON_WRITABLE = "not_a_directory/testwallet_tes
 const char * WALLET_PASS = "password";
 const char * WALLET_PASS2 = "password22";
 const char * WALLET_LANG = "English";
+const char * ONION_DAEMON_ADDRESS = "6dsdenlu6pc7feyi7d7fkxkfbenpj7cca5dvbdfayvmz2ykwixnztqad.onion:18081";
 
 std::string WALLETS_ROOT_DIR = "/var/monero/testnet_pvt";
 std::string TESTNET_WALLET1_NAME;
@@ -252,6 +254,186 @@ struct WalletTest2 : public testing::Test
     }
 
 };
+
+struct FirstBytesListener
+{
+    boost::asio::io_context ioc;
+    boost::asio::ip::tcp::acceptor acceptor;
+    boost::asio::ip::tcp::socket sock;
+    const uint16_t port;
+    boost::thread worker;
+    std::vector<unsigned char> first_bytes;
+
+    explicit FirstBytesListener(bool speak_socks5)
+        : acceptor(ioc, boost::asio::ip::tcp::endpoint(boost::asio::ip::address_v4::loopback(), 0))
+        , sock(ioc)
+        , port(acceptor.local_endpoint().port())
+    {
+        worker = boost::thread([this, speak_socks5] {
+            boost::system::error_code ec;
+            acceptor.accept(sock, ec);
+            // refuse the wallet's retry rather than sit out its RPC timeout
+            boost::system::error_code ignored;
+            acceptor.close(ignored);
+            if (ec)
+                return;
+            if (speak_socks5 && !grant_socks5(sock))
+                return;
+            unsigned char buffer[epee::net_utils::get_ssl_magic_size()] = {};
+            const size_t received = boost::asio::read(sock, boost::asio::buffer(buffer, sizeof(buffer)), ec);
+            first_bytes.assign(buffer, buffer + received);
+            sock.close(ignored);
+        });
+    }
+
+    ~FirstBytesListener()
+    {
+        unblock_and_join();
+    }
+
+    std::string address() const
+    {
+        return "127.0.0.1:" + std::to_string(port);
+    }
+
+    const std::vector<unsigned char> &wait()
+    {
+        if (!worker.try_join_for(boost::chrono::seconds(60)))
+            unblock_and_join();
+        return first_bytes;
+    }
+
+private:
+    void unblock_and_join()
+    {
+        boost::system::error_code ignored;
+        {
+            // closing the acceptor does not return a worker blocked in accept(); a connection
+            // does, and its close then ends the read
+            boost::asio::ip::tcp::socket wake(ioc);
+            wake.connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address_v4::loopback(), port), ignored);
+        }
+        // racy cross-thread call, but nothing else here can return a read() blocked on sock
+        sock.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored);
+        if (worker.joinable())
+            worker.join();
+    }
+
+    static bool grant_socks5(boost::asio::ip::tcp::socket &sock)
+    {
+        boost::system::error_code ec;
+        unsigned char greeting[2] = {};
+        boost::asio::read(sock, boost::asio::buffer(greeting), ec);
+        std::vector<unsigned char> methods(greeting[1]);
+        if (!ec && !methods.empty())
+            boost::asio::read(sock, boost::asio::buffer(methods), ec);
+        const unsigned char no_auth[2] = {5, 0};
+        if (!ec)
+            boost::asio::write(sock, boost::asio::buffer(no_auth), ec);
+
+        unsigned char request[5] = {};
+        if (!ec)
+            boost::asio::read(sock, boost::asio::buffer(request), ec);
+        if (ec || request[3] != 3) // domain type, request[4] is its length
+            return false;
+
+        std::vector<unsigned char> target(request[4] + 2u);
+        boost::asio::read(sock, boost::asio::buffer(target), ec);
+
+        const unsigned char granted[10] = {5, 0, 0, 1, 0, 0, 0, 0, 0, 0};
+        if (!ec)
+            boost::asio::write(sock, boost::asio::buffer(granted), ec);
+        return !ec;
+    }
+};
+
+static std::vector<unsigned char> first_bytes_on_init(
+        Monero::WalletManager *wmgr, const std::string &onion_address, bool use_ssl)
+{
+    const bool over_socks = !onion_address.empty();
+    Utils::deleteWallet(WALLET_NAME);
+    FirstBytesListener listener(over_socks);
+    Monero::Wallet *wallet = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG, WALLET_NETWORK_TYPE);
+    EXPECT_TRUE(wallet->init(over_socks ? onion_address : listener.address(), 0, "", "", use_ssl,
+            false, over_socks ? "socks5://" + listener.address() : std::string()));
+    wallet->connected();
+    const std::vector<unsigned char> sent = listener.wait();
+    EXPECT_TRUE(wmgr->closeWallet(wallet));
+    return sent;
+}
+
+TEST_F(WalletManagerTest, WalletInitSkipsTlsOnAnonymityNetwork)
+{
+    const std::vector<unsigned char> plain = first_bytes_on_init(wmgr, ONION_DAEMON_ADDRESS, false);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), plain.size());
+    EXPECT_FALSE(epee::net_utils::is_ssl(plain.data(), plain.size()));
+}
+
+// Tor lowercases the name it is handed, so an uppercase spelling reaches the same daemon
+TEST_F(WalletManagerTest, WalletInitSkipsTlsOnUppercaseAnonymityHost)
+{
+    const std::vector<unsigned char> plain =
+            first_bytes_on_init(wmgr, boost::to_upper_copy<std::string>(ONION_DAEMON_ADDRESS), false);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), plain.size());
+    EXPECT_FALSE(epee::net_utils::is_ssl(plain.data(), plain.size()));
+}
+
+TEST_F(WalletManagerTest, WalletInitAttemptsTlsOnAnonymityNetworkWhenAsked)
+{
+    const std::vector<unsigned char> encrypted = first_bytes_on_init(wmgr, ONION_DAEMON_ADDRESS, true);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), encrypted.size());
+    EXPECT_TRUE(epee::net_utils::is_ssl(encrypted.data(), encrypted.size()));
+}
+
+TEST_F(WalletManagerTest, WalletInitHonoursHttpsSchemeOnAnonymityNetwork)
+{
+    const std::vector<unsigned char> encrypted =
+            first_bytes_on_init(wmgr, std::string("https://") + ONION_DAEMON_ADDRESS, false);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), encrypted.size());
+    EXPECT_TRUE(epee::net_utils::is_ssl(encrypted.data(), encrypted.size()));
+}
+
+TEST_F(WalletManagerTest, WalletInitKeepsAutodetectOnClearnet)
+{
+    const std::vector<unsigned char> encrypted = first_bytes_on_init(wmgr, "", false);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), encrypted.size());
+    EXPECT_TRUE(epee::net_utils::is_ssl(encrypted.data(), encrypted.size()));
+}
+
+static std::vector<unsigned char> first_bytes_on_manager(Monero::WalletManager *wmgr, const std::string &onion_address, bool use_ssl)
+{
+    FirstBytesListener listener(true);
+    EXPECT_TRUE(wmgr->setProxy("socks5://" + listener.address()));
+    wmgr->setDaemonAddress(onion_address, use_ssl);
+    wmgr->connected();
+    const std::vector<unsigned char> sent = listener.wait();
+    // the manager is shared with later tests
+    EXPECT_TRUE(wmgr->setProxy(""));
+    wmgr->setDaemonAddress(DAEMON_ADDRESS);
+    return sent;
+}
+
+TEST_F(WalletManagerTest, WalletManagerSkipsTlsOnAnonymityNetwork)
+{
+    const std::vector<unsigned char> plain = first_bytes_on_manager(wmgr, ONION_DAEMON_ADDRESS, false);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), plain.size());
+    EXPECT_FALSE(epee::net_utils::is_ssl(plain.data(), plain.size()));
+}
+
+TEST_F(WalletManagerTest, WalletManagerAttemptsTlsOnAnonymityNetworkWhenAsked)
+{
+    const std::vector<unsigned char> encrypted = first_bytes_on_manager(wmgr, ONION_DAEMON_ADDRESS, true);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), encrypted.size());
+    EXPECT_TRUE(epee::net_utils::is_ssl(encrypted.data(), encrypted.size()));
+}
+
+TEST_F(WalletManagerTest, WalletManagerHonoursHttpsSchemeOnAnonymityNetwork)
+{
+    const std::vector<unsigned char> encrypted =
+            first_bytes_on_manager(wmgr, std::string("https://") + ONION_DAEMON_ADDRESS, false);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), encrypted.size());
+    EXPECT_TRUE(epee::net_utils::is_ssl(encrypted.data(), encrypted.size()));
+}
 
 TEST_F(WalletManagerTest, WalletManagerCreatesWallet)
 {

--- a/tests/libwallet_api_tests/main.cpp
+++ b/tests/libwallet_api_tests/main.cpp
@@ -34,6 +34,7 @@
 #include "wallet/wallet2.h"
 #include "include_base_utils.h"
 #include "common/util.h"
+#include "net/net_ssl.h"
 
 #include <boost/chrono/chrono.hpp>
 #include <boost/filesystem.hpp>
@@ -67,6 +68,7 @@ const char * WALLET_NAME_WITH_DIR_NON_WRITABLE = "not_a_directory/testwallet_tes
 const char * WALLET_PASS = "password";
 const char * WALLET_PASS2 = "password22";
 const char * WALLET_LANG = "English";
+const char * ONION_DAEMON_ADDRESS = "6dsdenlu6pc7feyi7d7fkxkfbenpj7cca5dvbdfayvmz2ykwixnztqad.onion:18081";
 
 std::string WALLETS_ROOT_DIR = "/var/monero/testnet_pvt";
 std::string TESTNET_WALLET1_NAME;
@@ -252,6 +254,135 @@ struct WalletTest2 : public testing::Test
     }
 
 };
+
+struct FirstBytesListener
+{
+    boost::asio::io_context ioc;
+    boost::asio::ip::tcp::acceptor acceptor;
+    boost::thread worker;
+    std::vector<unsigned char> first_bytes;
+
+    explicit FirstBytesListener(bool speak_socks5)
+        : acceptor(ioc, boost::asio::ip::tcp::endpoint(boost::asio::ip::address_v4::loopback(), 0))
+    {
+        worker = boost::thread([this, speak_socks5] {
+            boost::system::error_code ec;
+            boost::asio::ip::tcp::socket sock(ioc);
+            acceptor.accept(sock, ec);
+            // refuse the retry rather than sit out the wallet's 20s RPC timeout
+            boost::system::error_code ignored;
+            acceptor.close(ignored);
+            if (ec)
+                return;
+            if (speak_socks5 && !grant_socks5(sock))
+                return;
+            unsigned char buffer[epee::net_utils::get_ssl_magic_size()] = {};
+            const size_t received = boost::asio::read(sock, boost::asio::buffer(buffer, sizeof(buffer)), ec);
+            first_bytes.assign(buffer, buffer + received);
+            sock.close(ignored);
+        });
+    }
+
+    ~FirstBytesListener()
+    {
+        boost::system::error_code ignored;
+        acceptor.close(ignored);
+        if (worker.joinable())
+            worker.join();
+    }
+
+    std::string address() const
+    {
+        return "127.0.0.1:" + std::to_string(acceptor.local_endpoint().port());
+    }
+
+    const std::vector<unsigned char> &wait()
+    {
+        if (!worker.try_join_for(boost::chrono::seconds(60)))
+        {
+            boost::system::error_code ignored;
+            acceptor.close(ignored);
+            worker.join();
+        }
+        return first_bytes;
+    }
+
+private:
+    static bool grant_socks5(boost::asio::ip::tcp::socket &sock)
+    {
+        boost::system::error_code ec;
+        unsigned char greeting[2] = {};
+        boost::asio::read(sock, boost::asio::buffer(greeting), ec);
+        std::vector<unsigned char> methods(greeting[1]);
+        if (!ec && !methods.empty())
+            boost::asio::read(sock, boost::asio::buffer(methods), ec);
+        const unsigned char no_auth[2] = {5, 0};
+        if (!ec)
+            boost::asio::write(sock, boost::asio::buffer(no_auth), ec);
+
+        unsigned char request[5] = {};
+        if (!ec)
+            boost::asio::read(sock, boost::asio::buffer(request), ec);
+        if (ec || request[3] != 3) // domain address type; request[4] is then its length
+            return false;
+
+        std::vector<unsigned char> target(request[4] + 2u);
+        boost::asio::read(sock, boost::asio::buffer(target), ec);
+
+        const unsigned char granted[10] = {5, 0, 0, 1, 0, 0, 0, 0, 0, 0};
+        if (!ec)
+            boost::asio::write(sock, boost::asio::buffer(granted), ec);
+        return !ec;
+    }
+};
+
+static std::vector<unsigned char> first_bytes_on_init(
+        Monero::WalletManager *wmgr, const std::string &onion_address, bool use_ssl)
+{
+    const bool over_socks = !onion_address.empty();
+    Utils::deleteWallet(WALLET_NAME);
+    FirstBytesListener listener(over_socks);
+    Monero::Wallet *wallet = wmgr->createWallet(WALLET_NAME, WALLET_PASS, WALLET_LANG, WALLET_NETWORK_TYPE);
+    EXPECT_TRUE(wallet->init(over_socks ? onion_address : listener.address(), 0, "", "", use_ssl,
+            false, over_socks ? "socks5://" + listener.address() : std::string()));
+    // must dial even if init() already did: a listener left in accept() is not reliably
+    // unblocked by closing the acceptor, and hangs the suite on Windows
+    wallet->connected();
+    const std::vector<unsigned char> sent = listener.wait();
+    EXPECT_TRUE(wmgr->closeWallet(wallet));
+    return sent;
+}
+
+TEST_F(WalletManagerTest, WalletInitSkipsTlsOnAnonymityNetwork)
+{
+    const std::vector<unsigned char> plain = first_bytes_on_init(wmgr, ONION_DAEMON_ADDRESS, false);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), plain.size());
+    EXPECT_FALSE(epee::net_utils::is_ssl(plain.data(), plain.size()));
+}
+
+// positive control: the probe above must be able to spot a handshake when there is one
+TEST_F(WalletManagerTest, WalletInitAttemptsTlsOnAnonymityNetworkWhenAsked)
+{
+    const std::vector<unsigned char> encrypted = first_bytes_on_init(wmgr, ONION_DAEMON_ADDRESS, true);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), encrypted.size());
+    EXPECT_TRUE(epee::net_utils::is_ssl(encrypted.data(), encrypted.size()));
+}
+
+// an https:// onion daemon may only speak TLS, so the scheme has to beat the address
+TEST_F(WalletManagerTest, WalletInitHonoursHttpsSchemeOnAnonymityNetwork)
+{
+    const std::vector<unsigned char> encrypted =
+            first_bytes_on_init(wmgr, std::string("https://") + ONION_DAEMON_ADDRESS, false);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), encrypted.size());
+    EXPECT_TRUE(epee::net_utils::is_ssl(encrypted.data(), encrypted.size()));
+}
+
+TEST_F(WalletManagerTest, WalletInitKeepsAutodetectOnClearnet)
+{
+    const std::vector<unsigned char> encrypted = first_bytes_on_init(wmgr, "", false);
+    ASSERT_EQ(epee::net_utils::get_ssl_magic_size(), encrypted.size());
+    EXPECT_TRUE(epee::net_utils::is_ssl(encrypted.data(), encrypted.size()));
+}
 
 TEST_F(WalletManagerTest, WalletManagerCreatesWallet)
 {

--- a/tests/unit_tests/util.cpp
+++ b/tests/unit_tests/util.cpp
@@ -48,3 +48,15 @@ TEST(LocalAddress, valid_domain) { ASSERT_FALSE(tools::is_local_address("getmone
 TEST(LocalAddress, local_prefix) { ASSERT_FALSE(tools::is_local_address("localhost.com")); }
 TEST(LocalAddress, invalid) { ASSERT_FALSE(tools::is_local_address("test")); }
 TEST(LocalAddress, empty) { ASSERT_FALSE(tools::is_local_address("")); }
+
+TEST(PrivacyPreservingNetwork, onion) { ASSERT_TRUE(tools::is_privacy_preserving_network("vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd.onion")); }
+TEST(PrivacyPreservingNetwork, onion_uppercase) { ASSERT_TRUE(tools::is_privacy_preserving_network("VWW6YBAL4BD7SZMGNCYRUUCPGFKQAHZDDI37KTCEO3AH7NGMCOPNPYYD.ONION")); }
+TEST(PrivacyPreservingNetwork, onion_mixed_case) { ASSERT_TRUE(tools::is_privacy_preserving_network("vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd.OnIoN")); }
+TEST(PrivacyPreservingNetwork, onion_subdomain) { ASSERT_TRUE(tools::is_privacy_preserving_network("www.vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd.onion")); }
+TEST(PrivacyPreservingNetwork, i2p) { ASSERT_TRUE(tools::is_privacy_preserving_network("xmrto2bturnore26xmrto2bturnore26xmrto2bturnore26xmr2.b32.i2p")); }
+TEST(PrivacyPreservingNetwork, i2p_uppercase) { ASSERT_TRUE(tools::is_privacy_preserving_network("XMRTO2BTURNORE26XMRTO2BTURNORE26XMRTO2BTURNORE26XMR2.B32.I2P")); }
+TEST(PrivacyPreservingNetwork, trailing_dot) { ASSERT_FALSE(tools::is_privacy_preserving_network("vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd.onion.")); }
+TEST(PrivacyPreservingNetwork, embedded_label) { ASSERT_FALSE(tools::is_privacy_preserving_network("x.onion.example.com")); }
+TEST(PrivacyPreservingNetwork, suffix_without_dot) { ASSERT_FALSE(tools::is_privacy_preserving_network("xonion")); }
+TEST(PrivacyPreservingNetwork, clearnet) { ASSERT_FALSE(tools::is_privacy_preserving_network("getmonero.org")); }
+TEST(PrivacyPreservingNetwork, empty) { ASSERT_FALSE(tools::is_privacy_preserving_network("")); }


### PR DESCRIPTION
doInit() took a `ssl` argument and never read it, so every connection used autodetect and onion/i2p daemons got a pointless TLS handshake over an already encrypted, authenticated transport.

TLS is now skipped for .onion/.i2p addresses. use_ssl or an https:// address requires it there instead, without certificate verification: this API cannot carry a CA or fingerprint yet (#10819 will), monerod's default certificate is self-signed so system-CA verification would just drop the connection, and a .onion/.i2p name is self-authenticating (as `ssl_options_t::has_strong_verification` already treats it). The policy covers both wallet-api paths (Wallet::init and WalletManager::setDaemonAddress), matches the suffix case insensitively since Tor lowercases the name it is handed, and logs its decision at INFO. Clearnet is untouched: use_ssl defaults to false, so acting on it would cut callers off https daemons.

Breaking edge: a TLS-only onion daemon addressed without https:// is no longer reached, and https:// at a plaintext-only one now fails instead of silently downgrading.

Tests: libwallet_api_tests captures the first bytes the wallet sends to a fake SOCKS5 proxy, for both paths, and checks for a TLS ClientHello (absent by default, present with use_ssl or https://, clearnet autodetect as the positive control); unit_tests cover the case-insensitive suffix check.

Not changed here: epee's `has_strong_verification` still matches the suffix case-sensitively, so `--daemon-address X.ONION --proxy` at CLI startup keeps rejecting an uppercase onion while the wallet API and simplewallet's `set_daemon` now treat it as a Tor address; a one-line follow-up in net_ssl.cpp if wanted.

Closes #10992