### PR TITLE
depends: boost: don't embed absolute paths in cmake config

### DIFF
--- a/contrib/depends/packages/boost.mk
+++ b/contrib/depends/packages/boost.mk
@@ -3,6 +3,7 @@ $(package)_version=1.91.0-1
 $(package)_download_path=https://github.com/boostorg/boost/releases/download/boost-$($(package)_version)
 $(package)_file_name=boost-$($(package)_version)-b2-nodocs.tar.gz
 $(package)_sha256_hash=b5a3d1490118e012f8b12688240d981bcdfcd009fd35bc70d120fbc907df4f7c
+$(package)_patches=no-embed-absolute.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -27,6 +28,7 @@ $(package)_cxxflags_darwin+=-ffile-prefix-map=$($(package)_extract_dir)=/usr
 endef
 
 define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/no-embed-absolute.patch && \
   echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <arflags>\"$($(package)_arflags)\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 

--- a/contrib/depends/patches/boost/no-embed-absolute.patch
+++ b/contrib/depends/patches/boost/no-embed-absolute.patch
@@ -1,0 +1,30 @@
+diff --git a/tools/boost_install/boost-install.jam b/tools/boost_install/boost-install.jam
+index 5e6bfa69..6425141f 100644
+--- a/tools/boost_install/boost-install.jam
++++ b/tools/boost_install/boost-install.jam
+@@ -797,25 +797,6 @@ rule make-cmake-config ( target : sources * : properties * )
+         "get_filename_component(_BOOST_CMAKEDIR \"${CMAKE_CURRENT_LIST_DIR}/../\" REALPATH)"
+         : true ;
+ 
+-    if [ path.is-rooted $(cmakedir) ]
+-    {
+-        local cmakedir-native = [ path-native-fwd $(cmakedir) ] ;
+-
+-        print.text
+-
+-            ""
+-            "# If the computed and the original directories are symlink-equivalent, use original"
+-            "if(EXISTS \"$(cmakedir-native)\")"
+-            "  get_filename_component(_BOOST_CMAKEDIR_ORIGINAL \"$(cmakedir-native)\" REALPATH)"
+-            "  if(_BOOST_CMAKEDIR STREQUAL _BOOST_CMAKEDIR_ORIGINAL)"
+-            "    set(_BOOST_CMAKEDIR \"$(cmakedir-native)\")"
+-            "  endif()"
+-            "  unset(_BOOST_CMAKEDIR_ORIGINAL)"
+-            "endif()"
+-            ""
+-            : true ;
+-    }
+-
+     get-dir "_BOOST_INCLUDEDIR" : $(includedir) ;
+ 
+     if $(library-type) = INTERFACE


### PR DESCRIPTION
`GUIX_ENVIRONMENT` can be non-deterministic across `guix-daemon` versions. We currently use this environment variable to derive depends hashes. Package sources are extracted to a path that contains this hash, which may end up in package archives. This only affects `boost` and `native_protobuf`. It does not affect the hashes of the release archive.

To make debugging reproducibility issues easier, avoid embedding absolute paths that contain the depends package hash.

I have not found a good alternative to `GUIX_ENVIRONMENT` to determine if we are in the same environment. Hashing `manifest.scm` and adding the time-machine commit seems too rigid.