### PR TITLE
cryptonote_protocol: prevent overlapping block sync spans

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4972,14 +4972,14 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
             return true;
           }
         }
-        if (have_block(block_hash))
+        if (!blocks_exist && have_block(block_hash))
           blocks_exist = true;
 
         std::advance(it, 1);
       }
     }
 
-    for (unsigned i = 0; i < extra && !blocks_exist; i++, blockidx++)
+    for (unsigned i = 0; i < extra; i++, blockidx++)
     {
       block &block = blocks[blockidx];
       crypto::hash block_hash;
@@ -4987,7 +4987,7 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
       if (!parse_and_validate_block_from_blob(it->block, block, block_hash))
         return false;
 
-      if (have_block(block_hash))
+      if (!blocks_exist && have_block(block_hash))
         blocks_exist = true;
 
       std::advance(it, 1);

--- a/src/cryptonote_protocol/block_queue.cpp
+++ b/src/cryptonote_protocol/block_queue.cpp
@@ -297,7 +297,8 @@ std::pair<uint64_t, uint64_t> block_queue::reserve_span(uint64_t first_block_hei
   uint64_t span_length = 0;
   std::vector<crypto::hash> hashes;
   bool first_is_pruned = sync_pruned_blocks && !tools::has_unpruned_block(span_start_height + span_length, blockchain_height, local_pruning_seed);
-  while (i != block_hashes.end() && span_length < max_blocks && (sync_pruned_blocks || tools::has_unpruned_block(span_start_height + span_length, blockchain_height, pruning_seed)))
+  while (i != block_hashes.end() && span_length < max_blocks && !requested_internal((*i).first) &&
+      (sync_pruned_blocks || tools::has_unpruned_block(span_start_height + span_length, blockchain_height, pruning_seed)))
   {
     // if we want to sync pruned blocks, stop at the first block for which we need full data
     if (sync_pruned_blocks && first_is_pruned == tools::has_unpruned_block(span_start_height + span_length, blockchain_height, local_pruning_seed))

--- a/tests/unit_tests/block_queue.cpp
+++ b/tests/unit_tests/block_queue.cpp
@@ -87,3 +87,23 @@ TEST(block_queue, flush_uuid)
   bq.add_blocks(0, 200, uuid1(), na);
   ASSERT_EQ(bq.get_max_block_height(), 399);
 }
+
+TEST(block_queue, reserve_does_not_overlap_later_span)
+{
+  cryptonote::block_queue bq;
+  epee::net_utils::network_address na;
+  std::vector<std::pair<crypto::hash, uint64_t>> hashes;
+  hashes.reserve(100);
+  for (size_t i = 0; i < 100; ++i)
+    hashes.emplace_back(crypto::rand<crypto::hash>(), 0);
+
+  ASSERT_EQ(bq.reserve_span(1, 100, 28, uuid1(), na, false, 0, 0, 101, hashes), std::make_pair(uint64_t{1}, uint64_t{28}));
+  ASSERT_EQ(bq.reserve_span(1, 100, 28, uuid1(), na, false, 0, 0, 101, hashes), std::make_pair(uint64_t{29}, uint64_t{28}));
+  ASSERT_EQ(bq.reserve_span(1, 100, 28, uuid1(), na, false, 0, 0, 101, hashes), std::make_pair(uint64_t{57}, uint64_t{28}));
+
+  ASSERT_TRUE(bq.remove_span(29));
+
+  // A recalculated, larger sync size must fill only the gap, without
+  // overlapping the span which is already reserved at height 57.
+  ASSERT_EQ(bq.reserve_span(1, 100, 36, uuid2(), na, false, 0, 0, 101, hashes), std::make_pair(uint64_t{29}, uint64_t{28}));
+}


### PR DESCRIPTION
Prevents block sync spans from overlapping existing reservations and ensures every block in an incoming batch is parsed. This avoids sync stalls, invalid block processing, and erroneous peer bans when a batch contains already known blocks.

Alternative to https://github.com/monero-project/monero/pull/10999.

Resolves https://github.com/monero-project/monero/issues/6419.