### PR TITLE
device: implement default device locking

### DIFF
--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -30,6 +30,7 @@
 
 
 
+#include <boost/thread/lock_guard.hpp>
 #include "device_default.hpp"
 #include "int-util.h"
 #include "crypto/wallet/crypto.h"
@@ -82,19 +83,32 @@ namespace hw {
             return true;
         }
 
+        // serialize mode access so callers cannot observe another wallet's transient signing mode
         bool  device_default::set_mode(device_mode mode) {
+            boost::lock_guard<boost::recursive_mutex> lock(device_locker);
             return device::set_mode(mode);
+        }
+
+        device::device_mode device_default::get_mode() const {
+            boost::lock_guard<boost::recursive_mutex> lock(device_locker);
+            return device::get_mode();
         }
 
         /* ======================================================================= */
         /*  LOCKER                                                                 */
         /* ======================================================================= */ 
     
-        void device_default::lock() { }
+        void device_default::lock() {
+            device_locker.lock();
+        }
 
-        bool device_default::try_lock() { return true; }
+        bool device_default::try_lock() {
+            return device_locker.try_lock();
+        }
 
-        void device_default::unlock() { }
+        void device_default::unlock() {
+            device_locker.unlock();
+        }
 
         /* ======================================================================= */
         /*                             WALLET & ADDRESS                            */

--- a/src/device/device_default.hpp
+++ b/src/device/device_default.hpp
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <boost/thread/recursive_mutex.hpp>
 #include "device.hpp"
 
 namespace hw {
@@ -60,6 +61,7 @@ namespace hw {
             bool disconnect() override;
  
             bool set_mode(device_mode mode) override;
+            device_mode get_mode() const override;
 
             device_type get_type() const override {return device_type::SOFTWARE;};
 
@@ -141,6 +143,10 @@ namespace hw {
             bool clsag_sign(const rct::key &c, const rct::key &a, const rct::key &p, const rct::key &z, const rct::key &mu_P, const rct::key &mu_C, rct::key &s) override;
 
             bool  close_tx(void) override;
+
+        private:
+            // Locker for concurrent access
+            mutable boost::recursive_mutex device_locker;
         };
 
     }


### PR DESCRIPTION
Transaction creation becomes corrupted (`hasInvalidInput:true`) when creating transactions concurrently from different wallets using native bindings to monero-project under one process. I traced the root issue using fable to this missing device lock, which exists for other devices (device_ledger, device_trezor_base), and I verified that it fixes the concurrency issue in all stress tests.

Release branch: https://github.com/monero-project/monero/pull/11023

More details from fable:

The bug (upstream monero, exposed by multi-wallet processes): every software wallet2 in a process shares one device_default instance (hw::get_device("default") returns a process-wide registry singleton), and its mode is a plain unsynchronized member. wallet2 builds candidate txs with set_mode(TRANSACTION_CREATE_FAKE) (wallet2.cpp:11353) for fee estimation, then rebuilds finals under TRANSACTION_CREATE_REAL (:11655). genRctSimple checks hwdev.get_mode() == TRANSACTION_CREATE_FAKE per input and, if so, emits make_dummy_clsag — every field set to rct::identity(), including D. So when wallet B enters its FAKE pass while wallet A is signing its REAL pass, A's finished tx silently carries an identity-D dummy CLSAG, and the daemon rejects it at exactly the D_8 == identity check — "Bad auxiliary key image", surfacing as hasInvalidInput. Reverse interleavings are benign, which is why it's one-way and intermittent. monero-wallet-rpc is one wallet per process, so upstream never sees this.

Why this is the root fix: wallet2 already wraps every signing-mode span in boost::unique_lock<hw::device> — create_transactions_2/_from hold it across their entire FAKE→REAL construction, scanning holds it per-transaction. The locking discipline was designed in; it just silently didn't apply to the software device because its lock was a no-op. This change makes device_default honor the same contract hardware devices already run, so concurrent wallets can no longer interleave TRANSACTION_CREATE_FAKE into another wallet's real signing pass.