### PR TITLE
unit_tests: avoid nonexistent TLD in DNSSEC test

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -357,11 +357,6 @@ DNSResolver DNSResolver::create()
   return DNSResolver();
 }
 
-void DNSResolver::set_debug_level(int level)
-{
-  ub_ctx_debuglevel(m_data->m_ub_context, level);
-}
-
 namespace dns_utils
 {
 

--- a/src/common/dns_utils.h
+++ b/src/common/dns_utils.h
@@ -144,8 +144,6 @@ public:
    */
   static DNSResolver create();
 
-  void set_debug_level(int level);
-
 private:
 
   /**

--- a/tests/unit_tests/address_from_url.cpp
+++ b/tests/unit_tests/address_from_url.cpp
@@ -109,9 +109,7 @@ TEST(AddressFromURL, Failure)
 {
   bool dnssec_result = false;
 
-  tools::DNSResolver::instance().set_debug_level(4);
   std::vector<std::string> addresses = tools::dns_utils::addresses_from_url("example.veryinvalid", dnssec_result);
-  tools::DNSResolver::instance().set_debug_level(0);
 
   // for a non-existing domain such as "example.invalid", the non-existence is proved with NSEC records
   ASSERT_TRUE(dnssec_result);

--- a/tests/unit_tests/address_from_url.cpp
+++ b/tests/unit_tests/address_from_url.cpp
@@ -109,9 +109,9 @@ TEST(AddressFromURL, Failure)
 {
   bool dnssec_result = false;
 
-  std::vector<std::string> addresses = tools::dns_utils::addresses_from_url("example.veryinvalid", dnssec_result);
+  std::vector<std::string> addresses = tools::dns_utils::addresses_from_url("nonexistent.getmonero.org", dnssec_result);
 
-  // for a non-existing domain such as "example.invalid", the non-existence is proved with NSEC records
+  // The absence of a TXT record is authenticated with DNSSEC denial records.
   ASSERT_TRUE(dnssec_result);
 
   ASSERT_EQ(0, addresses.size());


### PR DESCRIPTION
Context: https://github.com/NLnetLabs/unbound/issues/1483