### PR TITLE
chore: consolidate anonymity networks info

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Portions Copyright (c) 2012-2013 The Cryptonote developers.
     - [Guix builds](#guix-builds)
   - [Installing Monero from a package](#installing-monero-from-a-package)
   - [Running monerod](#running-monerod)
-  - [Using Tor](#using-tor)
+  - [Using Tor and I2P](#using-tor-and-i2p)
   - [Pruning](#pruning)
   - [Debugging](#debugging)
   - [Known issues](#known-issues)
@@ -540,32 +540,9 @@ To run as a systemd service, copy [monerod.service](utils/systemd/monerod.servic
 
 If you're on Mac, you may need to add the `--max-concurrency 1` option to monero-wallet-cli, and possibly monerod, if you get crashes refreshing.
 
-## Using Tor
+## Using Tor and I2P
 
-> There is a new, still experimental, [integration with Tor](docs/ANONYMITY_NETWORKS.md). The feature allows connecting over IPv4 and Tor simultaneously - IPv4 is used for relaying blocks and relaying transactions received by peers whereas Tor is used solely for relaying transactions received over local RPC. This provides privacy and better protection against surrounding node (sybil) attacks.
-
-While Monero isn't made to integrate with Tor, it can be used wrapped with torsocks, by setting the following configuration parameters and environment variables:
-
-* `--p2p-bind-ip 127.0.0.1` on the command line or `p2p-bind-ip=127.0.0.1` in monerod.conf to disable listening for connections on external interfaces.
-* If you use the wallet with a Tor daemon via the loopback IP (eg, 127.0.0.1:9050), then use `--untrusted-daemon` unless it is your own hidden service.
-
-Example command line to start monerod through Tor:
-
-```bash
-monerod --proxy 127.0.0.1:9050 --p2p-bind-ip 127.0.0.1
-```
-
-A helper script is in contrib/tor/monero-over-tor.sh. It assumes Tor is installed already, and runs Tor and Monero with the right configuration.
-
-### Using Tor on Tails
-
-TAILS ships with a very restrictive set of firewall rules. Therefore, you need to add a rule to allow this connection too, in addition to telling torsocks to allow inbound connections. Full example:
-
-```bash
-sudo iptables -I OUTPUT 2 -p tcp -d 127.0.0.1 -m tcp --dport 18081 -j ACCEPT
-DNS_PUBLIC=tcp torsocks ./monerod --p2p-bind-ip 127.0.0.1 --rpc-bind-ip 127.0.0.1 \
-    --data-dir /home/amnesia/Persistent/your/directory/to/the/blockchain
-```
+See [ANONYMITY_NETWORKS.md](docs/ANONYMITY_NETWORKS.md).
 
 ## Pruning
 

--- a/docs/ANONYMITY_NETWORKS.md
+++ b/docs/ANONYMITY_NETWORKS.md
@@ -1,11 +1,11 @@
 # Anonymity Networks with Monero
 
 Currently only Tor and I2P have been integrated into Monero. The usage of
-these networks is still considered experimental - there are a few pessimistic
-cases where privacy is leaked. The design is intended to maximize privacy of
+these networks is still considered somewhat experimental - there are a few pessimistic
+cases where privacy may be leaked. The design is intended to maximize privacy of
 the source of a transaction by broadcasting it over an anonymity network, while
 relying on IPv4 for the remainder of messages to make surrounding node attacks
-(via sybil) more difficult.
+(via Sybil) more difficult.
 
 
 ## Behavior
@@ -23,7 +23,7 @@ will only be sent to peers on anonymity networks. If an anonymity network is
 enabled but no peers over an anonymity network are available, an error is
 logged and the transaction is kept for future broadcasting over an anonymity
 network. The transaction will not be broadcast unless an anonymity connection
-is made or until `monerod` is shutdown and restarted with only public
+is made or until `monerod` is shut down and restarted with only public
 connections enabled.
 
 Anonymity networks can also be used with `monero-wallet-cli` and
@@ -44,8 +44,8 @@ with additional exclusive IPv4 address(es).
 
 ### Blockchain sync
 
-Monerod does not support synchronizing the blockchain over onion or I2P hidden services.
-You may sync the blockchain using a SOCKS4 proxy. Monerod will connect to IPv4
+`monerod` does not support synchronizing the blockchain over onion or I2P hidden services.
+You may sync the blockchain using a SOCKS proxy. `monerod` will connect to IPv4
 nodes using this proxy to sync the blockchain.
 
 ```bash
@@ -62,7 +62,7 @@ You may use the below options with or without `--proxy`.
 #### Outbound Connections
 
 Connecting to an anonymous address requires the command line option
-`--tx-proxy` which tells `monerod` the ip/port of a socks proxy provided by a
+`--tx-proxy` which tells `monerod` the ip/port of a SOCKS proxy provided by a
 separate process. On most systems the configuration will look like:
 
 ```bash
@@ -71,9 +71,9 @@ monerod \
     --tx-proxy i2p,127.0.0.1:4447
 ```
 
-which tells `monerod` to connect to ".onion" P2P addresses using a socks
+which tells `monerod` to connect to ".onion" P2P addresses using a SOCKS
 proxy at IP 127.0.0.1 port 9050 with a max of 10 outgoing connections and
-".b32.i2p" P2P addresses using a socks proxy at IP 127.0.0.1 port 4447
+".i2p" P2P addresses using a SOCKS proxy at IP 127.0.0.1 port 4447
 with the default max outgoing connections.
 
 If desired, peers can be manually specified:
@@ -134,7 +134,7 @@ monero-wallet-cli \
 The proxy must match the address type - a Tor proxy will not work properly with
 I2P addresses, etc.
 
-I2P hidden service (b32.i2p) and Tor Hidden service (.onion) addresses provide the information necessary to authenticate and
+I2P hidden service (.i2p) and Tor hidden service (.onion) addresses provide the information necessary to authenticate and
 encrypt the connection from end-to-end. If desired, SSL can also be applied to
 the connection with `--daemon-address https://5tymba6faziy36md5ffy42vatbjzlye4vyr3gyz6lcvdfximnvwpmwqd.onion` which
 requires a server certificate that is signed by a "root" certificate on the
@@ -150,10 +150,10 @@ encryption, or bypassed with `--daemon-ssl-allow-any-cert`.
 #### Tor & I2P
 
 Options `--add-exclusive-node`, `--add-priority-node`, and `--add-peer` recognize ".onion" and
-".b32.i2p" addresses, and will properly forward those addresses to the proxy
+".i2p" addresses, and will properly forward those addresses to the proxy
 provided with `--tx-proxy tor,...` or `--tx-proxy i2p,...`.
 
-Option `--anonymous-inbound` also recognizes ".onion" and ".b32.i2p" addresses,
+Option `--anonymous-inbound` also recognizes ".onion" and ".i2p" addresses,
 and will automatically be sent out to outgoing Tor/I2P connections so the peer
 can distribute the address to its other peers.
 
@@ -195,7 +195,7 @@ monerod
 
 ### Connect to IPv4 Nodes Over Clearnet and Relay Transactions via Tor
 
-Monerod will connect to IPv4 nodes via clearnet, revealing to your ISP
+`monerod` will connect to IPv4 nodes via clearnet, revealing to your ISP
 that you are running a Monero node, but your transactions will be relayed over
 Tor.
 
@@ -208,7 +208,7 @@ monerod --tx-proxy tor,127.0.0.1:9050,10
 ### Connect To IPv4 Nodes Over Tor Only
 
 This configuration does not connect to hidden services or accept incoming
-connections. Your ISP will see that you are running Tor, but not Monerod.
+connections. Your ISP will see that you are running Tor, but not `monerod`.
 
 ```bash
 sudo apt install tor # Or install Tor some other way
@@ -218,7 +218,7 @@ monerod --proxy 127.0.0.1:9050 --p2p-bind-ip 127.0.0.1
 
 ### Connect to IPv4 Nodes Over Tor and Connect to Hidden Services
 
-Your ISP will see that you are running Tor and I2P, but not Monerod. Transactions
+Your ISP will see that you are running Tor and I2P, but not `monerod`. Transactions
 will be relayed to hidden services. Your node will not accept any incoming
 connections (including from Tor and I2P).
 
@@ -244,8 +244,18 @@ monerod --proxy 127.0.0.1:9050 \
 
 ### Connect Exclusively to Hidden Services (avoid IPv4 entirely)
 
-This configuration is not currently supported. Monerod relies on IPv4 to sync
+This configuration is not currently supported. `monerod` relies on IPv4 to sync
 the blockchain to make Sybil attacks more difficult.
+
+### Using Tor on Tails
+
+Tails ships with a very restrictive set of firewall rules. Therefore, you need to add a rule to allow this connection too, in addition to telling `torsocks` to allow inbound connections. Full example:
+
+```bash
+sudo iptables -I OUTPUT 2 -p tcp -d 127.0.0.1 -m tcp --dport 18081 -j ACCEPT
+DNS_PUBLIC=tcp torsocks ./monerod --p2p-bind-ip 127.0.0.1 --rpc-bind-ip 127.0.0.1 \
+    --data-dir /home/amnesia/Persistent/your/directory/to/the/blockchain
+```
 
 ## Privacy Limitations
 

--- a/docs/ANONYMITY_NETWORKS.md
+++ b/docs/ANONYMITY_NETWORKS.md
@@ -1,11 +1,11 @@
 # Anonymity Networks with Monero
 
 Currently only Tor and I2P have been integrated into Monero. The usage of
-these networks is still considered experimental - there are a few pessimistic
-cases where privacy is leaked. The design is intended to maximize privacy of
+these networks is still considered somewhat experimental - there are a few pessimistic
+cases where privacy may be leaked. The design is intended to maximize privacy of
 the source of a transaction by broadcasting it over an anonymity network, while
 relying on IPv4 for the remainder of messages to make surrounding node attacks
-(via sybil) more difficult.
+(via Sybil) more difficult.
 
 
 ## Behavior
@@ -23,7 +23,7 @@ will only be sent to peers on anonymity networks. If an anonymity network is
 enabled but no peers over an anonymity network are available, an error is
 logged and the transaction is kept for future broadcasting over an anonymity
 network. The transaction will not be broadcast unless an anonymity connection
-is made or until `monerod` is shutdown and restarted with only public
+is made or until `monerod` is shut down and restarted with only public
 connections enabled.
 
 Anonymity networks can also be used with `monero-wallet-cli` and
@@ -44,8 +44,8 @@ with additional exclusive IPv4 address(es).
 
 ### Blockchain sync
 
-Monerod does not support synchronizing the blockchain over onion or I2P hidden services.
-You may sync the blockchain using a SOCKS4 proxy. Monerod will connect to IPv4
+`monerod` does not support synchronizing the blockchain over onion or I2P hidden services.
+You may sync the blockchain using a SOCKS proxy. `monerod` will connect to IPv4
 nodes using this proxy to sync the blockchain.
 
 ```bash
@@ -62,7 +62,7 @@ You may use the below options with or without `--proxy`.
 #### Outbound Connections
 
 Connecting to an anonymous address requires the command line option
-`--tx-proxy` which tells `monerod` the ip/port of a socks proxy provided by a
+`--tx-proxy` which tells `monerod` the ip/port of a SOCKS proxy provided by a
 separate process. On most systems the configuration will look like:
 
 ```bash
@@ -71,9 +71,9 @@ monerod \
     --tx-proxy i2p,127.0.0.1:4447
 ```
 
-which tells `monerod` to connect to ".onion" P2P addresses using a socks
+which tells `monerod` to connect to ".onion" P2P addresses using a SOCKS
 proxy at IP 127.0.0.1 port 9050 with a max of 10 outgoing connections and
-".b32.i2p" P2P addresses using a socks proxy at IP 127.0.0.1 port 4447
+".i2p" P2P addresses using a SOCKS proxy at IP 127.0.0.1 port 4447
 with the default max outgoing connections.
 
 If desired, peers can be manually specified:
@@ -134,7 +134,7 @@ monero-wallet-cli \
 The proxy must match the address type - a Tor proxy will not work properly with
 I2P addresses, etc.
 
-I2P hidden service (b32.i2p) and Tor Hidden service (.onion) addresses provide the information necessary to authenticate and
+I2P hidden service (.i2p) and Tor hidden service (.onion) addresses provide the information necessary to authenticate and
 encrypt the connection from end-to-end. If desired, SSL can also be applied to
 the connection with `--daemon-address https://5tymba6faziy36md5ffy42vatbjzlye4vyr3gyz6lcvdfximnvwpmwqd.onion` which
 requires a server certificate that is signed by a "root" certificate on the
@@ -150,10 +150,10 @@ encryption, or bypassed with `--daemon-ssl-allow-any-cert`.
 #### Tor & I2P
 
 Options `--add-exclusive-node`, `--add-priority-node`, and `--add-peer` recognize ".onion" and
-".b32.i2p" addresses, and will properly forward those addresses to the proxy
+".i2p" addresses, and will properly forward those addresses to the proxy
 provided with `--tx-proxy tor,...` or `--tx-proxy i2p,...`.
 
-Option `--anonymous-inbound` also recognizes ".onion" and ".b32.i2p" addresses,
+Option `--anonymous-inbound` also recognizes ".onion" and ".i2p" addresses,
 and will automatically be sent out to outgoing Tor/I2P connections so the peer
 can distribute the address to its other peers.
 
@@ -195,7 +195,7 @@ monerod
 
 ### Connect to IPv4 Nodes Over Clearnet and Relay Transactions via Tor
 
-Monerod will connect to IPv4 nodes via clearnet, revealing to your ISP
+`monerod` will connect to IPv4 nodes via clearnet, revealing to your ISP
 that you are running a Monero node, but your transactions will be relayed over
 Tor.
 
@@ -208,7 +208,7 @@ monerod --tx-proxy tor,127.0.0.1:9050,10
 ### Connect To IPv4 Nodes Over Tor Only
 
 This configuration does not connect to hidden services or accept incoming
-connections. Your ISP will see that you are running Tor, but not Monerod.
+connections. Your ISP will see that you are running Tor, but not `monerod`.
 
 ```bash
 sudo apt install tor # Or install Tor some other way
@@ -218,7 +218,7 @@ monerod --proxy 127.0.0.1:9050 --p2p-bind-ip 127.0.0.1
 
 ### Connect to IPv4 Nodes Over Tor and Connect to Hidden Services
 
-Your ISP will see that you are running Tor and I2P, but not Monerod. Transactions
+Your ISP will see that you are running Tor and I2P, but not `monerod`. Transactions
 will be relayed to hidden services. Your node will not accept any incoming
 connections (including from Tor and I2P).
 
@@ -244,8 +244,17 @@ monerod --proxy 127.0.0.1:9050 \
 
 ### Connect Exclusively to Hidden Services (avoid IPv4 entirely)
 
-This configuration is not currently supported. Monerod relies on IPv4 to sync
+This configuration is not currently supported. `monerod` relies on IPv4 to sync
 the blockchain to make Sybil attacks more difficult.
+
+### Using Tor on Tails
+
+Tails does not transparently 'torify' traffic, so `monerod` needs to be told to
+use the local Tor SOCKS proxy directly with `--proxy`:
+
+```bash
+./monerod --proxy 127.0.0.1:9050 --data-dir /home/amnesia/Persistent/.bitmonero
+```
 
 ## Privacy Limitations
 


### PR DESCRIPTION
Moves the content of the "Using Tor" section in `README.md` to the `docs/` folder, fixes some grammar/capitalization nitpicks, and updates I2P address info for [human-readable hostnames](https://github.com/monero-project/monero/pull/10458).