### PR TITLE
epee: fix peak upload speed accounting

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -547,8 +547,8 @@ namespace net_utils
           m_state.stat.out.throttle.handle_trafic_exact(bytes_transferred);
           const auto speed = m_state.stat.out.throttle.get_current_speed();
           get_context().m_current_speed_up = speed;
-          get_context().m_max_speed_down = std::max(
-            get_context().m_max_speed_down,
+          get_context().m_max_speed_up = std::max(
+            get_context().m_max_speed_up,
             speed
           );
           if (speed_limit_is_enabled()) {


### PR DESCRIPTION
The send path currently stores upload throughput in `m_max_speed_down`, leaving `m_max_speed_up` at zero

That can inflate the peak download rate used for standby peer span scheduling

This restores the per-direction accounting used before the connection rewrite

Tests:
- `cmake --build build --target all`
- `ctest --test-dir build --output-on-failure -E core_tests`
- `ctest --test-dir build --output-on-failure -R core_tests`
- 1000 repetitions of `boosted_tcp_server.strand_deadlock`
