### PR TITLE
p2p: use a bool for send()

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -111,7 +111,7 @@ public:
   template<class callback_t>
   int invoke_async(int command, message_writer in_msg, boost::uuids::uuid connection_id, const callback_t &cb, std::chrono::milliseconds timeout = LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED);
 
-  int send(epee::byte_slice message, const boost::uuids::uuid& connection_id);
+  bool send(epee::byte_slice message, const boost::uuids::uuid& connection_id);
   bool close(boost::uuids::uuid connection_id, const bool wait_for_shutdown);
   bool request_callback(boost::uuids::uuid connection_id);
   template<class callback_t>
@@ -640,15 +640,15 @@ public:
       `message_writer::finalize_notify`. See additional instructions for
       `make_fragmented_notify`.
 
-      \return 1 on success */
-  int send(byte_slice message)
+      \return true on success */
+  bool send(byte_slice message)
   {
     if (!send_message(std::move(message)))
     {
       LOG_ERROR_CC(m_connection_context, "Failed to send message, dropping it");
-      return -1;
+      return false;
     }
-    return 1;
+    return true;
   }
   //------------------------------------------------------------------------------------------
   boost::uuids::uuid get_connection_id() {return m_connection_context.m_connection_id;}
@@ -799,10 +799,10 @@ void async_protocol_handler_config<t_connection_context>::set_handler(levin_comm
 }
 //------------------------------------------------------------------------------------------
 template<class t_connection_context>
-int async_protocol_handler_config<t_connection_context>::send(byte_slice message, const boost::uuids::uuid& connection_id)
+bool async_protocol_handler_config<t_connection_context>::send(byte_slice message, const boost::uuids::uuid& connection_id)
 {
   const std::shared_ptr<levin_endpoint> aph = find_and_lock_connection(connection_id);
-  return aph ? aph->m_protocol_handler.send(std::move(message)) : 0;
+  return aph ? aph->m_protocol_handler.send(std::move(message)) : false;
 }
 //------------------------------------------------------------------------------------------
 template<class t_connection_context>

--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -104,7 +104,7 @@ public:
   template<class callback_t>
   int invoke_async(int command, message_writer in_msg, boost::uuids::uuid connection_id, const callback_t &cb, std::chrono::milliseconds timeout = LEVIN_DEFAULT_TIMEOUT_PRECONFIGURED);
 
-  int send(epee::byte_slice message, const boost::uuids::uuid& connection_id);
+  bool send(epee::byte_slice message, const boost::uuids::uuid& connection_id);
   bool close(boost::uuids::uuid connection_id, const bool wait_for_shutdown);
   bool update_connection_context(const t_connection_context& contxt);
   bool request_callback(boost::uuids::uuid connection_id);
@@ -662,17 +662,17 @@ public:
       `message_writer::finalize_notify`. See additional instructions for
       `make_fragmented_notify`.
 
-      \return 1 on success */
-  int send(byte_slice message)
+      \return true on success */
+  bool send(byte_slice message)
   {
     const scope_guard scope_exit_handler(boost::bind(&async_protocol_handler::finish_outer_call, this));
 
     if (!send_message(std::move(message)))
     {
       LOG_ERROR_CC(m_connection_context, "Failed to send message, dropping it");
-      return -1;
+      return false;
     }
-    return 1;
+    return true;
   }
   //------------------------------------------------------------------------------------------
   boost::uuids::uuid get_connection_id() {return m_connection_context.m_connection_id;}
@@ -844,11 +844,11 @@ void async_protocol_handler_config<t_connection_context>::set_handler(levin_comm
 }
 //------------------------------------------------------------------------------------------
 template<class t_connection_context>
-int async_protocol_handler_config<t_connection_context>::send(byte_slice message, const boost::uuids::uuid& connection_id)
+bool async_protocol_handler_config<t_connection_context>::send(byte_slice message, const boost::uuids::uuid& connection_id)
 {
   async_protocol_handler<t_connection_context>* aph;
   int r = find_and_lock_connection(connection_id, aph);
-  return LEVIN_OK == r ? aph->send(std::move(message)) : 0;
+  return LEVIN_OK == r ? aph->send(std::move(message)) : false;
 }
 //------------------------------------------------------------------------------------------
 template<class t_connection_context>

--- a/contrib/epee/include/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/storages/levin_abstract_invoke2.h
@@ -110,10 +110,10 @@ namespace epee
       levin::message_writer to_send;
       stg.store_to_binary(to_send.buffer);
 
-      int res = transport.send(to_send.finalize_notify(command), conn_id);
-      if(res <=0 )
+      bool res = transport.send(to_send.finalize_notify(command), conn_id);
+      if(!res)
       {
-        MERROR("Failed to notify command " << command << " return code " << res);
+        MERROR("Failed to notify command " << command);
         return false;
       }
       return true;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2533,8 +2533,8 @@ namespace nodetool
       return false;
 
     network_zone& zone = m_network_zones.at(context.m_remote_address.get_zone());
-    int res = zone.m_net_server.get_config_object().send(message.finalize_notify(command), context.m_connection_id);
-    return res > 0;
+    bool res = zone.m_net_server.get_config_object().send(message.finalize_notify(command), context.m_connection_id);
+    return res;
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2503,8 +2503,8 @@ namespace nodetool
       return false;
 
     network_zone& zone = m_network_zones.at(context.m_remote_address.get_zone());
-    int res = zone.m_net_server.get_config_object().send(message.finalize_notify(command), context.m_connection_id);
-    return res > 0;
+    bool res = zone.m_net_server.get_config_object().send(message.finalize_notify(command), context.m_connection_id);
+    return res;
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>

--- a/tests/unit_tests/levin.cpp
+++ b/tests/unit_tests/levin.cpp
@@ -2445,7 +2445,7 @@ TEST_F(levin_notify, command_max_bytes)
         bytes = dest.finalize_notify(ping_command);
     }
 
-    EXPECT_EQ(1, get_connections().send(bytes.clone(), contexts_.front().get_id()));
+    EXPECT_TRUE(get_connections().send(bytes.clone(), contexts_.front().get_id()));
     EXPECT_EQ(1u, contexts_.front().process_send_queue(true));
     EXPECT_EQ(1u, receiver_.notified_size());
 
@@ -2461,7 +2461,7 @@ TEST_F(levin_notify, command_max_bytes)
         bytes = dest.finalize_notify(ping_command);
     }
 
-    EXPECT_EQ(1, get_connections().send(std::move(bytes), contexts_.front().get_id()));
+    EXPECT_TRUE(get_connections().send(std::move(bytes), contexts_.front().get_id()));
     EXPECT_EQ(1u, contexts_.front().process_send_queue(false));
     EXPECT_EQ(0u, receiver_.notified_size());
 }

--- a/tests/unit_tests/levin.cpp
+++ b/tests/unit_tests/levin.cpp
@@ -2470,8 +2470,8 @@ TEST_F(levin_notify, command_max_bytes)
         bytes = dest.finalize_notify(ping_command);
     }
 
-    EXPECT_EQ(1, get_connections().send(bytes.clone(), contexts_.front()->get_id()));
-    EXPECT_EQ(1u, contexts_.front()->process_send_queue(true));
+    EXPECT_TRUE(get_connections().send(bytes.clone(), contexts_.front()->get_id()));
+    EXPECT_TRUE(contexts_.front()->process_send_queue(true));
     EXPECT_EQ(1u, receiver_.notified_size());
 
     const received_message msg = receiver_.get_raw_notification();
@@ -2486,7 +2486,7 @@ TEST_F(levin_notify, command_max_bytes)
         bytes = dest.finalize_notify(ping_command);
     }
 
-    EXPECT_EQ(1, get_connections().send(std::move(bytes), contexts_.front()->get_id()));
-    EXPECT_EQ(1u, contexts_.front()->process_send_queue(false));
+    EXPECT_TRUE(get_connections().send(std::move(bytes), contexts_.front()->get_id()));
+    EXPECT_TRUE(contexts_.front()->process_send_queue(false));
     EXPECT_EQ(0u, receiver_.notified_size());
 }


### PR DESCRIPTION
Identified by @selsta

Callers can otherwise misinterpret int -1 as truthy success.

Example bug:

- `make_payload_send_txs` would return true even on failure [here](https://github.com/monero-project/monero/blob/83405f127d006c470f7b8715895ebb318da5fcca/src/cryptonote_protocol/levin_notify.cpp#L564).
- Thus even if a stem tx fails to relay, the node incorrectly assumes it succeeded and won't re-attempt relay until the re-relay check loop.