### PR TITLE
common: don't calibrate perf timer at static init

### DIFF
--- a/src/common/perf_timer.cpp
+++ b/src/common/perf_timer.cpp
@@ -71,13 +71,10 @@ namespace tools
   }
 #endif
 
-#ifdef __x86_64__
-  uint64_t ticks_per_ns = get_ticks_per_ns();
-#endif
-
   uint64_t ticks_to_ns(uint64_t ticks)
   {
 #if defined(__x86_64__)
+    static const uint64_t ticks_per_ns = get_ticks_per_ns();
     return 256 * ticks / ticks_per_ns;
 #else
     return ticks;

--- a/src/common/perf_timer.cpp
+++ b/src/common/perf_timer.cpp
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <vector>
+#include <atomic>
 #include "time_helper.h"
 #include "perf_timer.h"
 
@@ -72,12 +73,25 @@ namespace tools
 #endif
 
 #ifdef __x86_64__
-  uint64_t ticks_per_ns = get_ticks_per_ns();
+  namespace
+  {
+    std::atomic<uint64_t> ticks_per_ns_value{0};
+
+    uint64_t calibrate_ticks_per_ns()
+    {
+      const uint64_t tpns = get_ticks_per_ns();
+      ticks_per_ns_value.store(tpns, std::memory_order_release);
+      return tpns;
+    }
+  }
 #endif
 
   uint64_t ticks_to_ns(uint64_t ticks)
   {
 #if defined(__x86_64__)
+    uint64_t ticks_per_ns = ticks_per_ns_value.load(std::memory_order_acquire);
+    if (ticks_per_ns == 0)
+      ticks_per_ns = calibrate_ticks_per_ns();
     return 256 * ticks / ticks_per_ns;
 #else
     return ticks;

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -357,6 +357,9 @@ int main(int argc, char const * argv[])
       }
     }
 
+    // Calibrate perf timer on startup
+    (void)tools::ticks_to_ns(0);
+
     MINFO("Moving from main() into the daemonize now.");
 
     return daemonizer::daemonize(argc, argv, daemonize::t_executor{parse_public_rpc_port(vm)}, vm) ? 0 : 1;


### PR DESCRIPTION
Lazily calibrates the performance timer instead of doing so on startup. This effectively removes a 100ms wait from the startup time of binaries, which is especially noticeable when running commands such as `--help`.

Before:
```
Executed in  137.48 millis    fish           external
   usr time  104.19 millis  836.00 micros  103.35 millis
   sys time   11.73 millis  314.00 micros   11.41 millis
```

After:
```
Executed in   15.25 millis    fish           external
   usr time    6.09 millis    0.00 micros    6.09 millis
   sys time    9.09 millis  978.00 micros    8.11 millis
```

(both times listed above are for `./monero-wallet-cli --help`)