### PR TITLE
wallet: upstream misc stuff before FCMP++

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2026, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -5504,14 +5504,18 @@ void wallet2::decrypt_keys(const epee::wipeable_string &password)
   decrypt_keys(key);
 }
 
-void wallet2::setup_new_blockchain()
+void wallet2::setup_new_blockchain(const bool add_subaddr_account)
 {
+  m_blockchain.clear();
   cryptonote::block b;
   generate_genesis(b);
-  m_blockchain.push_back(get_block_hash(b));
+  const crypto::hash genesis_hash = get_block_hash(b);
+  m_blockchain.push_back(genesis_hash);
   m_last_block_reward = cryptonote::get_outs_money_amount(b.miner_tx);
-  add_subaddress_account(tr("Primary account"));
+  if (add_subaddr_account)
+    add_subaddress_account(tr("Primary account"));
 }
+
 
 void wallet2::create_keys_file(const std::string &wallet_, bool watch_only, const epee::wipeable_string &password, bool create_address_file)
 {
@@ -8550,14 +8554,22 @@ uint64_t wallet2::get_fee_quantization_mask()
   return fee_quantization_mask;
 }
 //----------------------------------------------------------------------------------------------------
-fee_algorithm wallet2::get_fee_algorithm()
+fee_algorithm wallet2::get_fee_algorithm(bool offline)
 {
-  // changes at v3, v5, v8
-  if (use_fork_rules(HF_VERSION_PER_BYTE_FEE, 0))
+  offline = offline || m_offline;
+  const auto use_fork_rules_fn = [this, offline](uint8_t version, int64_t early_blocks = 0) -> bool
+  {
+    return offline
+      ? use_fork_rules_offline(version, early_blocks)
+      : use_fork_rules(version, early_blocks);
+  };
+
+  // changes at v3, v5, v8, v17
+  if (use_fork_rules_fn(HF_VERSION_PER_BYTE_FEE, 0))
     return fee_algorithm::HardforkV8;
-  if (use_fork_rules(5, 0))
+  if (use_fork_rules_fn(5, 0))
     return fee_algorithm::HardforkV5;
-  if (use_fork_rules(3, -30 * 14))
+  if (use_fork_rules_fn(3, -30 * 14))
    return fee_algorithm::HardforkV3;
   return fee_algorithm::PreHardforkV3;
 }
@@ -11429,6 +11441,37 @@ bool wallet2::use_fork_rules(uint8_t version, int64_t early_blocks)
     LOG_PRINT_L2("Using v" << (unsigned)version << " rules");
   else
     LOG_PRINT_L2("Not using v" << (unsigned)version << " rules");
+  return close_enough;
+}
+//----------------------------------------------------------------------------------------------------
+bool wallet2::use_fork_rules_offline(uint8_t version, int64_t early_blocks) const
+{
+  // get hard fork table based on network type
+  const size_t wallet_num_hard_forks = m_nettype == TESTNET ? num_testnet_hard_forks
+    : m_nettype == STAGENET ? num_stagenet_hard_forks : num_mainnet_hard_forks;
+  const hardfork_t *wallet_hard_forks = m_nettype == TESTNET ? testnet_hard_forks
+    : m_nettype == STAGENET ? stagenet_hard_forks : mainnet_hard_forks;
+
+  // find hard fork with lowest version >= `version`
+  const hardfork_t *best_fork_info = nullptr;
+  for (std::size_t i = 0; i < wallet_num_hard_forks; ++i)
+  {
+    const hardfork_t &fork_info = wallet_hard_forks[i];
+    if (fork_info.version < version)
+      continue;
+    if (nullptr == best_fork_info || fork_info.version < best_fork_info->version)
+      best_fork_info = &fork_info;
+  }
+
+  if (nullptr == best_fork_info) // did not find fork in table
+    return false;
+
+  const int64_t height = static_cast<int64_t>(get_blockchain_current_height());
+  const bool close_enough = height >= static_cast<int64_t>(best_fork_info->height) - early_blocks;
+  if (close_enough)
+    LOG_PRINT_L2("Using v" << static_cast<unsigned>(version) << " rules (offline)");
+  else
+    LOG_PRINT_L2("Not using v" << static_cast<unsigned>(version) << " rules (offline)");
   return close_enough;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2026, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -99,7 +99,6 @@ namespace tools
       result_type operator()() { return crypto::rand<result_type>(); }
     } engine;
 
-private:
     std::gamma_distribution<double> gamma;
     const std::vector<uint64_t> &rct_offsets;
     const uint64_t *begin, *end;
@@ -845,6 +844,7 @@ private:
     void set_subaddress_label(const cryptonote::subaddress_index &index, const std::string &label);
     void set_subaddress_lookahead(size_t major, size_t minor);
     std::pair<size_t, size_t> get_subaddress_lookahead() const { return {m_subaddress_lookahead_major, m_subaddress_lookahead_minor}; }
+    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &get_subaddress_map_ref() const { return m_subaddresses; }
     /*!
      * \brief Tells if the wallet file is deprecated.
      */
@@ -905,9 +905,71 @@ private:
     bool parse_unsigned_tx_from_str(const std::string &unsigned_tx_st, unsigned_tx_set &exported_txs) const;
     bool load_tx(const std::string &signed_filename, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set&)> accept_func = NULL);
     bool parse_tx_from_str(const std::string &signed_tx_st, std::vector<tools::wallet2::pending_tx> &ptx, std::function<bool(const signed_tx_set &)> accept_func);
-    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs = {});     // pass subaddr_indices by value on purpose
+    /**
+     * @brief Create "transfer" style txs (or tx proposals in hot/cold & multisig wallets)
+     * @param dsts list of (address, amount) payments to fulfill
+     * @param fake_outs_count the number of decoys per input, AKA "mixin"
+     * @param priority fee priority level
+     * @param extra any non-ephemeral-tx-pubkey tx.extra fields, including PIDs
+     * @param subaddr_account the only account (AKA major) index for which input selection should pull inputs from
+     * @param subaddr_indices if non-empty, the only minor indices for which input selection should pull inputs from
+     * @param subtract_fee_from_outputs indices into `dsts` which are "fee-subtractable"
+     * @return list of "pending txs": structs which contain partially or fully formed txs and construction information
+     *
+     * Transfer-style means that transactions are added until all payment outlays are fulfilled.
+     */
+    std::vector<wallet2::pending_tx> create_transactions_2(
+      std::vector<cryptonote::tx_destination_entry> dsts,
+      const size_t fake_outs_count,
+      fee_priority priority,
+      const std::vector<uint8_t>& extra,
+      uint32_t subaddr_account,
+      std::set<uint32_t> subaddr_indices, // pass subaddr_indices by value on purpose
+      const unique_index_container& subtract_fee_from_outputs = {});
+    /**
+     * @brief Create "sweep-all" style txs (or tx proposals in hot/cold & multisig wallets)
+     * @param below the money amount below which input selection should pull inputs from; higher amounts are excluded
+     * @param address public address for all destinations in txs
+     * @param is_subaddress true iff `address` refers to a subaddress
+     * @param outputs the minimum num of outputs to make per tx (if `address` isn't ours, a change output is included)
+     * @param fake_outs_count the number of decoys per input, AKA "mixin"
+     * @param priority fee priority level
+     * @param extra any non-ephemeral-tx-pubkey tx.extra fields, including PIDs
+     * @param subaddr_account the only account (AKA major) index for which input selection should pull inputs from
+     * @param subaddr_indices if non-empty, the only minor indices for which input selection should pull inputs from
+     * @return list of "pending txs": structs which contain partially or fully formed txs and construction information
+     *
+     * Sweep-all-style means that transactions are added until all inputs <= amount `below` are spent.
+     */
     std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices);
+    /**
+     * @brief Create "sweep-single" style txs (or tx proposals in hot/cold & multisig wallets)
+     * @param ki the key image of the input that is to be spent
+     * @param address public address for all destinations in txs
+     * @param is_subaddress true iff `address` refers to a subaddress
+     * @param outputs the minimum num of outputs to make per tx (if `address` isn't ours, a change output is included)
+     * @param fake_outs_count the number of decoys per input, AKA "mixin"
+     * @param priority fee priority level
+     * @param extra any non-ephemeral-tx-pubkey tx.extra fields, including PIDs
+     * @return list of "pending txs": structs which contain partially or fully formed txs and construction information
+     *
+     * Sweep-single-style means that 1 transaction is returned which spends the given key image
+     */
     std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra);
+    /**
+     * @brief Create "sweep-multiple" style txs (or tx proposals in hot/cold & multisig wallets)
+     * @param address public address for all destinations in txs
+     * @param is_subaddress true iff `address` refers to a subaddress
+     * @param outputs the minimum num of outputs to make per tx (if `address` isn't ours, a change output is included)
+     * @param unused_transfers_indices indices into `m_transfers` of RingCT & validly-decomposed pre-RingCT inputs
+     * @param unused_dust_indices indices into `m_transfers` of non-validly-decomposed pre-RingCT inputs
+     * @param fake_outs_count the number of decoys per input, AKA "mixin"
+     * @param priority fee priority level
+     * @param extra any non-ephemeral-tx-pubkey tx.extra fields, including PIDs
+     * @return list of "pending txs": structs which contain partially or fully formed txs and construction information
+     *
+     * Sweep-multiple-style means that transactions are added until all inputs specified by index are spent.
+     */
     std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra);
     bool sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, const std::vector<cryptonote::tx_destination_entry>& dsts, const unique_index_container& subtract_fee_from_outputs = {}) const;
     void cold_tx_aux_import(const std::vector<pending_tx>& ptx, const std::vector<std::string>& tx_device_aux);
@@ -1251,8 +1313,26 @@ private:
 
     uint8_t get_current_hard_fork();
     void get_hard_fork_info(uint8_t version, uint64_t &earliest_height);
+    /**
+     * @brief Determine if daemon's blockchain is past a certain fork version
+     * @param version fork version
+     * @param early_blocks threshold of blocks for which the the fork can be away from activation
+     * @return true iff daemon's blockchain is past the fork version, within said threshold
+     */
     bool use_fork_rules(uint8_t version, int64_t early_blocks = 0);
-    fee_algorithm get_fee_algorithm();
+    /**
+     * @brief Determine if wallet's cached blockchain is past a certain fork version, according to its own fork table
+     * @param version fork version
+     * @param early_blocks threshold of blocks for which the the fork can be away from activation
+     * @return true iff wallet's cached blockchain is past the fork version, within said threshold
+     */
+    bool use_fork_rules_offline(uint8_t version, int64_t early_blocks = 0) const;
+    /**
+     * @brief Determine fee algorithm to used based on active fork rules
+     * @param offline true iff should use `use_fork_rules_offline()`, else use `use_fork_rules()`
+     * @return fee algorithm
+     */
+    fee_algorithm get_fee_algorithm(bool offline = false);
 
     std::string get_wallet_file() const;
     std::string get_keys_file() const;
@@ -1486,7 +1566,9 @@ private:
 
     static std::string get_default_daemon_address() { CRITICAL_REGION_LOCAL(default_daemon_address_lock); return default_daemon_address; }
 
+  #ifndef IN_UNIT_TESTS
   private:
+  #endif
     /*!
      * \brief  Stores wallet information to wallet file.
      * \param  keys_file_name Name of wallet file
@@ -1612,7 +1694,11 @@ private:
     std::shared_ptr<std::map<std::pair<uint64_t, uint64_t>, size_t>> create_output_tracker_cache() const;
 
     void init_type(hw::device::device_type device_type);
-    void setup_new_blockchain();
+    /**
+     * @brief Reset blockchain state to the genesis
+     * @param add_subaddr_account true to add a new subaddress account labeled "Primary account"
+     */
+    void setup_new_blockchain(const bool add_subaddr_account = true);
     void create_keys_file(const std::string &wallet_, bool watch_only, const epee::wipeable_string &password, bool create_address_file);
 
     wallet_device_callback * get_device_callback();

--- a/src/wallet/wallet2_basic/wallet2_types.h
+++ b/src/wallet/wallet2_basic/wallet2_types.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, The Monero Project
+// Copyright (c) 2025-2026, The Monero Project
 //
 // All rights reserved.
 //
@@ -52,7 +52,7 @@ template <class Archive> void serialize(Archive&, wallet2_basic::hashchain&, uns
 namespace wallet2_basic
 {
 /**
- * @brief: caches a contiguous list of block hashes and a genesis block
+ * @brief Caches a contiguous list of block hashes and a genesis block
 */
 class hashchain
 {
@@ -60,51 +60,51 @@ public:
     hashchain(): m_genesis(crypto::null_hash), m_offset(0) {}
 
     /**
-     * @brief: get the "height" of the blockchain, not the number of hashes stored
+     * @brief Get the "height" of the blockchain, not the number of hashes stored
     */
     size_t size() const { return m_blockchain.size() + m_offset; }
     /**
-     * @brief: get the height that the hash list begins at
+     * @brief Get the height that the hash list begins at
     */
     size_t offset() const { return m_offset; }
     /**
-     * @brief: get the genesis block hash
+     * @brief Get the genesis block hash
     */
     const crypto::hash &genesis() const { return m_genesis; }
     /**
-     * @brief: add a block hash to the top of the chain
+     * @brief Add a block hash to the top of the chain
     */
     void push_back(const crypto::hash &hash) { if (m_offset == 0 && m_blockchain.empty()) m_genesis = hash; m_blockchain.push_back(hash); }
     /**
-     * @brief: query if there is a hash available for a given height
+     * @brief Query if there is a hash available for a given height
     */
     bool is_in_bounds(size_t idx) const { return idx >= m_offset && idx < size(); }
     /**
-     * @brief: get a const reference to the block hash at a given height
+     * @brief Get a const reference to the block hash at a given height
     */
     const crypto::hash &operator[](size_t idx) const { return m_blockchain[idx - m_offset]; }
     /**
-     * @brief: get a mutable reference to the block hash at a given height
+     * @brief Get a mutable reference to the block hash at a given height
     */
     crypto::hash &operator[](size_t idx) { return m_blockchain[idx - m_offset]; }
     /**
-     * @brief: crop stored hashes after a certain height, where the height of the top block == `height`-1
+     * @brief Crop stored hashes after a certain height, where the height of the top block == `height`-1
     */
     void crop(size_t height) { m_blockchain.resize(std::max(std::min(height, size()), m_offset) - m_offset); }
     /**
-     * @brief: delete all stored hashes and set the offset to 0
+     * @brief Delete all stored hashes and set the offset to 0
     */
     void clear() { m_offset = 0; m_blockchain.clear(); }
     /**
-     * @brief: query if the blockchain is "empty": there are no stored hashes and the offset is 0
+     * @brief Query if the blockchain is "empty": there are no stored hashes and the offset is 0
     */
     bool empty() const { return m_blockchain.empty() && m_offset == 0; }
     /**
-     * @brief: crop stored hashes before a certain height and shift the offset accordingly, but always leave at least 1 hash
+     * @brief Crop stored hashes before a certain height and shift the offset accordingly, but always leave at least 1 hash
     */
     void trim(size_t height) { while (height > m_offset && m_blockchain.size() > 1) { m_blockchain.pop_front(); ++m_offset; } m_blockchain.shrink_to_fit(); }
     /**
-     * @brief: push a block hash onto the chain and move all block hashes back by one block
+     * @brief Push a block hash onto the chain and move all block hashes back by one block
     */
     void refill(const crypto::hash &hash) { m_blockchain.push_back(hash); --m_offset; }
 


### PR DESCRIPTION
Some miscellaneous wallet changes that aren't FCMP++-specific, but help support the FCMP++ wallet integration.

- Add `use_fork_rules_offline()`
- Add offline mode for `get_fee_algorithm()`
- Add mode for `setup_new_blockchain()` for already-initiated wallet instances
- Add `get_subaddress_map_ref()`
- Remove spurious `private` label in `gamma_picker`
- Adds docstrings for `create_transactions_*()`
- Refactor `brief` tags for docstrings in basic types header
- If `IN_UNIT_TESTS` is defined, exclude `private` label for `wallet2` fields

Part of upstreaming Carrot/FCMP++