### PR TITLE
simplewallet: use the swept account for index=all in sweep_main

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6849,7 +6849,7 @@ bool simple_wallet::sweep_main(uint32_t account, uint64_t below, const std::vect
   {
     if (local_args[0] == "index=all")
     {
-      for (uint32_t i = 0; i < m_wallet->get_num_subaddresses(m_current_subaddress_account); ++i)
+      for (uint32_t i = 0; i < m_wallet->get_num_subaddresses(account); ++i)
         subaddr_indices.insert(i);
     }
     else if (!parse_subaddress_indices(local_args[0], subaddr_indices))


### PR DESCRIPTION
`sweep_main()` takes the account to sweep as a parameter, but the `index=all`
expansion counts subaddresses on `m_current_subaddress_account`:

```cpp
if (local_args[0] == "index=all")
{
  for (uint32_t i = 0; i < m_wallet->get_num_subaddresses(m_current_subaddress_account); ++i)
    subaddr_indices.insert(i);
}
```

`sweep_all` and `sweep_below` pass the current account, so `sweep_account` is
the one command that can end up with a set built from the wrong account.

When the current account has fewer subaddresses than the one being swept, the
set comes out too small and outputs in the higher minor indices never make it
into the sweep. If none of the target's unlocked outputs land in that range,
`create_transactions_all` throws `"No unlocked balance in the specified
subaddress(es)"` for an account that visibly has a balance.

27d551d12f8d is where it came in. That commit added the `account` parameter and
switched `create_transactions_all` over to it, but left this loop on the old
field:

```
-    bool sweep_main(uint64_t below, bool locked, const std::vector<std::string> &args);
+    bool sweep_main(uint32_t account, uint64_t below, bool locked, const std::vector<std::string> &args);
```

The RPC already does it the right way — `wallet_rpc_server.cpp` uses
`get_num_subaddresses(req.account_index)` for `subaddr_indices_all`. So this is
the CLI drifting from the RPC rather than a question about intended semantics.

### Checked locally

Built at ae3931c1d, gcc 16.1.1, boost 1.91 — `monero-wallet-cli` links clean.

No test: `simplewallet` isn't linked into `tests/unit_tests`, and
`tests/functional_tests` drives the wallet RPC rather than the CLI, so there's
nowhere for this to live. I'd rather say that than imply coverage I didn't add.

Worth knowing: #10233 rewrites this line as part of the Wallet API port, and
carries the same bug over as `numSubaddresses(m_current_subaddress_account)`.
Fixing it here means that port picks up the correct version.
