### PR TITLE
cryptonote_protocol: limit the block sync queue dynamically

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4874,6 +4874,14 @@ bool Blockchain::has_block_weights(uint64_t height, uint64_t nblocks) const
   return true;
 }
 
+uint64_t Blockchain::get_prevalidated_block_weight(uint64_t height) const
+{
+  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  if (height >= m_blocks_hash_check.size())
+    return 0;
+  return m_blocks_hash_check[height].second;
+}
+
 //------------------------------------------------------------------
 // ND: Speedups:
 // 1. Thread long_hash computations if possible (m_max_prepare_blocks_threads = nthreads, default = 4)

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1151,6 +1151,12 @@ namespace cryptonote
     bool has_block_weights(uint64_t height, uint64_t nblocks) const;
 
     /**
+     * @brief returns the prevalidated block weight
+     * @return the prevalidated weight, or zero if unavailable
+     */
+    uint64_t get_prevalidated_block_weight(uint64_t height) const;
+
+    /**
      * @brief flush the invalid blocks set
      */
     void flush_invalid_blocks();

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -124,9 +124,9 @@ namespace cryptonote
   , "Set maximum size of block download queue in bytes (0 for default)"
   , 0
   };
-  const command_line::arg_descriptor<size_t> arg_span_limit  = {
-    "span-limit"
-  , "Defines how many minutes of block synchronization data to request at a time (default is 2 minutes)"
+  const command_line::arg_descriptor<size_t> arg_block_sync_queue_time  = {
+    "block-sync-queue-time"
+  , "Target duration of block synchronization data to keep queued, in minutes (default is 2 minutes)"
   , 2
   };
   const command_line::arg_descriptor<bool> arg_sync_pruned_blocks  = {
@@ -326,7 +326,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg_offline);
     command_line::add_arg(desc, arg_disable_dns_checkpoints);
     command_line::add_arg(desc, arg_block_download_max_size);
-    command_line::add_arg(desc, arg_span_limit);
+    command_line::add_arg(desc, arg_block_sync_queue_time);
     command_line::add_arg(desc, arg_sync_pruned_blocks);
     command_line::add_arg(desc, arg_max_txpool_weight);
     command_line::add_arg(desc, arg_block_notify);

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -951,7 +951,8 @@ namespace cryptonote
              << " bytes and the max average blocksize in the queue is " << max_average_of_blocksize_in_queue << " bytes");
       uint64_t projected_blocksize = std::max(max_average_of_blocksize_in_queue, max_weight);
       uint64_t blocks_huge_threshold = (batch_max_weight / 2);
-      if ((projected_blocksize * BLOCKS_MAX_WINDOW) < batch_max_weight)
+      // batch_max_weight is positive; compare without overflowing the projected batch weight.
+      if (projected_blocksize <= (batch_max_weight - 1) / BLOCKS_MAX_WINDOW)
       {
         res = BLOCKS_MAX_WINDOW;
         MINFO("blocks are tiny, " << projected_blocksize << " bytes, sync " << res << " blocks in next batch");
@@ -1928,6 +1929,11 @@ namespace cryptonote
   bool core::has_block_weights(uint64_t height, uint64_t nblocks) const
   {
     return get_blockchain_storage().has_block_weights(height, nblocks);
+  }
+  //-----------------------------------------------------------------------------------------------
+  uint64_t core::get_prevalidated_block_weight(uint64_t height) const
+  {
+    return get_blockchain_storage().get_prevalidated_block_weight(height);
   }
   //-----------------------------------------------------------------------------------------------
   std::time_t core::get_start_time() const

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -69,7 +69,7 @@ namespace cryptonote
   extern const command_line::arg_descriptor<difficulty_type> arg_fixed_difficulty;
   extern const command_line::arg_descriptor<bool> arg_offline;
   extern const command_line::arg_descriptor<size_t> arg_block_download_max_size;
-  extern const command_line::arg_descriptor<size_t> arg_span_limit;
+  extern const command_line::arg_descriptor<size_t> arg_block_sync_queue_time;
   extern const command_line::arg_descriptor<bool> arg_sync_pruned_blocks;
 
   /************************************************************************/

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -783,6 +783,7 @@ namespace cryptonote
       * @return the number of blocks to sync in one go
       */
      size_t get_block_sync_size(uint64_t height, const uint64_t max_average_of_blocksize_in_queue = 0) const;
+     bool is_block_sync_size_adaptive() const { return block_sync_size == 0; }
 
      /**
       * @brief get the sum of coinbase tx amounts between blocks

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -783,6 +783,7 @@ namespace cryptonote
       * @return the number of blocks to sync in one go
       */
      size_t get_block_sync_size(uint64_t height, const uint64_t max_average_of_blocksize_in_queue = 0) const;
+     bool is_block_sync_size_adaptive() const { return block_sync_size == 0; }
 
      /**
       * @brief get the sum of coinbase tx amounts between blocks
@@ -870,6 +871,12 @@ namespace cryptonote
       * @brief checks whether block weights are known for the given range
       */
      bool has_block_weights(uint64_t height, uint64_t nblocks) const;
+
+     /**
+      * @brief returns the prevalidated block weight
+      * @return the prevalidated weight, or zero if unavailable
+      */
+     uint64_t get_prevalidated_block_weight(uint64_t height) const;
 
      /**
       * @brief flushes the invalid block cache

--- a/src/cryptonote_protocol/block_queue.cpp
+++ b/src/cryptonote_protocol/block_queue.cpp
@@ -434,6 +434,18 @@ size_t block_queue::get_num_filled_spans() const
   return size;
 }
 
+uint64_t block_queue::get_num_filled_blocks() const
+{
+  boost::unique_lock<boost::recursive_mutex> lock(mutex);
+  uint64_t size = 0;
+  for (const auto &span: blocks)
+  {
+    if (!span.blocks.empty())
+      size += span.nblocks;
+  }
+  return size;
+}
+
 float block_queue::get_speed(const boost::uuids::uuid &connection_id) const
 {
   boost::unique_lock<boost::recursive_mutex> lock(mutex);

--- a/src/cryptonote_protocol/block_queue.cpp
+++ b/src/cryptonote_protocol/block_queue.cpp
@@ -446,6 +446,33 @@ uint64_t block_queue::get_num_filled_blocks() const
   return size;
 }
 
+uint64_t block_queue::get_max_block_size_average() const
+{
+  boost::unique_lock<boost::recursive_mutex> lock(mutex);
+  uint64_t max_average = 0;
+  for (const auto &span: blocks)
+  {
+    if (span.blocks.empty())
+      continue;
+
+    uint64_t span_size = 0;
+    for (const block_complete_entry &entry: span.blocks)
+    {
+      uint64_t block_size = entry.block.size();
+      for (const tx_blob_entry &tx: entry.txs)
+      {
+        const uint64_t tx_size = tx.blob.size();
+        block_size += std::min(tx_size, std::numeric_limits<uint64_t>::max() - block_size);
+      }
+      if (entry.pruned)
+        block_size = std::max(block_size, entry.block_weight);
+      span_size += std::min(block_size, std::numeric_limits<uint64_t>::max() - span_size);
+    }
+    max_average = std::max(max_average, span_size / span.nblocks);
+  }
+  return max_average;
+}
+
 float block_queue::get_speed(const boost::uuids::uuid &connection_id) const
 {
   boost::unique_lock<boost::recursive_mutex> lock(mutex);

--- a/src/cryptonote_protocol/block_queue.h
+++ b/src/cryptonote_protocol/block_queue.h
@@ -89,6 +89,7 @@ namespace cryptonote
     bool has_next_span(uint64_t height, bool &filled, boost::posix_time::ptime &time, boost::uuids::uuid &connection_id) const;
     size_t get_data_size() const;
     size_t get_num_filled_spans() const;
+    uint64_t get_num_filled_blocks() const;
     float get_speed(const boost::uuids::uuid &connection_id) const;
     bool foreach(std::function<bool(const span&)> f) const;
     bool requested(const crypto::hash &hash) const;

--- a/src/cryptonote_protocol/block_queue.h
+++ b/src/cryptonote_protocol/block_queue.h
@@ -90,6 +90,7 @@ namespace cryptonote
     size_t get_data_size() const;
     size_t get_num_filled_spans() const;
     uint64_t get_num_filled_blocks() const;
+    uint64_t get_max_block_size_average() const;
     float get_speed(const boost::uuids::uuid &connection_id) const;
     bool foreach(std::function<bool(const span&)> f) const;
     bool requested(const crypto::hash &hash) const;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -114,14 +114,9 @@ namespace cryptonote
     const block_queue &get_block_queue() const { return m_block_queue; }
     std::uint64_t max_average_of_blocksize_in_queue()
     {
-      std::vector<std::uint64_t> average_blocksize{0};
-      m_block_queue.foreach([&](const cryptonote::block_queue::span &span)
-      {
-        average_blocksize.push_back(span.size / span.nblocks);
-        return true; // we don't care about the return value
-      });
-      MINFO("Maximum average of blocksize for current batches : " << *std::max_element(average_blocksize.begin(), average_blocksize.end()));
-      return *std::max_element(average_blocksize.begin(), average_blocksize.end());
+      const uint64_t max_average = m_block_queue.get_max_block_size_average();
+      MINFO("Maximum average of blocksize for current batches : " << max_average);
+      return max_average;
     }
     void stop();
     void on_connection_close(cryptonote_connection_context &context);

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -178,7 +178,7 @@ namespace cryptonote
     size_t skip_unneeded_hashes(cryptonote_connection_context& context, bool check_block_queue) const;
     bool request_txpool_complement(cryptonote_connection_context &context);
     void hit_score(cryptonote_connection_context &context, int32_t score);
-    void calculate_dynamic_span(const double blocks_per_seconds);
+    void calculate_block_queue_limit(double blocks_per_second);
 
     t_core& m_core;
 
@@ -203,9 +203,8 @@ namespace cryptonote
     uint64_t m_sync_download_chain_size, m_sync_download_objects_size;
     size_t m_block_download_max_size;
     bool m_sync_pruned_blocks;
-    size_t m_span_time;
-    std::atomic<size_t> m_span_limit;
-    std::atomic<size_t> m_bss;
+    size_t m_block_sync_queue_time;
+    std::atomic<uint64_t> m_block_queue_limit;
 
     // Values for sync time estimates
     boost::posix_time::ptime m_sync_start_time;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -2174,7 +2174,8 @@ skip:
       NOTIFY_REQUEST_GET_OBJECTS::request req;
       bool is_next = false;
       size_t count = 0;
-      const size_t l_m_bss = m_core.get_block_sync_size(m_core.get_current_blockchain_height(), max_average_of_blocksize_in_queue());
+      const uint64_t max_average = m_core.is_block_sync_size_adaptive() ? max_average_of_blocksize_in_queue() : 0;
+      const size_t l_m_bss = m_core.get_block_sync_size(m_core.get_current_blockchain_height(), max_average);
       std::pair<uint64_t, uint64_t> span = std::make_pair(0, 0);
       if (force_next_span)
       {

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -38,7 +38,9 @@
 #include <boost/optional/optional.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
+#include <cmath>
 #include <list>
+#include <limits>
 #include <ctime>
 
 #include <cryptonote_core/cryptonote_core.h>
@@ -187,9 +189,8 @@ namespace cryptonote
                                                                                                               m_ask_for_txpool_complement(true),
                                                                                                               m_stopping(false),
                                                                                                               m_no_sync(false),
-                                                                                                              m_span_limit(BLOCK_QUEUE_NSPANS_MINIMUM),
-                                                                                                              m_span_time(0),
-                                                                                                              m_bss(0)
+                                                                                                              m_block_sync_queue_time(0),
+                                                                                                              m_block_queue_limit(0)
 
   {
     if(!m_p2p)
@@ -212,22 +213,28 @@ namespace cryptonote
 
     m_block_download_max_size = command_line::get_arg(vm, cryptonote::arg_block_download_max_size);
     m_sync_pruned_blocks = command_line::get_arg(vm, cryptonote::arg_sync_pruned_blocks);
-    m_span_time = command_line::get_arg(vm, cryptonote::arg_span_limit);
+    m_block_sync_queue_time = command_line::get_arg(vm, cryptonote::arg_block_sync_queue_time);
 
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------
   template<class t_core>
-  void t_cryptonote_protocol_handler<t_core>::calculate_dynamic_span(const double blocks_per_seconds)
+  void t_cryptonote_protocol_handler<t_core>::calculate_block_queue_limit(double blocks_per_second)
   {
-    size_t current_bss = m_bss.load();
-    size_t current_span_limit = m_span_limit.load();
-    MINFO("m_bss : " << current_bss << ", blocks_per_seconds : " << blocks_per_seconds << ", current_span_limit : " << current_span_limit);
-    current_span_limit = (current_bss && blocks_per_seconds) ? (( blocks_per_seconds * 60 * m_span_time ) / current_bss) : BLOCK_QUEUE_NSPANS_MINIMUM;
-    if (current_span_limit < BLOCK_QUEUE_NSPANS_MINIMUM)
-      current_span_limit = BLOCK_QUEUE_NSPANS_MINIMUM;
-    m_span_limit = current_span_limit;
-    MINFO("calculated dynamic span limit is span_limit : " << m_span_limit);
+    if (!(blocks_per_second > 0.0) || !std::isfinite(blocks_per_second))
+    {
+      MWARNING("Not updating block queue limit from invalid sync rate " << blocks_per_second);
+      return;
+    }
+
+    const long double requested_blocks = static_cast<long double>(blocks_per_second) * 60 * m_block_sync_queue_time;
+    const long double max_block_queue_limit = static_cast<long double>(std::numeric_limits<uint64_t>::max());
+    const uint64_t block_queue_limit = requested_blocks >= max_block_queue_limit
+      ? std::numeric_limits<uint64_t>::max()
+      : static_cast<uint64_t>(requested_blocks);
+    m_block_queue_limit = block_queue_limit;
+    MINFO("Calculated dynamic block queue limit: " << block_queue_limit << " blocks at "
+        << blocks_per_second << " blocks per second");
   }
   //------------------------------------------------------------------------------------------------------------------------
   template<class t_core>
@@ -1590,8 +1597,11 @@ namespace cryptonote
           {
             const uint64_t target_blockchain_height = m_core.get_target_blockchain_height();
             const boost::posix_time::time_duration dt = boost::posix_time::microsec_clock::universal_time() - start;
-            const double blocks_per_seconds = (((current_blockchain_height - previous_height) * 1e6) / dt.total_microseconds());
-            calculate_dynamic_span(blocks_per_seconds);
+            const int64_t elapsed_us = dt.total_microseconds();
+            const double blocks_per_seconds = elapsed_us > 0
+              ? ((current_blockchain_height - previous_height) * 1e6) / elapsed_us
+              : 0.0;
+            calculate_block_queue_limit(blocks_per_seconds);
             std::string progress_message = "";
             if (current_blockchain_height < target_blockchain_height)
             {
@@ -2026,6 +2036,7 @@ skip:
       do
       {
         const size_t nspans = m_block_queue.get_num_filled_spans();
+        const uint64_t nblocks = m_block_queue.get_num_filled_blocks();
         const size_t size = m_block_queue.get_data_size();
         const uint64_t bc_height = m_core.get_current_blockchain_height();
         const auto next_needed_pruning_stripe = get_next_needed_pruning_stripe();
@@ -2033,7 +2044,8 @@ skip:
         const uint32_t peer_stripe = tools::get_pruning_stripe(context.m_pruning_seed);
         const uint32_t local_stripe = tools::get_pruning_stripe(m_core.get_blockchain_pruning_seed());
         const size_t block_queue_size_threshold = m_block_download_max_size ? m_block_download_max_size : BLOCK_QUEUE_SIZE_THRESHOLD;
-        const bool queue_proceed_init = (nspans < m_span_limit.load()) && (size < block_queue_size_threshold);
+        const bool queue_proceed_init = (nspans < BLOCK_QUEUE_NSPANS_MINIMUM || nblocks < m_block_queue_limit.load()) &&
+            size < block_queue_size_threshold;
         // get rid of blocks we already requested, or already have
         if (skip_unneeded_hashes(context, true) && context.m_needed_objects.empty() && context.m_num_requested == 0)
         {
@@ -2078,7 +2090,8 @@ skip:
                << ", stripe_proceed_secondary : " << stripe_proceed_secondary
                << ", next_height_proceed : " << next_height_proceed
                << ", next_block_height/next_needed_height/bc_height : " << next_block_height << "/" << next_needed_height << "/" << bc_height
-               << ", nspans/span_limit : " << nspans << "/" << m_span_limit
+               << ", nspans/minimum : " << nspans << "/" << BLOCK_QUEUE_NSPANS_MINIMUM
+               << ", nblocks/block_queue_limit : " << nblocks << "/" << m_block_queue_limit
                << ", queue size/size_limit : " << size << "/" << block_queue_size_threshold);
 
         // if we're waiting for next span, try to get it before unblocking threads below,
@@ -2161,7 +2174,7 @@ skip:
       NOTIFY_REQUEST_GET_OBJECTS::request req;
       bool is_next = false;
       size_t count = 0;
-      size_t l_m_bss = m_bss = m_core.get_block_sync_size(m_core.get_current_blockchain_height(), max_average_of_blocksize_in_queue());
+      const size_t l_m_bss = m_core.get_block_sync_size(m_core.get_current_blockchain_height(), max_average_of_blocksize_in_queue());
       std::pair<uint64_t, uint64_t> span = std::make_pair(0, 0);
       if (force_next_span)
       {

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1265,12 +1265,16 @@ namespace cryptonote
     }
     else
     {
-      // we accept pruned data, check that if we got some, then no weights are zero
-      for (block_complete_entry& block_entry: arg.blocks)
+      // Weights used for adaptive sync sizing must match the prevalidated chain data.
+      for (size_t i = 0; i < arg.blocks.size(); ++i)
       {
-        if (block_entry.block_weight == 0 && block_entry.pruned)
+        const block_complete_entry &block_entry = arg.blocks[i];
+        if (!block_entry.pruned)
+          continue;
+        const uint64_t expected_weight = m_core.get_prevalidated_block_weight(start_height + i);
+        if (expected_weight == 0 || block_entry.block_weight != expected_weight)
         {
-          MERROR(context << "returned at least one pruned block with 0 weight, dropping connection");
+          MERROR(context << "returned an incorrect weight for pruned block at height " << start_height + i << ", dropping connection");
           drop_connection(context, false, false);
           ++m_sync_bad_spans_downloaded;
           return 1;
@@ -2174,7 +2178,8 @@ skip:
       NOTIFY_REQUEST_GET_OBJECTS::request req;
       bool is_next = false;
       size_t count = 0;
-      const size_t l_m_bss = m_core.get_block_sync_size(m_core.get_current_blockchain_height(), max_average_of_blocksize_in_queue());
+      const uint64_t max_average = m_core.is_block_sync_size_adaptive() ? max_average_of_blocksize_in_queue() : 0;
+      const size_t l_m_bss = m_core.get_block_sync_size(m_core.get_current_blockchain_height(), max_average);
       std::pair<uint64_t, uint64_t> span = std::make_pair(0, 0);
       if (force_next_span)
       {

--- a/tests/unit_tests/block_queue.cpp
+++ b/tests/unit_tests/block_queue.cpp
@@ -100,3 +100,19 @@ TEST(block_queue, count_filled_blocks)
   ASSERT_EQ(bq.get_num_filled_spans(), 2);
   ASSERT_EQ(bq.get_num_filled_blocks(), 7);
 }
+
+TEST(block_queue, pruned_weight_in_block_size_average)
+{
+  cryptonote::block_queue bq;
+  epee::net_utils::network_address na;
+  std::vector<cryptonote::block_complete_entry> blocks(2);
+  blocks[0].block.resize(100);
+  blocks[0].txs.emplace_back(cryptonote::blobdata(50, '\0'));
+  blocks[1].pruned = true;
+  blocks[1].block.resize(10);
+  blocks[1].block_weight = 1000;
+
+  bq.add_blocks(0, std::move(blocks), uuid1(), na, 0.0f, 160);
+
+  ASSERT_EQ(bq.get_max_block_size_average(), 575);
+}

--- a/tests/unit_tests/block_queue.cpp
+++ b/tests/unit_tests/block_queue.cpp
@@ -87,3 +87,16 @@ TEST(block_queue, flush_uuid)
   bq.add_blocks(0, 200, uuid1(), na);
   ASSERT_EQ(bq.get_max_block_height(), 399);
 }
+
+TEST(block_queue, count_filled_blocks)
+{
+  cryptonote::block_queue bq;
+  epee::net_utils::network_address na;
+
+  bq.add_blocks(0, std::vector<cryptonote::block_complete_entry>(3), uuid1(), na, 0.0f, 0);
+  bq.add_blocks(3, 2, uuid2(), na);
+  bq.add_blocks(5, std::vector<cryptonote::block_complete_entry>(4), uuid2(), na, 0.0f, 0);
+
+  ASSERT_EQ(bq.get_num_filled_spans(), 2);
+  ASSERT_EQ(bq.get_num_filled_blocks(), 7);
+}

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -92,6 +92,7 @@ public:
   bool update_checkpoints(const bool skip_dns = false) { return true; }
   uint64_t get_target_blockchain_height() const { return 1; }
   size_t get_block_sync_size(uint64_t height, const uint64_t max_average_of_blocksize_in_queue = 0) const { return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT; }
+  bool is_block_sync_size_adaptive() const { return false; }
   virtual void on_transactions_relayed(epee::span<const cryptonote::blobdata> tx_blobs, cryptonote::relay_method tx_relay) {}
   cryptonote::network_type get_nettype() const { return cryptonote::MAINNET; }
   bool get_pool_transaction(const crypto::hash& id, cryptonote::blobdata& tx_blob, cryptonote::relay_category tx_category) const { return false; }

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -92,6 +92,7 @@ public:
   bool update_checkpoints(const bool skip_dns = false) { return true; }
   uint64_t get_target_blockchain_height() const { return 1; }
   size_t get_block_sync_size(uint64_t height, const uint64_t max_average_of_blocksize_in_queue = 0) const { return BLOCKS_SYNCHRONIZING_DEFAULT_COUNT; }
+  bool is_block_sync_size_adaptive() const { return false; }
   virtual void on_transactions_relayed(epee::span<const cryptonote::blobdata> tx_blobs, cryptonote::relay_method tx_relay) {}
   cryptonote::network_type get_nettype() const { return cryptonote::MAINNET; }
   bool get_pool_transaction(const crypto::hash& id, cryptonote::blobdata& tx_blob, cryptonote::relay_category tx_category) const { return false; }
@@ -111,6 +112,7 @@ public:
   bool prune_blockchain(uint32_t pruning_seed = 0) { return true; }
   bool is_within_compiled_block_hash_area(uint64_t height) const { return false; }
   bool has_block_weights(uint64_t height, uint64_t nblocks) const { return false; }
+  uint64_t get_prevalidated_block_weight(uint64_t height) const { return 0; }
   bool get_txpool_complement(const std::vector<crypto::hash> &hashes, std::vector<cryptonote::blobdata> &txes) { return false; }
   bool get_pool_transaction_hashes(std::vector<crypto::hash>& txs, bool include_unrelayed_txes = true) const { return false; }
   crypto::hash get_block_id_by_height(uint64_t height) const { return crypto::null_hash; }


### PR DESCRIPTION
#9495 introduced a dynamic limit on the number of queued spans, but a span is not a fixed unit of work. Span sizes can differ when the block sync size changes, or when a request stops before an existing reservation, so counting spans can misrepresent how many blocks are actually queued. This replaces the span count limit with a queued block count derived from the observed block processing rate and the target set by `--block-sync-queue-time`.

The per span sync size calculation now also accounts for the full weight of pruned blocks. This prevents their smaller transmitted representation from underestimating average block size and causing subsequent spans to request too many blocks.

Should be merged after #11006.