### PR TITLE
wallet2: clamp export_outputs start to the number of transfers

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -14014,7 +14014,7 @@ std::tuple<uint64_t, uint64_t, std::vector<tools::wallet2::exported_transfer_det
     while (offset < m_transfers.size() && (m_transfers[offset].m_key_image_known && !m_transfers[offset].m_key_image_request))
       ++offset;
   else
-    offset = start;
+    offset = std::min<size_t>(start, m_transfers.size());
 
   outs.reserve(m_transfers.size() - offset);
   for (size_t n = offset; n < m_transfers.size() && n - offset < count; ++n)


### PR DESCRIPTION
Fixes #8625.

`export_outputs()` already documents what should happen when the pagination
params run off the end:

```cpp
// for convenience, start/count are allowed to go past the valid range, then nothing is returned
```

The loop honours that. `offset` doesn't — with `all=true` it takes `start`
unchecked, so `m_transfers.size() - offset` underflows and `reserve()` gets a
value near `SIZE_MAX`. `vector::reserve` throws `std::length_error` on that.

That's where the error in #8625 comes from. The reporter's curl gets back:

```json
{"error": {"code": -1, "message": "vector::reserve"}, "id": "0", "jsonrpc": "2.0"}
```

`"vector::reserve"` is libstdc++'s own text for that throw, which points at this
line specifically.

I clamped `offset` instead of only guarding the `reserve`, because the returned
offset goes out in the exported blob and `import_outputs` throws `"Offset is
larger than total outputs"` when it's past the total. Guarding just the reserve
would move the failure from export to import.

`git log -L` on the line: the `reserve` dates to 8d71b2b1b371, back when
`offset` could only come from the `!all` scan and was always <= size. The commit
that added `start`/`count` added the loop bound but didn't revisit it.

### Checked locally

Built at ae3931c1d, gcc 16.1.1, boost 1.91. Throwaway test against an empty
wallet, where any non-zero `start` is past the end:

```cpp
tools::wallet2 w;
auto outputs = w.export_outputs(true /*all*/, 1 /*start*/, 1 /*count*/);
```

Before:

```
Expected: outputs = w.export_outputs(true , 1 , 1 ) doesn't throw an exception.
  Actual: it throws std::length_error with description "vector::reserve".
```

After: returns `(0, 0, {})` and doesn't throw. Full unit suite is 1273 passed,
2 skipped, 0 failed.

I kept this to the one line rather than shipping the test, since there's no
wallet2 export test to append to and a new file felt heavy for a one-liner. Say
the word if you'd rather have the regression covered.

One open question: both commenters on #8625 leaned toward returning a validation
error rather than silently clamping. I went with the clamp because the comment
above the code already calls "nothing is returned" the intended behaviour, but
I'm happy to make it throw instead if you'd prefer that.
