### PR TITLE
cryptonote_protocol: trim overlapping spans

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1411,6 +1411,19 @@ namespace cryptonote
             ++m_sync_old_spans_downloaded;
             continue;
           }
+          if (start_height < previous_height)
+          {
+            const uint64_t skip = previous_height - start_height;
+            MDEBUG(context << " Trimming " << skip << " overlap block(s) from span (span starts at "
+                << start_height << ", chain is at " << previous_height << ")");
+            blocks.erase(blocks.begin(), blocks.begin() + skip);
+            start_height = previous_height;
+            if (blocks.empty())
+            {
+              m_block_queue.remove_spans(span_connection_id, start_height);
+              continue;
+            }
+          }
           if (!parse_and_validate_block_from_blob(blocks.front().block, new_block))
           {
             MERROR(context << "Failed to parse block, but it should already have been parsed");


### PR DESCRIPTION
resolves: https://github.com/seraphis-migration/monero/issues/221
resolves: https://github.com/monero-project/monero/issues/6419

root cause was the way that monerod handled overlapping spans

It is exacerbated by the dynamic block sync size commit.

```
                                                   
2026-05-18 21:26:13.418 I Synced 949944/3005287 (31%, 2055343 left) (0.193760 sec, 201.279934 blocks/sec), 15.201876 MB queued in 211 spans, stripe 8 -> 8: [<<_ooooo_oooooooooooooo_ooo
oooooooooo_ooooooooooooo_oo_oo_oooooooooooo_oooooooooooo_oooooooooooo_oooo__oooooooooooooo_ooooooo_oooooooooo_oooooooooooo_ooooooooooooo_ooooooooooooo_oooooooooooo_ooooooooooooo_oooo__
ooooo_ooooooooooooooooo]                                                                                                                                                                
2026-05-18 21:26:13.418 D [207.180.199.254:28080 OUT]  next span in the queue has blocks 949909-949936, we need 949944                                                                  
2026-05-18 21:26:13.418 D block <412ca45a5ce3280cd7727155836e3921671e22769930816d2b3b82370bef5e02> found in main chain                                                                  
2026-05-18 21:26:13.418 D [207.180.199.254:28080 OUT] These are old blocks, ignoring: blocks 949909 - 949936, blockchain height 949944                                                  
2026-05-18 21:26:13.418 D Erasing span starting from block 949909                                                                                                                       
2026-05-18 21:26:13.419 D [207.180.199.254:28080 OUT]  next span in the queue has blocks 949937-949964, we need 949944                                                                  
2026-05-18 21:26:13.419 D block <412ca45a5ce3280cd7727155836e3921671e22769930816d2b3b82370bef5e02> found in main chain                                                                  

...

2026-05-18 21:26:13.419 D block_batches: 0
2026-05-18 21:26:13.419 D block <3bef5243349b473ba95dbdecedabb8c8de7b958f1627c01328a5158301ff92b1> found in main chain
2026-05-18 21:26:13.419 D Skipping remainder of prepare blocks. Blocks exist.
2026-05-18 21:26:13.419 D block <3bef5243349b473ba95dbdecedabb8c8de7b958f1627c01328a5158301ff92b1> found in main chain
2026-05-18 21:26:13.419 E wrong miner tx in block: <fb877ea3400f731c2b948e87655368f1c0486e3c114bb3f8f3839bec1b2f9596>, b.miner_tx.vin.size() != 1
2026-05-18 21:26:13.419 E Block with id: fb877ea3400f731c2b948e87655368f1c0486e3c114bb3f8f3839bec1b2f9596 (as alternative), but miner tx says height is 0.
2026-05-18 21:26:13.419 W dropping connections to 127.0.0.1:28780
2026-05-18 21:26:13.419 D Host 127.0.0.1 fail score=10
```

note the issue also causes bans, so might help there as well