### PR TITLE
cmake: silence rapidjson warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,7 +459,8 @@ elseif(CMAKE_SYSTEM_NAME MATCHES ".*BSDI.*")
   set(BSDI TRUE)
 endif()
 
-include_directories(external/rapidjson/include external/easylogging++ src contrib/epee/include external external/supercop/include)
+include_directories(SYSTEM external/rapidjson/include)
+include_directories(external/easylogging++ src contrib/epee/include external external/supercop/include)
 
 option(STATIC "Link libraries statically" OFF)
 


### PR DESCRIPTION
Silences some RapidJSON warnings. These show up when using `clang++` 22.1.8 on Linux (x86_64).

```
warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
```