### PR TITLE
depends: native_protobuf: don't include debug symbols in protoc binary

### DIFF
--- a/contrib/depends/packages/native_protobuf.mk
+++ b/contrib/depends/packages/native_protobuf.mk
@@ -8,6 +8,7 @@ $(package)_sha256_hash=4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c60
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --prefix=$(build_prefix)
   $(package)_config_opts_linux=--with-pic
+  $(package)_cxxflags+=-g0
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
Follow up to #11028

Also reduces `native_protobuf` package archive from 28.4 MB to 2.1 MB (-93%).