### PR TITLE
device: fix ledger status code reporting

### DIFF
--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -81,10 +81,9 @@ namespace hw {
       static const char *to_string(unsigned int code);
     };
 
-    // Must be sorted in ascending order by the code
     #define LEDGER_STATUS(status) {status, #status}
     constexpr Status status_codes[] = {
-      LEDGER_STATUS(SW_OK),
+      LEDGER_STATUS(SW_LOCKED_DEVICE),
       LEDGER_STATUS(SW_WRONG_LENGTH),
       LEDGER_STATUS(SW_SECURITY_PIN_LOCKED),
       LEDGER_STATUS(SW_SECURITY_LOAD_KEY),
@@ -98,7 +97,6 @@ namespace hw {
       LEDGER_STATUS(SW_SECURITY_INTERNAL),
       LEDGER_STATUS(SW_SECURITY_MAX_SIGNATURE_REACHED),
       LEDGER_STATUS(SW_SECURITY_PREFIX_HASH),
-      LEDGER_STATUS(SW_SECURITY_LOCKED),
       LEDGER_STATUS(SW_COMMAND_NOT_ALLOWED),
       LEDGER_STATUS(SW_SUBCOMMAND_NOT_ALLOWED),
       LEDGER_STATUS(SW_DENY),
@@ -106,12 +104,23 @@ namespace hw {
       LEDGER_STATUS(SW_WRONG_DATA),
       LEDGER_STATUS(SW_WRONG_DATA_RANGE),
       LEDGER_STATUS(SW_IO_FULL),
+      LEDGER_STATUS(SW_SECURITY_LOCKED),
       LEDGER_STATUS(SW_CLIENT_NOT_SUPPORTED),
       LEDGER_STATUS(SW_WRONG_P1P2),
       LEDGER_STATUS(SW_INS_NOT_SUPPORTED),
       LEDGER_STATUS(SW_PROTOCOL_NOT_SUPPORTED),
-      LEDGER_STATUS(SW_UNKNOWN)
+      LEDGER_STATUS(SW_UNKNOWN),
+      LEDGER_STATUS(SW_OK)
     };
+
+    constexpr bool status_codes_sorted()
+    {
+      for (size_t i = 1; i < sizeof(status_codes) / sizeof(status_codes[0]); ++i)
+        if (!(status_codes[i-1].code < status_codes[i].code))
+          return false;
+      return true;
+    }
+    static_assert(status_codes_sorted(), "status_codes must be sorted in ascending order by the code");
 
     const char *Status::to_string(unsigned int code)
     {
@@ -488,6 +497,7 @@ namespace hw {
       MDEBUG("Device "<< this->id << " exchange: sw: " << this->sw << " expected: " << ok);
       ASSERT_X(sw != SW_CLIENT_NOT_SUPPORTED, "Monero Ledger App doesn't support current monero version. Try to update the Monero Ledger App, at least " << MINIMAL_APP_VERSION_MAJOR<< "." << MINIMAL_APP_VERSION_MINOR << "." << MINIMAL_APP_VERSION_MICRO << " is required.");
       ASSERT_X(sw != SW_PROTOCOL_NOT_SUPPORTED, "Make sure no other program is communicating with the Ledger.");
+      ASSERT_X(sw != SW_LOCKED_DEVICE, "Ledger is locked.");
       ASSERT_SW(this->sw,ok,mask);
 
       return this->sw;
@@ -505,6 +515,7 @@ namespace hw {
         // cancel on device
         deny = 1;
       } else {
+        ASSERT_X(this->sw != SW_LOCKED_DEVICE, "Ledger is locked.");
         ASSERT_SW(this->sw,ok,mask);
       }
 

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -86,6 +86,9 @@ namespace hw {
     #define SW_PROTOCOL_NOT_SUPPORTED               0x6e00
     #define SW_UNKNOWN                              0x6f00
 
+    // Origin: https://github.com/LedgerHQ/ledger-live/blob/68b9451b5456ae6cd452d00aa5007a875bdf4c6f/libs/ledgerjs/packages/errors/src/index.ts#L337
+    #define SW_LOCKED_DEVICE                        0x5515
+
     void set_apdu_verbose(bool verbose);
 
     class ABPkeys {


### PR DESCRIPTION
## Problem

Opening a Ledger-backed wallet while the device is connected but locked fails with:

```
Wrong Device Status: 0x5515 (UNKNOWN), EXPECTED 0x9000 (UNKNOWN), MASK 0xffff
```

Two separate problems are visible in that one line.

## 1. `status_codes` is not sorted, so names are misreported

`Status::to_string()` looks the code up with `std::lower_bound`, which requires a
sorted range. A comment above the table says it must be sorted, but nothing enforced
that, and it was not: `SW_OK` (0x9000) was the first entry, and `SW_SECURITY_LOCKED`
(0x69EE) sat before `SW_COMMAND_NOT_ALLOWED` (0x6980).

Three codes therefore resolved to `UNKNOWN`:

| code | reported | correct |
| --- | --- | --- |
| 0x9000 | UNKNOWN | SW_OK |
| 0x6700 | UNKNOWN | SW_WRONG_LENGTH |
| 0x69EE | UNKNOWN | SW_SECURITY_LOCKED |

`SW_OK` is the expected status in every one of these messages, so *every* Ledger
error has been printing `EXPECTED 0x9000 (UNKNOWN)`.

The first commit sorts the table and adds a `static_assert` so the ordering is
enforced rather than merely documented. The table has been unsorted since #6322
introduced it.

## 2. A locked device is reported as a raw status dump

0x5515 is a Ledger OS status word meaning the device is locked. It is not one of the
Monero app's own status words, so it has no table entry and falls through to the raw
dump above.

The second commit reports it the way `SW_CLIENT_NOT_SUPPORTED` and
`SW_PROTOCOL_NOT_SUPPORTED` are already reported a few lines up:

```
Ledger is locked.
```

The same guard is added to `exchange_wait_on_input()`, which is the path used while
signing a transaction — a device that auto-locks mid-signing hits it.

0x5515 is documented as `LOCKED_DEVICE` in Ledger's own error definitions:
https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/errors/src/index.ts

Reported downstream as monero-project/monero-gui#3507.
