### PR TITLE
device_trezor: add Trezor Host Protocol v2 support

### DIFF
--- a/cmake/CheckTrezor.cmake
+++ b/cmake/CheckTrezor.cmake
@@ -125,7 +125,8 @@ if(Protobuf_FOUND AND USE_DEVICE_TREZOR)
     set(_proto_files "messages.proto"
                      "messages-common.proto"
                      "messages-management.proto"
-                     "messages-monero.proto")
+                     "messages-monero.proto"
+                     "messages-thp.proto")
     if (TREZOR_DEBUG)
         list(APPEND _proto_files "messages-debug.proto")
     endif ()

--- a/src/device/device.hpp
+++ b/src/device/device.hpp
@@ -81,6 +81,18 @@ namespace hw {
         virtual boost::optional<epee::wipeable_string> on_pin_request() { return boost::none; }
         virtual boost::optional<epee::wipeable_string> on_passphrase_request(bool & on_device) { on_device = true; return boost::none; }
         virtual void on_progress(const device_progress& event) {}
+
+        // Called once during the THP CodeEntry pairing flow used by the
+        // Trezor Safe 7 (and any future device that drops the legacy v1
+        // protocol).  The host/GUI is expected to render a modal asking
+        // the user to type the 6-digit code currently shown on the
+        // Trezor's screen.  Return the user-entered code as ASCII
+        // digits; throw or return nothing to abort pairing (which will
+        // tear down the channel).  The code authenticates the CPace
+        // exchange, so it is carried in the same wipeable string as the
+        // PIN.
+        virtual boost::optional<epee::wipeable_string> on_pairing_code_request() { return boost::none; }
+
         virtual ~i_device_callback() = default;
     };
 

--- a/src/device_trezor/CMakeLists.txt
+++ b/src/device_trezor/CMakeLists.txt
@@ -31,6 +31,7 @@ set(TREZOR_PROTOB_H
         trezor/messages/messages-common.pb.h
         trezor/messages/messages-management.pb.h
         trezor/messages/messages-monero.pb.h
+        trezor/messages/messages-thp.pb.h
 )
 
 set(TREZOR_PROTOB_CPP
@@ -38,6 +39,7 @@ set(TREZOR_PROTOB_CPP
         trezor/messages/messages-common.pb.cc
         trezor/messages/messages-management.pb.cc
         trezor/messages/messages-monero.pb.cc
+        trezor/messages/messages-thp.pb.cc
 )
 
 set(trezor_headers
@@ -45,6 +47,12 @@ set(trezor_headers
         trezor/messages_map.hpp
         trezor/protocol.hpp
         trezor/transport.hpp
+        trezor/thp/auto_detect.hpp
+        trezor/thp/framing.hpp
+        trezor/thp/noise.hpp
+        trezor/thp/pairing.hpp
+        trezor/thp/protocol_v2.hpp
+        trezor/thp/store.hpp
         device_trezor_base.hpp
         device_trezor.hpp
         trezor.hpp
@@ -55,6 +63,12 @@ set(trezor_sources
         trezor/messages_map.cpp
         trezor/protocol.cpp
         trezor/transport.cpp
+        trezor/thp/auto_detect.cpp
+        trezor/thp/framing.cpp
+        trezor/thp/noise.cpp
+        trezor/thp/pairing.cpp
+        trezor/thp/protocol_v2.cpp
+        trezor/thp/store.cpp
         device_trezor_base.cpp
         device_trezor.cpp
         ${TREZOR_PROTOB_CPP}
@@ -97,6 +111,7 @@ if(DEVICE_TREZOR_READY)
             ${Protobuf_LIBRARY}
             ${TREZOR_LIBUSB_LIBRARIES}
             PRIVATE
+            ${OPENSSL_LIBRARIES}
             ${EXTRA_LIBRARIES}
             ${TREZOR_EXTRA_LIBRARIES})
 

--- a/src/device_trezor/README.md
+++ b/src/device_trezor/README.md
@@ -13,6 +13,40 @@ Transaction is build incrementally on the device.
 Trezor implements the signing protocol in [trezor-firmware] repository, in the [monero](https://github.com/trezor/trezor-firmware/tree/master/core/src/apps/monero) application.
 Please, refer to [monero readme](https://github.com/trezor/trezor-firmware/blob/master/core/src/apps/monero/README.md) for more information.
 
+## Wire protocols
+
+The signing protocol above is carried over one of two wire protocols.
+
+Protocol v1 is the long-standing plaintext framing used by the Trezor One,
+Model T, Safe 3 and Safe 5. It is implemented by `ProtocolV1` in
+`trezor/protocol.cpp` and is unchanged.
+
+Protocol v2, the Trezor Host Protocol (THP), is an end-to-end-encrypted
+protocol built on the Noise Protocol Framework. The Trezor Safe 7 speaks it
+exclusively and has no v1 support at all, so THP is required to use a Safe 7
+with Monero. It is implemented under `trezor/thp/`; see
+[trezor/thp/README.md](trezor/thp/README.md) for the wire format, the
+handshake and the pairing flow.
+
+Which protocol a device speaks is detected rather than configured.
+`ProtocolAutoDetect` (`trezor/thp/auto_detect.cpp`) is installed by default;
+on the first `open()` it sends a THP channel-allocation request on the
+broadcast channel. A Safe 7 answers with a channel-allocation response and
+the connection continues over THP on the channel just allocated. A v1 device
+answers with a v1 `Failure` report, which is not a valid THP frame, and the
+probe falls back to `ProtocolV1`. The result is cached per device path, so
+one probe per attach is enough. Setting `TREZOR_FORCE_THP=1` or
+`TREZOR_FORCE_V1=1` in the environment skips the probe and forces one
+protocol, which is only intended for diagnostics.
+
+THP authenticates the device the first time it is seen: the user confirms a
+6-digit code shown on the Trezor, and the device then issues a long-lived
+credential the host presents on later connections. That credential, together
+with the host's own static key, is kept in `.trezor/thp_store.bin` under the
+Monero data directory; the store creates that directory and file with
+owner-only access. If the file is deleted, the next connection simply asks
+for the pairing code again.
+
 ## Dependencies
 
 Trezor uses [Protobuf](https://protobuf.dev/) library.

--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -172,7 +172,10 @@ namespace trezor {
         pubkey = info.address;
         return true;
 
-      } catch(exc::FirmwareNotSupportedException const&){
+      } catch(exc::TrezorException const&){
+        // A device failure carries its kind in the exception type, and
+        // the wallet layer classifies it to decide what the user can do
+        // about it; flattening it into a bare false loses all of that.
         throw;
       } catch(std::exception const& e){
         MERROR("Get public address exception: " << e.what());
@@ -208,8 +211,8 @@ namespace trezor {
         return true;
 
       } catch(const exc::proto::CancelledException &){
-        CHECK_AND_ASSERT_THROW_MES(false, "Key export rejected on device");
-      } catch(exc::FirmwareNotSupportedException const&){
+        throw exc::proto::CancelledException("Key export rejected on device");
+      } catch(exc::TrezorException const&){
         throw;
       } catch(std::exception const& e){
         MERROR("Get secret keys exception: " << e.what());

--- a/src/device_trezor/device_trezor_base.cpp
+++ b/src/device_trezor/device_trezor_base.cpp
@@ -29,11 +29,19 @@
 
 #include "device_trezor_base.hpp"
 #include "memwipe.h"
+#include "common/util.h"
+#include "trezor/thp/auto_detect.hpp"
+#include "trezor/thp/store.hpp"
 #include <algorithm>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/regex.hpp>
+
+#ifdef WIN32
+#include <shlobj.h>
+#endif
 
 namespace hw {
 namespace trezor {
@@ -49,7 +57,9 @@ namespace trezor {
     device_trezor_base::device_trezor_base(): m_callback(nullptr), m_last_msg_type(messages::MessageType_Success),
                                               m_reply_with_empty_passphrase(false),
                                               m_always_use_empty_passphrase(false),
-                                              m_seen_passphrase_entry_message(false) {
+                                              m_seen_passphrase_entry_message(false),
+                                              m_pairing_code_requested(false),
+                                              m_pairing_code_entered(false) {
 #ifdef WITH_TREZOR_DEBUGGING
       m_debug = false;
 #endif
@@ -76,6 +86,20 @@ namespace trezor {
       this->m_full_name = name;
       this->name = "";
 
+      // Carrier-prefixed paths (e.g. the UDP emulator
+      // "udp:127.0.0.1:21324"): keep the whole string.  connect()
+      // compares this->name as a prefix of transport->get_path(), and a
+      // transport's get_path() includes the carrier prefix, so stripping
+      // it here would leave the bare body, which would never match the
+      // prefixed path and silently fall through to the "match every
+      // transport" fallback.
+      if (boost::starts_with(name, UdpTransport::PATH_PREFIX)) {
+        this->name = name;
+        return true;
+      }
+
+      // Legacy "<scheme>:<rest>" form (e.g. "Trezor:/dev/hidraw0"):
+      // strip the scheme so the filter compares against the bare path.
       auto delim = name.find(':');
       if (delim != std::string::npos && delim + 1 < name.length()) {
         this->name = name.substr(delim + 1);
@@ -111,11 +135,52 @@ namespace trezor {
       }
     }
 
+    // Directory holding the THP credential store.  It has to be private to
+    // the current user and specific to the network: the file keeps the host
+    // static private key and every pairing credential in the clear, and one
+    // store per network stops a testnet wallet from spending a mainnet
+    // wallet's credential.
+    static std::string thp_store_data_dir(cryptonote::network_type nettype) {
+      boost::filesystem::path dir;
+#ifdef WIN32
+      // tools::get_default_data_dir() resolves to CSIDL_COMMON_APPDATA,
+      // which every local account on the machine shares.
+      dir = tools::get_special_folder_path(CSIDL_APPDATA, true) + "\\" + CRYPTONOTE_NAME;
+#else
+      dir = tools::get_default_data_dir();
+#endif
+      switch (nettype) {
+        case cryptonote::TESTNET:   dir /= "testnet";  break;
+        case cryptonote::STAGENET:  dir /= "stagenet"; break;
+        case cryptonote::FAKECHAIN: dir /= "fake";     break;
+        default: break;
+      }
+      return dir.string();
+    }
+
+    // A rejected pairing code surfaces either as a failure the device
+    // reported (its CPace tag check refused the code) or as a host-side
+    // security fault (the commitment check refused it).  An on-device
+    // cancel is a device failure too, but it is a cancellation rather
+    // than a wrong code.
+    static bool is_pairing_rejection(const std::exception &e) {
+      if (dynamic_cast<const exc::proto::CancelledException *>(&e)) {
+        return false;
+      }
+      return dynamic_cast<const exc::proto::FailureException *>(&e) != nullptr
+          || dynamic_cast<const exc::SecurityException *>(&e) != nullptr;
+    }
+
+    // Reports failure by throwing rather than by returning false: the
+    // wallet layer classifies the exception to decide what the user can
+    // do about it, and a bare false carries none of that.
     bool device_trezor_base::connect() {
       disconnect();
 
       // Enumerate all available devices
       TREZOR_AUTO_LOCK_DEVICE();
+      m_pairing_code_requested = false;
+      m_pairing_code_entered = false;
       try {
         hw::trezor::t_transport_vect trans;
 
@@ -128,30 +193,140 @@ namespace trezor {
           MDEBUG("  device: " << *(cur.get()));
         }
 
+        // Collect candidates: prefer those whose path begins with the
+        // pinned specifier (legacy carrier-prefixed wallets), but fall
+        // through to all enumerated transports if the specifier matches
+        // nothing.  Modern wallets persist just "Trezor" so this->name
+        // is empty and every transport matches.
+        std::vector<std::shared_ptr<Transport>> candidates;
+        candidates.reserve(trans.size());
         for (auto &cur : trans) {
-          std::string cur_path = cur->get_path();
-          if (boost::starts_with(cur_path, this->name)) {
-            MDEBUG("Device Match: " << cur_path);
-            m_transport = cur;
-            break;
+          if (boost::starts_with(cur->get_path(), this->name)) {
+            candidates.push_back(cur);
           }
         }
-
-        if (!m_transport) {
-          MERROR("No matching Trezor device found. Device specifier: \"" + this->name + "\"");
-          return false;
+        // Deliberately fail-open: a stale persisted specifier (device
+        // re-plugged on another USB port, emulator port change) should
+        // not brick the wallet.  Connecting to the wrong physical device
+        // is harmless: get_public_address() is checked against the
+        // wallet's stored address right after connect, which is the
+        // actual authority on device identity.
+        if (candidates.empty() && !this->name.empty()) {
+          MWARNING("Trezor specifier \"" << this->name
+                   << "\" did not match any enumerated transport; "
+                   << "falling back to all " << trans.size() << " device(s)");
+          candidates = trans;
         }
 
-        m_transport->open();
+        if (candidates.empty()) {
+          throw exc::NotConnectedException(
+              "No Trezor device found. Device specifier: \"" + this->name + "\"");
+        }
 
+        // Try the candidates in enumeration order until one opens.
+        // Modern wallets persist just "Trezor" so this->name is empty
+        // and every transport matches; legacy wallets may pin a fuller
+        // path.  Iterating matters: a Safe 7 needs the direct-USB
+        // carrier, which enumeration lists after Bridge, and on setups
+        // where libusb can enumerate but not open the device (Linux
+        // without udev rules, or trezord-go / Suite holding the USB
+        // interface) the working candidate is the Bridge one.
+        std::exception_ptr last_error;
+        for (size_t i = 0; i < candidates.size(); ++i) {
+          const std::shared_ptr<Transport> &chosen = candidates[i];
+          MDEBUG("Trezor device candidate " << (i + 1) << "/"
+                 << candidates.size() << ": " << chosen->get_path());
+
+          // Configure THP auto-detect so the CodeEntry pairing prompt
+          // and the credential store are wired up before open() drives
+          // session_begin().  No-op for transports that don't carry a
+          // ProtocolAutoDetect (e.g. BridgeTransport).
+          if (auto p = chosen->protocol()) {
+            if (auto autod = std::dynamic_pointer_cast<thp::ProtocolAutoDetect>(p)) {
+              thp::ProtocolConfig cfg;
+              cfg.host_name  = "Monero Wallet";
+              cfg.app_name   = "monero-wallet";
+              cfg.store_path = thp::ThpStore::default_path(
+                  thp_store_data_dir(m_network_type));
+              cfg.pairing_prompt = [this]() -> epee::wipeable_string {
+                return this->on_pairing_code_request();
+              };
+              autod->configure(cfg);
+            }
+          }
+
+          try {
+            m_transport = chosen;
+            m_transport->open();
 #ifdef WITH_TREZOR_DEBUGGING
-        setup_debug();
+            setup_debug();
 #endif
-        return true;
+            return true;
+          } catch (const std::exception &e) {
+            try { m_transport->close(); } catch (...) {}
+            m_transport = nullptr;
+
+            // Only a carrier we could not acquire justifies trying the
+            // next one.  Anything the device itself reported (a rejected
+            // PIN, an on-device cancel, any other Failure) has already
+            // reached the user, and moving to another carrier would ask
+            // them for it a second time on the same hardware.
+            const bool carrier_fault =
+                dynamic_cast<const exc::DeviceAcquireException *>(&e) != nullptr ||
+                dynamic_cast<const exc::NotConnectedException *>(&e) != nullptr;
+            if (!carrier_fault) {
+              throw;  // handled (classified + logged) by the catch below
+            }
+
+            last_error = std::current_exception();
+            MDEBUG("Trezor candidate " << chosen->get_path()
+                   << " failed to open: " << e.what()
+                   << (i + 1 < candidates.size()
+                       ? "; trying the next candidate" : ""));
+          }
+        }
+        // Every candidate failed; surface the last failure through the
+        // classifying catch below.
+        std::rethrow_exception(last_error);
 
       } catch(std::exception const& e){
-        MERROR("Open exception: " << e.what());
-        return false;
+        // Tear down the transport on open failure so the underlying
+        // USB state is released.  Previously the transport was leaked
+        // here, which could leave a half-open device handle around for
+        // subsequent connect() attempts.
+        if (m_transport) {
+          try { m_transport->close(); } catch (...) {}
+          m_transport = nullptr;
+        }
+
+        // The pairing prompt is the only place that knows a CodeEntry
+        // exchange was in flight, and neither of its user-visible
+        // outcomes is distinguishable by exception type on its own: a
+        // declined prompt aborts the handshake somewhere below, and a
+        // wrong code comes back as a plain device failure.  Restate both
+        // in the exception hierarchy so the wallet layer can tell them
+        // from a communication error.
+        if (m_pairing_code_requested && !m_pairing_code_entered) {
+          MWARNING("Open failed, pairing declined by the user: " << e.what());
+          throw exc::proto::CancelledException("Trezor pairing declined by the user");
+        }
+        if (m_pairing_code_entered && is_pairing_rejection(e)) {
+          MWARNING("Open failed, device rejected the pairing code: " << e.what());
+          throw exc::proto::PairingFailedException(
+              std::string("Trezor rejected the pairing code: ") + e.what());
+        }
+
+        // Don't shout ERROR for the failures a user meets and resolves
+        // themselves.  When the device is off, unreachable, or they
+        // cancelled on-device, painting the log red scares them into
+        // thinking there is a code bug; MERROR stays for protocol
+        // violations and unclassified faults.
+        if (exc::is_expected_failure(exc::classify(e))) {
+          MWARNING("Open failed (user-recoverable): " << e.what());
+        } else {
+          MERROR("Open exception: " << e.what());
+        }
+        throw;
       }
     }
 
@@ -518,6 +693,25 @@ namespace trezor {
       resp = call_raw(&m);
     }
 
+    epee::wipeable_string device_trezor_base::on_pairing_code_request()
+    {
+      MDEBUG("on_pairing_code_request");
+
+      // Records what the prompt did, so that a failure arriving later in
+      // the handshake can be attributed to the pairing step.
+      m_pairing_code_requested = true;
+      m_pairing_code_entered = false;
+
+      boost::optional<epee::wipeable_string> code;
+      TREZOR_CALLBACK_GET(code, on_pairing_code_request);
+      if (!code || code->empty()) {
+        return epee::wipeable_string();
+      }
+
+      m_pairing_code_entered = true;
+      return std::move(*code);
+    }
+
 #ifdef WITH_TREZOR_DEBUGGING
     void device_trezor_base::wipe_device()
     {
@@ -569,6 +763,10 @@ namespace trezor {
 
     boost::optional<epee::wipeable_string> trezor_debug_callback::on_passphrase_request(bool & on_device) {
       on_device = true;
+      return boost::none;
+    }
+
+    boost::optional<epee::wipeable_string> trezor_debug_callback::on_pairing_code_request() {
       return boost::none;
     }
 

--- a/src/device_trezor/device_trezor_base.hpp
+++ b/src/device_trezor/device_trezor_base.hpp
@@ -71,6 +71,7 @@ namespace trezor {
       void on_button_request(uint64_t code=0) override;
       boost::optional<epee::wipeable_string> on_pin_request() override;
       boost::optional<epee::wipeable_string> on_passphrase_request(bool & on_device) override;
+      boost::optional<epee::wipeable_string> on_pairing_code_request() override;
       void on_passphrase_state_request(const std::string &state);
       void on_disconnect();
     protected:
@@ -100,10 +101,15 @@ namespace trezor {
       boost::optional<epee::wipeable_string> m_passphrase;
       messages::MessageType m_last_msg_type;
 
-      cryptonote::network_type m_network_type;
+      cryptonote::network_type m_network_type = cryptonote::MAINNET;
       bool m_reply_with_empty_passphrase;
       bool m_always_use_empty_passphrase;
       bool m_seen_passphrase_entry_message;
+      // Outcome of the CodeEntry pairing prompt in the current connect()
+      // attempt: whether it ran at all, and whether the user supplied a
+      // code instead of declining.
+      bool m_pairing_code_requested;
+      bool m_pairing_code_entered;
 
 #ifdef WITH_TREZOR_DEBUGGING
       std::shared_ptr<trezor_debug_callback> m_debug_callback;
@@ -289,6 +295,9 @@ namespace trezor {
     const std::string get_name() const override;
     bool init() override;
     bool release() override;
+    // Returns true or throws: a failure carries a hw::trezor::exc
+    // exception the wallet layer classifies to pick the recovery it
+    // offers the user.
     bool connect() override;
     bool disconnect() override;
 
@@ -318,6 +327,7 @@ namespace trezor {
     void on_button_pressed();
     void on_pin_request(GenericMessage & resp, const messages::common::PinMatrixRequest * msg);
     void on_passphrase_request(GenericMessage & resp, const messages::common::PassphraseRequest * msg);
+    epee::wipeable_string on_pairing_code_request();
 
 #ifdef WITH_TREZOR_DEBUGGING
     void set_debug(bool debug){

--- a/src/device_trezor/trezor/exceptions.hpp
+++ b/src/device_trezor/trezor/exceptions.hpp
@@ -192,7 +192,80 @@ namespace proto {
     FirmwareErrorException(): FailureException("Trezor returned firmware error"){}
   };
 
+  class PairingFailedException : public FailureException {
+  public:
+    using FailureException::FailureException;
+    PairingFailedException(): FailureException("Trezor rejected the pairing code"){}
+  };
+
 }
+
+  // Broad categories of device failure.  The exception type says exactly
+  // what went wrong; this collapses the hierarchy into the few cases a
+  // caller has to treat differently, such as the log level to use or the
+  // recovery a wallet frontend offers.  Monero::Wallet::TrezorError
+  // mirrors these values across the wallet API boundary, so they are
+  // append-only.
+  enum class error_kind : int {
+    none                 = 0,  // not a device failure
+    unreachable          = 1,  // device off, unplugged, held elsewhere, or unresponsive
+    cancelled            = 2,  // cancelled on the device or in a host prompt
+    protocol             = 3,  // framing, Noise, or protocol assertion failure
+    other                = 4,  // device refused the operation for a reason of its own
+    firmware_unsupported = 5,  // firmware has no Monero support
+    pairing_rejected     = 6,  // device rejected the pairing code
+  };
+
+  // Categorizes a failure by exception type.  The hierarchy nests (a
+  // CancelledException is a FailureException is a ProtocolException), so
+  // the tests run most derived first and the first match wins.
+  inline error_kind classify(const std::exception &e) {
+    if (dynamic_cast<const proto::PairingFailedException *>(&e)) {
+      return error_kind::pairing_rejected;
+    }
+    if (dynamic_cast<const proto::CancelledException *>(&e)) {
+      return error_kind::cancelled;
+    }
+    if (dynamic_cast<const FirmwareNotSupportedException *>(&e)) {
+      return error_kind::firmware_unsupported;
+    }
+    // Thrown by the client when a response does not match the request,
+    // which is a protocol fault despite deriving from FailureException.
+    if (dynamic_cast<const proto::UnexpectedMessageException *>(&e)) {
+      return error_kind::protocol;
+    }
+    // Anything else the device itself reported: an invalid PIN, an
+    // uninitialized device, a firmware error.
+    if (dynamic_cast<const proto::FailureException *>(&e)) {
+      return error_kind::other;
+    }
+    // SecurityException sits outside TrezorException and covers the
+    // transport's authentication failures.
+    if (dynamic_cast<const ProtocolException *>(&e) ||
+        dynamic_cast<const EncodingException *>(&e) ||
+        dynamic_cast<const SecurityException *>(&e)) {
+      return error_kind::protocol;
+    }
+    if (dynamic_cast<const CommunicationException *>(&e)) {
+      return error_kind::unreachable;
+    }
+    if (dynamic_cast<const TrezorException *>(&e)) {
+      return error_kind::other;
+    }
+    return error_kind::none;
+  }
+
+  // True for the failures a user is expected to meet and can respond to:
+  // the device is off or busy, they cancelled, they mistyped the pairing
+  // code, or the firmware has no Monero support.  Everything else means
+  // a fault in the protocol or in the client.
+  inline bool is_expected_failure(error_kind kind) {
+    return kind == error_kind::unreachable
+        || kind == error_kind::cancelled
+        || kind == error_kind::pairing_rejected
+        || kind == error_kind::firmware_unsupported;
+  }
+
 }
 }
 }

--- a/src/device_trezor/trezor/fetch_protob.sh
+++ b/src/device_trezor/trezor/fetch_protob.sh
@@ -3,17 +3,25 @@ set -e
 
 cd "$(dirname "$0")"
 
+# Revision the five long-standing protos are vendored from.
+COMMON_REF="bc28c316d05bf1e9ebfe3d7df1ab25831d98d168"
+# messages-thp.proto does not exist at COMMON_REF, so it is taken from a
+# later revision of the same repository rather than from a second upstream.
+# Bumping COMMON_REF instead would also rewrite the five protos above,
+# which is unrelated to Trezor Host Protocol v2 support.
+THP_REF="ff5f1525632ab09b286f765e5583df5207e222b7"
+
 if [ ! -d "trezor-common" ]; then
   git clone https://github.com/trezor/trezor-common.git
 fi
 
 cd trezor-common
 git fetch
-git reset --hard bc28c316d05bf1e9ebfe3d7df1ab25831d98d168
+git reset --hard "${COMMON_REF}"
 cd ..
 
-rm -rf protob
-mkdir protob
+mkdir -p protob
+rm -f protob/*.proto protob/COPYING
 
 proto_files="messages.proto messages-common.proto messages-monero.proto messages-management.proto messages-debug.proto"
 
@@ -22,6 +30,31 @@ do
   cp "trezor-common/protob/${file}" protob/
 done
 cp "trezor-common/COPYING" protob/
+
+# messages-thp.proto is read out of the object database at THP_REF, so both
+# pins are verified by git the same way. Two edits are applied and they are
+# the only difference between protob/messages-thp.proto and upstream:
+#
+#   - the import is redirected from options.proto to messages.proto. This
+#     tree does not vendor options.proto; the custom options the file needs
+#     (wire_in, wire_out, bitcoin_only, include_in_bitcoin_only) are all
+#     declared in messages.proto at COMMON_REF. Vendoring options.proto as
+#     well is not an alternative, because it declares the same extension
+#     numbers as messages.proto and protoc rejects the duplicates.
+#   - the (wire_enum) and (internal_only) options are dropped. Both are
+#     declared only in options.proto and only at revisions newer than
+#     COMMON_REF, so protoc cannot resolve them here. They are metadata for
+#     trezor-firmware's own code generator and affect neither the wire
+#     format nor the generated C++.
+#
+# See protob/README.md for provenance and licensing.
+git -C trezor-common show "${THP_REF}:protob/messages-thp.proto" > protob/messages-thp.proto
+# POSIX sed has no portable -i; edit via a temp file instead.
+sed -e 's|^import "options.proto";|import "messages.proto";|' \
+    -e '/option (wire_enum) = true;/d' \
+    -e '/option (internal_only) = true;/d' \
+    protob/messages-thp.proto > protob/messages-thp.proto.tmp
+mv protob/messages-thp.proto.tmp protob/messages-thp.proto
 
 cd protob
 echo "Checksums:"

--- a/src/device_trezor/trezor/messages_map.cpp
+++ b/src/device_trezor/trezor/messages_map.cpp
@@ -32,6 +32,7 @@
 #include "messages/messages-common.pb.h"
 #include "messages/messages-management.pb.h"
 #include "messages/messages-monero.pb.h"
+#include "messages/messages-thp.pb.h"
 
 #ifdef WITH_TREZOR_DEBUGGING
 #include "messages/messages-debug.pb.h"
@@ -44,6 +45,11 @@ namespace hw{
 namespace trezor
 {
 
+  // ThpCreateNewSession is `reserved 1000` in both MessageType and
+  // ThpMessageType, so it has no generated enum name. We map it by its
+  // wire number directly in two places below.
+  static constexpr int THP_CREATE_NEW_SESSION_WIRE = 1000;
+
   const char * TYPE_PREFIX = "MessageType_";
   const std::string PACKAGES[] = {
       "hw.trezor.messages.",
@@ -52,7 +58,8 @@ namespace trezor
 #ifdef WITH_TREZOR_DEBUGGING
       "hw.trezor.messages.debug.",
 #endif
-      "hw.trezor.messages.monero."
+      "hw.trezor.messages.monero.",
+      "hw.trezor.messages.thp."
   };
 
   google::protobuf::Message * MessageMapper::get_message(int wire_number) {
@@ -60,23 +67,42 @@ namespace trezor
   }
 
   google::protobuf::Message * MessageMapper::get_message(messages::MessageType wire_number) {
-    const string &messageTypeName = hw::trezor::messages::MessageType_Name(wire_number);
-    if (messageTypeName.empty()) {
-      throw exc::EncodingException(std::string("Message descriptor not found: ") + std::to_string(wire_number));
+    // ThpCreateNewSession is reserved (no enum name) in both MessageType
+    // and ThpMessageType. Construct it directly to avoid the descriptor
+    // lookup falling through to "Message descriptor not found".
+    if (static_cast<int>(wire_number) == THP_CREATE_NEW_SESSION_WIRE) {
+      return new hw::trezor::messages::thp::ThpCreateNewSession();
     }
-
-    string messageName = messageTypeName.substr(strlen(TYPE_PREFIX));
+    string messageTypeName = hw::trezor::messages::MessageType_Name(wire_number);
+    string messageName;
+    if (!messageTypeName.empty()) {
+      messageName = messageTypeName.substr(strlen(TYPE_PREFIX));
+    } else {
+      // THP messages live in a separate enum (ThpMessageType) with its own
+      // wire numbers in the 1008..1041 range. Fall back to it before
+      // declaring the wire number unknown.
+      const string &thpName = hw::trezor::messages::thp::ThpMessageType_Name(
+          static_cast<hw::trezor::messages::thp::ThpMessageType>(wire_number));
+      if (thpName.empty()) {
+        throw exc::EncodingException(std::string("Message descriptor not found: ") + std::to_string(wire_number));
+      }
+      messageName = thpName.substr(strlen("ThpMessageType_"));
+    }
     return MessageMapper::get_message(messageName);
   }
 
   google::protobuf::Message * MessageMapper::get_message(const std::string & msg_name) {
-    // Each package instantiation so lookup works
+    // Force one symbol from each package's generated .pb.cc to be linked
+    // in, so the protobuf DescriptorPool below can resolve message names
+    // by package.  default_instance() is [[nodiscard]] in newer protobuf;
+    // the (void) cast documents that we only want the side effect.
     (void)hw::trezor::messages::common::Success::default_instance();
     (void)hw::trezor::messages::management::Cancel::default_instance();
     (void)hw::trezor::messages::monero::MoneroGetAddress::default_instance();
+    (void)hw::trezor::messages::thp::ThpPairingRequest::default_instance();
 
 #ifdef WITH_TREZOR_DEBUGGING
-    hw::trezor::messages::debug::DebugLinkDecision::default_instance();
+    (void)hw::trezor::messages::debug::DebugLinkDecision::default_instance();
 #endif
 
     google::protobuf::Descriptor const * desc = nullptr;
@@ -125,11 +151,28 @@ namespace trezor
 
     messages::MessageType res;
     bool r = hw::trezor::messages::MessageType_Parse(enumMessageName, &res);
-    if (!r){
-      throw exc::EncodingException(std::string("Message ") + msg_name + " not found");
+    if (r){
+      return res;
     }
 
-    return res;
+    // THP-specific message types live in ThpMessageType (1008..1041). The
+    // wire numbers are unique across the two enums (THP reserves 0..999 and
+    // 1100..max for the main MessageType enum), so we can return them as
+    // messages::MessageType safely.
+    string thpEnumName = std::string("ThpMessageType_") + msg_name;
+    hw::trezor::messages::thp::ThpMessageType thp_res;
+    if (hw::trezor::messages::thp::ThpMessageType_Parse(thpEnumName, &thp_res)) {
+      return static_cast<messages::MessageType>(thp_res);
+    }
+
+    // ThpCreateNewSession is "reserved 1000" in both MessageType and
+    // ThpMessageType, so neither Parse call above resolves it. The message
+    // class is still generated and the firmware accepts wire type 1000.
+    if (msg_name == "ThpCreateNewSession") {
+      return static_cast<messages::MessageType>(THP_CREATE_NEW_SESSION_WIRE);
+    }
+
+    throw exc::EncodingException(std::string("Message ") + msg_name + " not found");
   }
 
 #ifdef PROTOBUF_HAS_ABSEIL

--- a/src/device_trezor/trezor/protob/README.md
+++ b/src/device_trezor/trezor/protob/README.md
@@ -1,0 +1,67 @@
+# Vendored Trezor protobuf definitions
+
+The `.proto` files in this directory come from Trezor's `trezor-common`
+repository. They are refreshed by `../fetch_protob.sh`, which is a hand-run
+developer tool: the build compiles the committed files with `protoc` at
+configure time (see `cmake/CheckTrezor.cmake`) and never runs the script.
+
+Upstream: <https://github.com/trezor/trezor-common>
+
+| File | Pinned revision |
+| ---- | --------------- |
+| `messages.proto`, `messages-common.proto`, `messages-monero.proto`, `messages-management.proto`, `messages-debug.proto`, `COPYING` | `bc28c316d05bf1e9ebfe3d7df1ab25831d98d168` |
+| `messages-thp.proto` | `ff5f1525632ab09b286f765e5583df5207e222b7` |
+
+`messages-thp.proto` carries the Trezor Host Protocol v2 message set, which
+did not exist at the older pin. Taking it from a later revision of the same
+repository keeps the vendoring to a single upstream. Bumping the older pin
+instead would rewrite all five files above, including semantic changes to
+`messages-monero.proto` that have nothing to do with THP.
+
+## Licence
+
+`COPYING` in this directory is a verbatim copy of `COPYING` at the root of
+`trezor-common`. It is the GNU Lesser General Public License version 3.
+SPDX identifier: `LGPL-3.0-only`. Upstream ships no per-file licence headers
+and makes no "or any later version" election, so the bare LGPL-3.0 text is
+the whole grant.
+
+`trezor-common` is a read-only export of the `common/` directory of the
+`trezor-firmware` monorepo. The same files inside that monorepo are governed
+by `common/COPYING`, which is the same LGPL-3.0 text. They are not governed
+by `trezor-firmware`'s repository-root `COPYING`, which is GPL-3.0 and
+covers the firmware itself.
+
+## Local modifications
+
+`messages-thp.proto` is not a byte-for-byte copy of upstream.
+`fetch_protob.sh` applies exactly two edits, and nothing else in the file is
+touched:
+
+  1. `import "options.proto";` becomes `import "messages.proto";`. This tree
+     does not vendor `options.proto`. Every custom option the file uses
+     (`wire_in`, `wire_out`, `bitcoin_only`, `include_in_bitcoin_only`) is
+     declared in `messages.proto` at the pin above. Vendoring
+     `options.proto` as well is not an alternative: it declares the same
+     extension numbers as `messages.proto`, and protoc rejects the
+     duplicates.
+  2. `option (wire_enum) = true;` and `option (internal_only) = true;` are
+     deleted, six lines in total. Both extensions are declared in
+     `options.proto` only, so protoc cannot resolve them here. They are
+     metadata for trezor-firmware's own code generator and change neither
+     the wire format nor the generated C++.
+
+To reproduce the vendored file:
+
+```shell
+git clone https://github.com/trezor/trezor-common.git
+git -C trezor-common show ff5f1525632ab09b286f765e5583df5207e222b7:protob/messages-thp.proto \
+  | sed -e 's|^import "options.proto";|import "messages.proto";|' \
+        -e '/option (wire_enum) = true;/d' \
+        -e '/option (internal_only) = true;/d'
+```
+
+The other files are verbatim copies of upstream at the pin above, with one
+exception: `messages-management.proto` carries a one-word comment typo fix
+made in this tree by commit `2c327aa32` ("fix spelling in comments and
+docs").

--- a/src/device_trezor/trezor/protob/messages-thp.proto
+++ b/src/device_trezor/trezor/protob/messages-thp.proto
@@ -1,0 +1,283 @@
+syntax = "proto2";
+package hw.trezor.messages.thp;
+
+import "messages.proto";
+
+// Sugar for easier handling in Java
+option java_outer_classname = "TrezorMessageThp";
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+
+// Include in BTC-only firmware
+option (include_in_bitcoin_only) = true;
+
+/**
+ * Mapping between Trezor wire identifier (uint) and a Thp protobuf message
+ */
+enum ThpMessageType {
+
+    reserved 0 to 19;  // values reserved by other messages, see messages.proto
+    ThpMessageType_Cancel = 20;
+    reserved 21 to 25;
+    ThpMessageType_ButtonRequest = 26;
+    ThpMessageType_ButtonAck = 27;
+    reserved 28 to 999;
+    reserved 1000;          // MessageType_ThpCreateNewSession
+    reserved 1001 to 1007;  // never appeared in a release, reserved for future use
+    ThpMessageType_ThpPairingRequest = 1008 [(wire_in) = true];
+    ThpMessageType_ThpPairingRequestApproved = 1009 [(wire_out) = true];
+    ThpMessageType_ThpSelectMethod = 1010 [(wire_in) = true];
+    ThpMessageType_ThpPairingPreparationsFinished = 1011 [(wire_out) = true];
+    reserved 1012 to 1015;  // never appeared in a release, reserved for future use
+    ThpMessageType_ThpCredentialRequest = 1016 [(wire_in) = true, (bitcoin_only) = true];
+    ThpMessageType_ThpCredentialResponse = 1017 [(wire_out) = true, (bitcoin_only) = true];
+    ThpMessageType_ThpEndRequest = 1018 [(wire_in) = true];
+    ThpMessageType_ThpEndResponse = 1019 [(wire_out) = true];
+    reserved 1020 to 1023;  // never appeared in a release, reserved for future use
+    ThpMessageType_ThpCodeEntryCommitment = 1024 [(wire_out) = true];
+    ThpMessageType_ThpCodeEntryChallenge = 1025 [(wire_in) = true];
+    ThpMessageType_ThpCodeEntryCpaceTrezor = 1026 [(wire_out) = true];
+    ThpMessageType_ThpCodeEntryCpaceHostTag = 1027 [(wire_in) = true];
+    ThpMessageType_ThpCodeEntrySecret = 1028 [(wire_out) = true];
+    reserved 1029 to 1031;  // never appeared in a release, reserved for future use
+    ThpMessageType_ThpQrCodeTag = 1032 [(wire_in) = true];
+    ThpMessageType_ThpQrCodeSecret = 1033 [(wire_out) = true];
+    reserved 1034 to 1039;  // never appeared in a release, reserved for future use
+    ThpMessageType_ThpNfcTagHost = 1040 [(wire_in) = true];
+    ThpMessageType_ThpNfcTagTrezor = 1041 [(wire_out) = true];
+    reserved 1042 to 1099;        // never appeared in a release, reserved for future use
+    reserved 1100 to 2147483647;  // values reserved by other messages, see messages.proto
+}
+
+/**
+ * Numeric identifiers of pairing methods.
+ * @embed
+ */
+enum ThpPairingMethod {
+    SkipPairing = 1;  // Trust without MITM protection.
+    CodeEntry = 2;    // User rewrites code displayed on Trezor into the host application.
+    QrCode = 3;       // User scans QR-code displayed on Trezor into the host application.
+    NFC = 4;          // Trezor and host application exchange authentication secrets via NFC.
+}
+
+/**
+ * @embed
+ */
+message ThpDeviceProperties {
+    required string internal_model = 1;               // Internal model name, e.g. "T2B1".
+    optional uint32 model_variant = 2 [default = 0];  // Encodes the device properties such as color.
+    required uint32 protocol_version_major = 3;       // The major version of the communication protocol
+                                                      // used by the firmware.
+    required uint32 protocol_version_minor = 4;       // The minor version of the communication protocol
+                                                      // used by the firmware.
+    repeated ThpPairingMethod pairing_methods = 5;    // Pairing methods supported by the Trezor.
+}
+
+/**
+ * @embed
+ */
+message ThpHandshakeCompletionReqNoisePayload {
+    optional bytes host_pairing_credential = 1;  // Host's pairing credential
+}
+
+/**
+ * Request: Ask device for a new session with given passphrase.
+ * @start
+ * @next Success
+ */
+message ThpCreateNewSession {
+    optional string passphrase = 1;
+    optional bool on_device = 2 [default = false];       // User wants to enter passphrase on the device
+    optional bool derive_cardano = 3 [default = false];  // If True, Cardano keys will be derived. Ignored with BTC-only
+}
+
+/**
+ * Request: Start pairing process.
+ * @start
+ * @next ThpPairingRequestApproved
+ */
+message ThpPairingRequest {
+    required string host_name = 1;  // Human-readable host name (browser name for web apps)
+    required string app_name = 2;   // Human-readable application name
+}
+
+/**
+ * Response: Host is allowed to start pairing process.
+ * @start
+ * @next ThpSelectMethod
+ */
+message ThpPairingRequestApproved {}
+
+/**
+ * Request: Start pairing using the method selected.
+ * @start
+ * @next ThpPairingPreparationsFinished
+ * @next ThpCodeEntryCommitment
+ */
+message ThpSelectMethod {
+    required ThpPairingMethod selected_pairing_method = 1;  // Pairing method selected by the host
+}
+
+/**
+ * Response: Pairing is ready for user input / OOB communication.
+ * @next ThpCodeEntryCpace
+ * @next ThpQrCodeTag
+ * @next ThpNfcTagHost
+ */
+message ThpPairingPreparationsFinished {}
+
+/**
+ * Response: If Code Entry is an allowed pairing option, Trezor responds with a commitment.
+ * @next ThpCodeEntryChallenge
+ */
+message ThpCodeEntryCommitment {
+    required bytes commitment = 1;  // SHA-256 of Trezor's random 32-byte secret
+}
+
+/**
+ * Response: Host responds to Trezor's Code Entry commitment with a challenge.
+ * @next ThpCodeEntryCpaceTrezor
+ */
+message ThpCodeEntryChallenge {
+    required bytes challenge = 1;  // Host's random 32-byte challenge
+}
+
+/**
+ * Response: Trezor continues with the CPACE protocol.
+ * @next ThpCodeEntryCpaceHostTag
+ */
+message ThpCodeEntryCpaceTrezor {
+    required bytes cpace_trezor_public_key = 1;  // Trezor's ephemeral CPace public key
+}
+
+/**
+ * Request: User selected Code Entry option in Host. Host starts CPACE protocol with Trezor.
+ * @next ThpCodeEntrySecret
+ */
+message ThpCodeEntryCpaceHostTag {
+    required bytes cpace_host_public_key = 1;  // Host's ephemeral CPace public key
+    required bytes tag = 2;                    // SHA-256 of shared secret
+}
+
+/**
+ * Response: Trezor finishes the CPACE protocol.
+ * @next ThpCredentialRequest
+ * @next ThpEndRequest
+ */
+message ThpCodeEntrySecret {
+    required bytes secret = 1;  // Trezor's secret
+}
+
+/**
+ * Request: User selected QR Code pairing option. Host sends a QR Tag.
+ * @next ThpQrCodeSecret
+ */
+message ThpQrCodeTag {
+    required bytes tag = 1;  // SHA-256 of shared secret
+}
+
+/**
+ * Response: Trezor sends the QR secret.
+ * @next ThpCredentialRequest
+ * @next ThpEndRequest
+ */
+message ThpQrCodeSecret {
+    required bytes secret = 1;  // Trezor's secret
+}
+
+/**
+ * Request: User selected Unidirectional NFC pairing option. Host sends an Unidirectional NFC Tag.
+ * @next ThpNfcTagTrezor
+ */
+message ThpNfcTagHost {
+    required bytes tag = 1;  // Host's tag
+}
+
+/**
+ * Response: Trezor sends the Unidirectioal NFC secret.
+ * @next ThpCredentialRequest
+ * @next ThpEndRequest
+ */
+message ThpNfcTagTrezor {
+    required bytes tag = 1;  // Trezor's tag
+}
+
+/**
+ * Request: Host requests issuance of a new pairing credential.
+ * @start
+ * @next ThpCredentialResponse
+ */
+message ThpCredentialRequest {
+    required bytes host_static_public_key = 1;        // Host's static public key identifying the credential.
+    optional bool autoconnect = 2 [default = false];  // Whether the host wants to autoconnect without user confirmation
+    optional bytes credential = 3;                    // Host's previous credential
+}
+
+/**
+ * Response: Trezor issues a new pairing credential.
+ * @next ThpCredentialRequest
+ * @next ThpEndRequest
+ */
+message ThpCredentialResponse {
+    required bytes trezor_static_public_key = 1;  // Trezor's static public key used in the handshake.
+    required bytes credential = 2;                // The pairing credential issued by the Trezor to the host.
+}
+
+/**
+ * Request: Host requests transition to the encrypted traffic phase.
+ * @start
+ * @next ThpEndResponse
+ */
+message ThpEndRequest {}
+
+/**
+ * Response: Trezor approves transition to the encrypted traffic phase
+ * @end
+ */
+message ThpEndResponse {}
+
+/**
+ * Only for internal use.
+ * @embed
+ */
+message ThpCredentialMetadata {
+    required string host_name = 1;  // Human-readable host name (browser name for web apps)
+    optional bool autoconnect = 2;  // Whether host is allowed to autoconnect without user confirmation
+    required string app_name = 3;   // Human-readable application name
+}
+
+/**
+ * Only for internal use.
+ * @embed
+ */
+message ThpPairingCredential {
+    required ThpCredentialMetadata cred_metadata = 1;  // Credential metadata
+    required bytes mac = 2;                            // Message authentication code generated by the Trezor
+}
+
+/**
+ * Only for internal use.
+ * @embed
+ */
+message ThpAuthenticatedCredentialData {
+    required bytes host_static_public_key = 1;         // Host's static public key used in the handshake
+    required ThpCredentialMetadata cred_metadata = 2;  // Credential metadata
+}
+
+/**
+ * Recent THP paired hosts.
+ * Only for internal use.
+ * @embed
+ */
+message ThpPairedCache {
+    repeated ThpPairedCacheEntry entries = 1;
+
+    /**
+     * Only for internal use.
+     * @embed
+     */
+    message ThpPairedCacheEntry {
+        required bytes mac_addr = 1;    // 6-byte MAC address
+        required string host_name = 2;  // Human-readable host name (≤32 bytes)
+        required string app_name = 3;   // Human-readable application name (≤32 bytes)
+    }
+}

--- a/src/device_trezor/trezor/thp/README.md
+++ b/src/device_trezor/trezor/thp/README.md
@@ -1,0 +1,182 @@
+# Trezor Host Protocol v2 (THP) over USB
+
+This directory implements the host side of the Trezor Host Protocol v2, the
+end-to-end-encrypted wire protocol that the Trezor Safe 7, and any future
+Trezor device that drops the legacy v1 protocol, speaks exclusively. The
+transport is USB: THP frames are carried in 64-byte USB-HID packets, the same
+carrier the existing v1 transports use. The protocol is specified at:
+
+  - <https://docs.trezor.io/trezor-firmware/common/thp/specification.html>
+  - `docs/common/thp/specification.md` in trezor-firmware at commit
+    `4c8a38f294d02bf092ec7995f4ae2274317b259d`.
+
+THP is built on the Noise Protocol Framework
+(`Noise_XX_25519_AESGCM_SHA256`), with one deviation described under
+"Relationship to stock Noise XX" below.
+
+## Layout
+
+| File | Purpose |
+| ---- | ------- |
+| `framing.{hpp,cpp}` | Wire-level segmentation. `encode_frame` produces 64-byte USB chunks; `FrameAssembler` reassembles them and checks the CRC-32 trailer, computed with `boost::crc_32_type` (CRC-32/ISO-HDLC, the same function the device uses). |
+| `noise.{hpp,cpp}` | Cryptographic primitives (X25519, SHA-256, HMAC-SHA-256, THP HKDF, AES-256-GCM, Trezor static-key masking) and the `NoiseXxInitiator` state machine that runs the host side of the handshake (HH0, HH1, HH2/HH3). |
+| `pairing.{hpp,cpp}` | CodeEntry pairing FSM (host side). Runs the CPace exchange (IRTF `CPACE-X25519-SHA512` symmetric suite) so the user can confirm the 6-digit code the Trezor displays and the device can issue a long-lived credential. |
+| `protocol_v2.{hpp,cpp}` | Channel allocation on the broadcast CID 0xFFFF, and `ProtocolV2 : public Protocol`, a drop-in replacement for `ProtocolV1` that performs allocation and handshake on `session_begin` and AES-GCM-seals or opens application traffic on `write` / `read`. |
+| `auto_detect.{hpp,cpp}` | `ProtocolAutoDetect : public Protocol`. Probes the attached device once and selects v1 or THP, then runs first-pairing (CodeEntry) and persists the device credential. |
+| `store.{hpp,cpp}` | TOFU device-credential store. Remembers paired devices (trust on first use) so CodeEntry only runs once per device. |
+
+## Protocol selection
+
+`transport.cpp` installs `ProtocolAutoDetect` by default. On the first
+`open()` it sends a `ChannelAllocationRequest` on the broadcast CID (a single
+64-byte USB packet that `framing.cpp` produces) and inspects the reply: a
+`ChannelAllocationResponse` means a THP device (Safe 7) and the
+freshly-allocated channel is reused; the legacy v1 magic (or no THP response)
+selects `ProtocolV1` for a Model T or earlier device. The decision is cached
+per device-path so a single probe per attach suffices.
+
+Two environment variables override the probe, mainly for diagnostics:
+
+  - `TREZOR_FORCE_THP=1` always uses `ProtocolV2` (skip the probe).
+  - `TREZOR_FORCE_V1=1` always uses `ProtocolV1` (skip the probe), useful if
+    the THP probe misbehaves on a particular USB stack.
+
+## Pairing
+
+The handshake produces a confidential channel but, on its own, only gives
+weak (TOFU) authentication of the device. Per the spec, mutual authentication
+requires a one-time pairing step in which the user confirms a 6-digit code
+displayed on the Trezor, after which Trezor issues a long-lived credential
+the host can present on subsequent connections.
+
+`pairing.cpp` implements the CodeEntry method: it runs the CPace exchange
+(IRTF `CPACE-X25519-SHA512` symmetric suite) seeded with the user-entered
+code, then verifies the device's commitment before accepting the issued
+credential. The pairing-code prompt is supplied by the host or GUI through
+the `on_pairing_code_request` callback that the device-glue layer registers;
+the resulting credential is persisted by `store.cpp` so the CodeEntry flow
+runs only once per device.
+
+## Credential store
+
+`store.cpp` keeps the host static keypair and one credential per paired
+device in a single file, `<data dir>/.trezor/thp_store.bin`, where the data
+directory is chosen by `device_trezor_base.cpp` and is always **per user and
+per network**:
+
+  - POSIX: `tools::get_default_data_dir()`, i.e. `~/.bitmonero`, with
+    `testnet/`, `stagenet/` or `fake/` appended for the non-mainnet networks.
+  - Windows: `CSIDL_APPDATA\<CRYPTONOTE_NAME>` rather than the
+    `CSIDL_COMMON_APPDATA` that `get_default_data_dir()` resolves to. The
+    common folder is shared by every local account on the machine, and the
+    file holds a private key in the clear.
+
+The layout is tag-prefixed records, documented field by field at the top of
+`store.hpp`. Unknown tags are skipped on load, so the format can grow without
+breaking an older wallet's file.
+
+**The host static private key is written in plaintext.** That matches the
+existing Trezor v1 flow, which persists hardware-wallet state without
+additional encryption, but it only holds up while the file is unreadable to
+other local accounts. So:
+
+  - the `.trezor` directory is created and then `chmod`ed to `S_IRWXU`
+    (0700), because `create_directories()` honours the umask and would
+    otherwise leave it group- and world-readable;
+  - on POSIX the file is written through `tools::private_file::create(...,
+    O_EXCL)`, which opens it 0600, exclusively and flock-held, and unlinks it
+    from its destructor, so no failure path strands the private key in a temp
+    file. It is `fsync`ed and then moved into place with
+    `tools::replace_file`, so a reader never sees a half-written store;
+  - on Windows `private_file` cannot be used, because it opens with
+    `FILE_FLAG_DELETE_ON_CLOSE` and the file has to survive the close that
+    precedes the rename. The temp file there goes through
+    `epee::file_io_utils::save_string_to_file`, is flushed, and is removed
+    explicitly on every failure path. Confidentiality there comes from the
+    per-user directory, which is why `default_path()` *requires* one rather
+    than setting a DACL of its own;
+  - the temp-file suffix is drawn from the CSPRNG on both, so a temp name
+    cannot be planted in advance and hijacked.
+
+Deleting the file is safe and costs only a re-pairing: the next connect
+regenerates a host static key and runs CodeEntry again.
+
+## Relationship to stock Noise XX
+
+THP instantiates `Noise_XX_25519_AESGCM_SHA256` as the Noise Protocol
+Framework defines it, revision 34. There is exactly one deviation, plus two
+constructions that read like deviations but are not. Both kinds are recorded
+here, because both cost time to establish when reading this code against the
+framework.
+
+The one real deviation is **Trezor static-key masking**. In stock XX the
+responder's message carries its static public key; in THP it carries
+`X25519(SHA-256(static_pub || eph_pub), static_pub)` instead, and the host
+uses that masked value directly as the peer static key for the `es` DH and
+the HKDF that follows. The device's ephemeral key is fresh on every
+connection, so the masked value rotates every session and cannot be used to
+recognise a device from the wire. Recognising a previously paired device
+therefore means recomputing the mask over each stored static key with this
+session's device ephemeral key and comparing, which is what
+`NoiseXxInitiator::consume_init_response` does.
+
+Two constructions that are stock Noise and must not be "corrected":
+
+  - **The initial chaining key is the literal protocol name, not its hash.**
+    `Noise_XX_25519_AESGCM_SHA256` is 28 ASCII bytes, and with the four
+    trailing NUL bytes it is exactly 32 bytes, which is HASHLEN. Section 5.2
+    (`InitializeSymmetric`) says to zero-pad rather than hash in that case,
+    and then to set `ck = h`. `PROTOCOL_NAME` in `noise.cpp` is that 32-byte
+    value and is passed straight into the first HKDF.
+  - **The device properties are mixed into `h` before the ephemeral keys.**
+    That is `MixHash(prologue)` from section 5.3 (`HandshakeState`), with the
+    `DeviceProperties` blob from `ChannelAllocationResponse` as the prologue.
+    Binding the allocation response into the handshake hash is what stops a
+    device from downgrading the pairing methods it advertised.
+
+Nonce encoding is stock too, at every counter value and not just at 0 and 1.
+Section 12.4 (AESGCM) specifies the 96-bit nonce as 32 zero bits followed by
+the **big-endian** encoding of `n`; little-endian belongs to ChaChaPoly in
+section 12.3. `crypto::iv_for_nonce` writes four zero bytes followed by the
+64-bit counter big-endian, which is exactly what the spec's `0^96` (counter
+0) and `0^95 || 1` (counter 1) notation denotes, and it matches the firmware:
+`full_nonce[4..].copy_from_slice(&nonce_counter.to_be_bytes())` in
+`core/embed/rust/src/thp/crypto.rs`.
+
+## Test vectors
+
+The deterministic upstream vectors used by
+`tests/unit_tests/device_trezor_thp.cpp` (AES-GCM under THP-derived IVs, the
+THP HKDF cascade, the IV layout, CRC-32, and a byte-exact wire fixture) were
+taken from trezor-firmware at commit
+`bc97a6b2b00068cb36a13da27ddaba8306314870`:
+
+  - `core/tests/test_trezor.wire.thp.crypto.py`
+  - `core/tests/test_trezor.wire.thp.checksum.py`
+  - `core/tests/test_trezor.wire.thp.writer.py`
+
+Upstream deleted all three in commit
+`00ec9a7f8b6388f45e7825f48d6cb5b42d27d795` ("feat(core): switch from Python
+THP implementation to Rust-based one"), and the Rust implementation that
+replaced them ships no vector tables, so `bc97a6b2b` is the last revision at
+which the published vectors can be read. That is why they are cited by commit
+rather than by branch.
+
+The remaining vectors come from the RFCs listed below, and the handshake as a
+whole is exercised end to end against an in-process simulator that follows
+the spec's state machine
+(`device_trezor_thp.cpp:thp_handshake.full_handshake_self_test`).
+
+## References
+
+  - THP specification: <https://docs.trezor.io/trezor-firmware/common/thp/>
+  - Noise Protocol Framework, revision 34: <https://noiseprotocol.org/noise.html>
+  - RFC 7748 (X25519): <https://datatracker.ietf.org/doc/html/rfc7748>
+  - RFC 4231 (HMAC-SHA-256 test vectors): <https://datatracker.ietf.org/doc/html/rfc4231>
+  - RFC 5869 (HKDF). THP's HKDF is Noise's own two-output HKDF from section
+    4.3, which is HKDF-Extract followed by HKDF-Expand with an empty info
+    string: <https://datatracker.ietf.org/doc/html/rfc5869>
+  - draft-irtf-cfrg-cpace (CPace, used by CodeEntry pairing): <https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-cpace>
+  - NIST SP 800-38D (AES-GCM): <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf>
+  - Upstream tracking issue (Monero core): <https://github.com/monero-project/monero/issues/10368>
+  - Upstream tracking issue (Monero GUI): <https://github.com/monero-project/monero-gui/issues/4517>

--- a/src/device_trezor/trezor/thp/auto_detect.cpp
+++ b/src/device_trezor/trezor/thp/auto_detect.cpp
@@ -1,0 +1,427 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "auto_detect.hpp"
+#include "pairing.hpp"
+#include "store.hpp"
+#include "../exceptions.hpp"
+#include "../messages/messages-thp.pb.h"
+#include "../messages/messages-common.pb.h"
+
+#include <cstring>
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "device.trezor.thp"
+
+namespace hw { namespace trezor { namespace thp {
+
+  ProtocolAutoDetect::ProtocolAutoDetect(bool force_thp)
+    : m_force_thp(force_thp) {}
+  ProtocolAutoDetect::~ProtocolAutoDetect() = default;
+
+  void ProtocolAutoDetect::configure(const ProtocolConfig &config)
+  {
+    m_config = config;
+  }
+
+  AllocatedChannel ProtocolAutoDetect::probe_thp(Transport &transport)
+  {
+    AllocatedChannel allocation;
+    const AllocationResult res = allocate_channel(transport, allocation);
+    if (res == AllocationResult::codec_v1_reply) {
+      throw exc::TimeoutException("THP: device replied with codec_v1; protocol-v1 device");
+    }
+    if (res != AllocationResult::allocated) {
+      throw exc::TimeoutException("THP: no channel allocation response");
+    }
+    return allocation;
+  }
+
+  void ProtocolAutoDetect::session_begin(Transport &transport)
+  {
+    if (m_actual) {
+      // Already opened.
+      m_actual->session_begin(transport);
+      return;
+    }
+
+    // Load the persistent THP store, if a path was configured.  This
+    // gives us the host static key and any prior pairing credentials.
+    ThpStore store;
+    bool have_store_path = !m_config.store_path.empty();
+    if (have_store_path) {
+      store.load_or_init(m_config.store_path);
+    }
+
+    // A Safe 7 answers the allocation in milliseconds; a protocol-v1
+    // device (Model T / Safe 3 / Safe 5) either stays silent or answers
+    // with a codec_v1 report, and probe_thp reports both as a timeout.
+    // Only a timeout falls back to V1: libusb stalls, encoding errors
+    // and security failures are real faults and must propagate, or a
+    // Safe 7 with a communication problem is reported as a V1 failure.
+    AllocatedChannel allocation;
+    try {
+      allocation = probe_thp(transport);
+    } catch (const exc::TimeoutException &e) {
+      if (m_force_thp) {
+        // Diagnostics asked for THP explicitly (TREZOR_FORCE_THP=1):
+        // surface the probe failure instead of masking it with a V1
+        // session that would fail differently.
+        throw;
+      }
+      MDEBUG("THP probe: " << e.what() << "; falling back to ProtocolV1");
+      m_actual   = std::make_shared<ProtocolV1>();
+      m_selected = "v1";
+      return;
+    }
+
+    MINFO("THP detected on channel " << allocation.channel_id);
+    auto v2 = std::make_shared<ProtocolV2>();
+
+    // Decide on host static key + known devices to feed the handshake.
+    if (have_store_path) {
+      HostStaticKey host_static = store.host_static();
+      if (host_static.pub == NoisePubKey{} || host_static.priv == NoisePrivKey{}) {
+        noise_crypto::x25519_keypair(host_static.pub, host_static.priv);
+        store.set_host_static(host_static);
+        try { store.save(m_config.store_path); }
+        catch (const std::exception &e) {
+          MWARNING("THP store: host static key save failed: " << e.what());
+        }
+      }
+      v2->set_host_static_key(host_static);
+      v2->set_known_devices(store.known_devices());
+    }
+
+    v2->adopt_allocation(allocation);
+    v2->session_begin(transport);
+
+    // We do NOT promote `v2` to `m_actual` until the full unpaired-or-paired
+    // routing decision is made and any pairing FSM has succeeded. If
+    // session_begin() succeeded but pairing then throws, m_actual must
+    // remain null so the next session_begin() retries from scratch
+    // rather than short-circuiting on the cached partial state.
+    auto promote = [&]() {
+      m_actual   = v2;
+      m_selected = "v2";
+    };
+
+    if (v2->trezor_state() == STATE_UNPAIRED) {
+      if (!m_config.pairing_prompt) {
+        // STATE_UNPAIRED with no prompt configured: fail closed; the
+        // application traffic phase isn't trustworthy without pairing.
+        throw exc::SecurityException(
+            "THP: device is unpaired and no pairing prompt is configured "
+            "(set ProtocolConfig::pairing_prompt before session_begin)");
+      }
+      // Make m_v2 visible to run_code_entry_pairing; reset it (and any
+      // partial promotion state) on any failure so the next reconnect
+      // starts clean. The credential round-trip and promote() sit in the
+      // same try/catch as pairing, so a Failure from the device during
+      // credential issuance cannot leave m_v2 dangling.
+      m_v2 = v2;
+      try {
+        run_code_entry_pairing(transport);
+
+        // Credential round-trip on TC1, only if we have a store to
+        // persist the credential to. Without persistence, requesting a
+        // credential is pointless (we'd lose it on shutdown).
+        if (have_store_path) {
+          const auto &hs = v2->host_static();
+          messages::thp::ThpCredentialRequest creq;
+          creq.set_host_static_public_key(reinterpret_cast<const char *>(hs.pub.data()),
+                                          hs.pub.size());
+          v2->write(transport, creq);
+
+          auto resp_msg = read_handling_buttons(transport, "ThpCredentialResponse");
+          auto cresp = std::dynamic_pointer_cast<messages::thp::ThpCredentialResponse>(resp_msg);
+          if (!cresp) {
+            throw exc::ProtocolException("THP: expected ThpCredentialResponse");
+          }
+
+          // ThpCredentialResponse delivers the device's *unmasked* static
+          // pubkey alongside the credential; the InitResponse only carries
+          // the masked form. We store the unmasked form so subsequent
+          // sessions can recompute the mask against each session's fresh
+          // device ephemeral pubkey.
+          const std::string &dev_static = cresp->trezor_static_public_key();
+          if (dev_static.size() != 32) {
+            throw exc::ProtocolException("THP: ThpCredentialResponse: bad trezor_static_public_key size");
+          }
+          KnownDevice kd;
+          std::memcpy(kd.trezor_static_pubkey.data(), dev_static.data(), 32);
+          kd.host_static = hs;
+          const std::string &cred = cresp->credential();
+          kd.pairing_credential.assign(cred.begin(), cred.end());
+          store.upsert_known_device(kd);
+          // The device has already issued the credential, so a store that
+          // cannot be written costs one re-pair on the next connect. It is
+          // not a reason to fail an open the user has just worked for.
+          try { store.save(m_config.store_path); }
+          catch (const std::exception &e) {
+            MWARNING("THP store: credential save failed, the device will "
+                     "have to be paired again: " << e.what());
+          }
+        }
+
+        // Always send ThpEndRequest after pairing completes, whether or not
+        // a credential was requested, to transition the device out of TC1
+        // (credential phase) and into the encrypted-transport state.
+        // Without this, the next message lands in TC1 and is rejected as
+        // "Message unrecognized in pairing context".
+        thp_end_then_create_app_session(transport);
+        promote();
+      } catch (...) {
+        m_v2.reset();
+        throw;
+      }
+    } else if (v2->trezor_state() == STATE_PAIRED ||
+               v2->trezor_state() == STATE_PAIRED_AUTOCONNECT) {
+      // The device claims a paired session. Trust it only if our store
+      // contains a matching unmasked static pubkey (TOFU). A device that
+      // reports paired status without a store entry is either a fresh
+      // device we somehow lost the credential for, or an attempted spoof.
+      if (!v2->is_known_device()) {
+        throw exc::SecurityException(
+            "THP: device claims paired status but is not in our known-devices "
+            "list. The pairing store may have been deleted or the device may "
+            "have been swapped. Re-pair the device by deleting "
+            ".trezor/thp_store.bin under the Monero data directory.");
+      }
+      // Per THP spec (states TC1 / HC0): after HandshakeCompletionResponse with
+      // STATE_PAIRED, the device is in the *credential phase* (TC1) and only
+      // accepts ThpCredentialRequest or ThpEndRequest. We must send ThpEndRequest
+      // to transition the device to the transport state before any application
+      // traffic; otherwise the device returns "Message unrecognized in pairing
+      // context" for the first GetFeatures / MoneroGetAddress / etc. The
+      // unpaired branch above already does this implicitly via the credential
+      // round-trip; this branch reuses an existing credential and so must
+      // emit a bare ThpEndRequest of its own.
+      m_v2 = v2;
+      try {
+        thp_end_then_create_app_session(transport);
+        promote();
+      } catch (...) {
+        m_v2.reset();
+        throw;
+      }
+    } else {
+      throw exc::ProtocolException(
+          "THP: device returned unknown state byte (got " +
+          std::to_string(int(v2->trezor_state())) + ")");
+    }
+  }
+
+  void ProtocolAutoDetect::thp_end_then_create_app_session(Transport &transport)
+  {
+    if (!m_v2) {
+      throw exc::ProtocolException("THP: thp_end_then_create_app_session without ProtocolV2");
+    }
+
+    // Phase 1: leave TC1 (credential phase) -> ENCRYPTED_TRANSPORT.
+    // The device may emit a ButtonRequest asking the user to confirm the
+    // reconnection (non-autoconnect credentials); read_handling_buttons
+    // ACKs it transparently.
+    {
+      messages::thp::ThpEndRequest end_req;
+      m_v2->write(transport, end_req);
+      auto end_resp = read_handling_buttons(transport, "ThpEndResponse");
+      if (!std::dynamic_pointer_cast<messages::thp::ThpEndResponse>(end_resp)) {
+        throw exc::ProtocolException("THP: expected ThpEndResponse");
+      }
+    }
+
+    // Phase 2: allocate a seeded application session. Without this, the
+    // device routes app traffic to a SeedlessSessionContext whose .cache
+    // raises InvalidSessionError, which firmware translates to
+    // Failure(code=14, "Invalid session"). The host picks session_id=1;
+    // the device's handle_ThpCreateNewSession (apps/base.py) then runs
+    // lock_manager.unlock_device (PIN unlock if locked, may emit
+    // ButtonRequest), derive_and_store_roots, and replies Success.
+    constexpr uint8_t APP_SESSION_ID = 0x01;
+    m_v2->set_session_id(APP_SESSION_ID);
+
+    messages::thp::ThpCreateNewSession sess_req;
+    sess_req.set_passphrase("");          // STANDARD_WALLET (no Trezor passphrase)
+    sess_req.set_derive_cardano(false);
+    try {
+      m_v2->write(transport, sess_req);
+      auto sess_resp = read_handling_buttons(transport, "Success after ThpCreateNewSession");
+      if (!std::dynamic_pointer_cast<messages::common::Success>(sess_resp)) {
+        throw exc::ProtocolException("THP: expected Success after ThpCreateNewSession");
+      }
+    } catch (...) {
+      // Roll the session_id back so a retry starts from the management
+      // session and doesn't accidentally reuse a half-allocated id.
+      m_v2->set_session_id(0);
+      throw;
+    }
+
+    MINFO("THP: app session " << int(APP_SESSION_ID)
+          << " allocated on channel " << m_v2->channel_id());
+  }
+
+  std::shared_ptr<google::protobuf::Message>
+  ProtocolAutoDetect::read_handling_buttons(Transport &transport, const char *expected)
+  {
+    if (!m_v2) {
+      throw exc::ProtocolException("THP: read_handling_buttons without ProtocolV2");
+    }
+    std::shared_ptr<google::protobuf::Message> msg;
+    messages::MessageType mt;
+    while (true) {
+      m_v2->read(transport, msg, &mt);
+      if (std::dynamic_pointer_cast<messages::common::ButtonRequest>(msg)) {
+        messages::common::ButtonAck ack;
+        m_v2->write(transport, ack);
+        continue;
+      }
+      if (auto fail = std::dynamic_pointer_cast<messages::common::Failure>(msg)) {
+        // Map to the typed exception hierarchy (ActionCancelled ->
+        // CancelledException etc.) exactly like the V1 read path, so
+        // an on-device cancel during pairing classifies as a user
+        // cancellation rather than a generic protocol fault.
+        MDEBUG("THP: device returned Failure while waiting for " << expected);
+        throw_failure_exception(fail.get());
+      }
+      return msg;
+    }
+  }
+
+  void ProtocolAutoDetect::run_code_entry_pairing(Transport &transport)
+  {
+    if (!m_v2) {
+      throw exc::ProtocolException("THP: pairing without ProtocolV2");
+    }
+
+    // 1. Send ThpPairingRequest(host_name, app_name) and wait for
+    //    ThpPairingRequestApproved.
+    messages::thp::ThpPairingRequest preq;
+    preq.set_host_name(m_config.host_name);
+    preq.set_app_name(m_config.app_name);
+    m_v2->write(transport, preq);
+    {
+      auto msg = read_handling_buttons(transport, "ThpPairingRequestApproved");
+      if (!std::dynamic_pointer_cast<messages::thp::ThpPairingRequestApproved>(msg)) {
+        throw exc::ProtocolException("THP pairing: unexpected message after PairingRequest");
+      }
+    }
+
+    // 2. Send ThpSelectMethod(CodeEntry).
+    messages::thp::ThpSelectMethod sel;
+    sel.set_selected_pairing_method(messages::thp::CodeEntry);
+    m_v2->write(transport, sel);
+
+    // 3. Receive ThpCodeEntryCommitment, send ThpCodeEntryChallenge.
+    CodeEntryPairing pairing(m_v2->handshake_hash());
+    {
+      auto msg = read_handling_buttons(transport, "ThpCodeEntryCommitment");
+      auto cmt = std::dynamic_pointer_cast<messages::thp::ThpCodeEntryCommitment>(msg);
+      if (!cmt) throw exc::ProtocolException("THP pairing: expected ThpCodeEntryCommitment");
+      const std::string &c = cmt->commitment();
+      pairing.consume_commitment_build_challenge(
+          reinterpret_cast<const uint8_t *>(c.data()), c.size());
+      messages::thp::ThpCodeEntryChallenge ch;
+      ch.set_challenge(reinterpret_cast<const char *>(pairing.challenge().data()),
+                       pairing.challenge().size());
+      m_v2->write(transport, ch);
+    }
+
+    // 4. Receive ThpCodeEntryCpaceTrezor.
+    {
+      auto msg = read_handling_buttons(transport, "ThpCodeEntryCpaceTrezor");
+      auto ct = std::dynamic_pointer_cast<messages::thp::ThpCodeEntryCpaceTrezor>(msg);
+      if (!ct) throw exc::ProtocolException("THP pairing: expected ThpCodeEntryCpaceTrezor");
+      const std::string &k = ct->cpace_trezor_public_key();
+      pairing.consume_cpace_trezor(reinterpret_cast<const uint8_t *>(k.data()), k.size());
+    }
+
+    // 5. Prompt the user for the code, send ThpCodeEntryCpaceHostTag.
+    //    An empty return value from the prompt is treated as a user
+    //    cancellation, which is a clearer error than feeding empty into
+    //    the derivation and getting a CPace tag mismatch.
+    const epee::wipeable_string code = m_config.pairing_prompt();
+    if (code.empty()) {
+      throw exc::proto::CancelledException("THP pairing: cancelled by user");
+    }
+    const CpaceHostTag host_tag = pairing.build_host_tag(code);
+    messages::thp::ThpCodeEntryCpaceHostTag tag_msg;
+    tag_msg.set_cpace_host_public_key(host_tag.cpace_host_public_key.data(),
+                                      host_tag.cpace_host_public_key.size());
+    tag_msg.set_tag(host_tag.tag.data(), host_tag.tag.size());
+    m_v2->write(transport, tag_msg);
+
+    // 6. Receive ThpCodeEntrySecret, verify. If the user typed a wrong
+    //    code, Trezor's CPace tag check fails and the device returns a
+    //    Failure rather than ThpCodeEntrySecret; read_handling_buttons
+    //    throws FailureException, which the GUI surfaces as "wrong code,
+    //    try again".
+    {
+      auto msg = read_handling_buttons(transport, "ThpCodeEntrySecret");
+      auto sec = std::dynamic_pointer_cast<messages::thp::ThpCodeEntrySecret>(msg);
+      if (!sec) throw exc::ProtocolException("THP pairing: expected ThpCodeEntrySecret");
+      const std::string &s = sec->secret();
+      if (!pairing.consume_secret(reinterpret_cast<const uint8_t *>(s.data()), s.size())) {
+        throw exc::SecurityException(
+            "THP pairing: code mismatch (commitment / SHA-256 verification failed)");
+      }
+    }
+
+    MINFO("THP CodeEntry pairing succeeded");
+  }
+
+  void ProtocolAutoDetect::session_end(Transport &transport)
+  {
+    if (m_actual) {
+      m_actual->session_end(transport);
+      m_actual.reset();
+      m_v2.reset();
+      m_selected = "unknown";
+    }
+  }
+
+  void ProtocolAutoDetect::write(Transport &transport,
+                                 const google::protobuf::Message &req)
+  {
+    if (!m_actual) {
+      throw exc::ProtocolException("THP auto-detect: write before session_begin");
+    }
+    m_actual->write(transport, req);
+  }
+
+  void ProtocolAutoDetect::read(Transport &transport,
+                                std::shared_ptr<google::protobuf::Message> &msg,
+                                messages::MessageType *msg_type)
+  {
+    if (!m_actual) {
+      throw exc::ProtocolException("THP auto-detect: read before session_begin");
+    }
+    m_actual->read(transport, msg, msg_type);
+  }
+
+}}}

--- a/src/device_trezor/trezor/thp/auto_detect.hpp
+++ b/src/device_trezor/trezor/thp/auto_detect.hpp
@@ -1,0 +1,149 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef MONERO_TREZOR_THP_AUTO_DETECT_H
+#define MONERO_TREZOR_THP_AUTO_DETECT_H
+
+#include "device_trezor/trezor/transport.hpp"
+#include "noise.hpp"
+#include "wipeable_string.h"
+#include "protocol_v2.hpp"
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace hw { namespace trezor { namespace thp {
+
+  // Pairing UI hook: invoked by ProtocolAutoDetect when a fresh THP
+  // device requires CodeEntry pairing.  The host (GUI) renders a modal
+  // asking the user for the 6-digit code shown on the Trezor; the
+  // returned string is the code.  Throws on user cancel, which aborts
+  // the pairing flow and closes the channel.
+  using PairingPromptHook = std::function<epee::wipeable_string()>;
+
+  // Configuration plumbed into ProtocolAutoDetect from the device-glue
+  // layer.  All fields are optional except `pairing_prompt`, which must
+  // be non-null on first-time pairing.
+  struct ProtocolConfig {
+    std::string         host_name      = "Monero Wallet";
+    std::string         app_name       = "monero-wallet-gui";
+    PairingPromptHook   pairing_prompt;
+    // Path to the host static key + credentials store (created if absent).
+    // If empty, the host static key is generated fresh per session and not
+    // persisted (TOFU + no recognition of returning devices).
+    std::string         store_path;
+  };
+
+  // ProtocolAutoDetect defers protocol selection (v1 vs v2) until the
+  // first session_begin.  It probes the device by attempting a THP
+  // ChannelAllocationRequest.  If that succeeds, it transitions to
+  // ProtocolV2 (running the handshake, persisted-key lookup, and, on
+  // the unpaired path, the CodeEntry pairing FSM).  If the probe times
+  // out or returns a non-THP response, it falls back to ProtocolV1
+  // transparently.
+  //
+  // Lifecycle and threading match the existing Protocol contract: a
+  // single instance is bound to one open transport for the lifetime
+  // of the session.
+  class ProtocolAutoDetect : public Protocol {
+  public:
+    // force_thp: diagnostics knob (TREZOR_FORCE_THP=1).  The channel-
+    // allocation probe still runs, since THP always needs one, but a
+    // probe timeout propagates instead of silently selecting V1, so a
+    // misbehaving THP device is reported as such.  The full THP
+    // bring-up (pairing, credential store, app session) is unchanged.
+    explicit ProtocolAutoDetect(bool force_thp = false);
+    ~ProtocolAutoDetect() override;
+
+    // Caller wires up the GUI prompt and the persistent store path
+    // before session_begin.  May be called repeatedly until then.
+    void configure(const ProtocolConfig &config);
+
+    void session_begin(Transport &transport) override;
+    void session_end  (Transport &transport) override;
+    void write(Transport &transport,
+               const google::protobuf::Message &req) override;
+    void read (Transport &transport,
+               std::shared_ptr<google::protobuf::Message> &msg,
+               messages::MessageType *msg_type = nullptr) override;
+
+    // After session_begin, returns "v1" or "v2" ("unknown" before).
+    // Used by tests and diagnostics; not part of the Protocol contract.
+    // Compare the content (strcmp / std::string), not the pointer.
+    const char *selected_protocol() const { return m_selected; }
+
+
+  private:
+    // Attempt a THP channel-allocation handshake; returns the
+    // allocated channel on success, throws on any failure.  The
+    // caller swallows the throw and falls back to v1.
+    AllocatedChannel probe_thp(Transport &transport);
+
+    // Drive the pairing FSM via the configured prompt.  Sends/receives
+    // pairing messages via `m_v2`'s ProtocolV2 (which already has the
+    // post-handshake transport cipherstates set up).
+    void run_code_entry_pairing(Transport &transport);
+
+    // Read the next encrypted message from `m_v2`, transparently ACKing
+    // any common.ButtonRequest and surfacing common.Failure as a typed
+    // FailureException. Returns the first non-button, non-failure
+    // message. `expected` names the message we're waiting for, used in
+    // the diagnostic if a Failure arrives without its own message.
+    std::shared_ptr<google::protobuf::Message>
+    read_handling_buttons(Transport &transport, const char *expected);
+
+    // Run the post-handshake bring-up sequence that promotes the channel
+    // from TC1 (credential phase) to a seeded application session ready
+    // for Monero traffic:
+    //
+    //   1. Send ThpEndRequest on session 0 -> read ThpEndResponse (handles
+    //      ButtonRequest if the firmware prompts the user to confirm the
+    //      reconnection for non-autoconnect credentials).
+    //   2. Bump m_v2->set_session_id(1) so the next encrypted-transport
+    //      plaintext header carries session_id=1.
+    //   3. Send ThpCreateNewSession(passphrase="", derive_cardano=false)
+    //      -> read Success (handles ButtonRequest from the firmware's
+    //      lock_manager.unlock_device PIN-prompt step inside
+    //      handle_ThpCreateNewSession).
+    //
+    // After this, ProtocolV2::write embeds session_id=1 in every encrypted
+    // plaintext header so the device routes the message to the seeded
+    // SessionContext for that session_id.
+    void thp_end_then_create_app_session(Transport &transport);
+
+    ProtocolConfig                        m_config;
+    std::shared_ptr<Protocol>             m_actual;     // v1 or v2 once selected
+    std::shared_ptr<ProtocolV2>           m_v2;         // shortcut typed alias
+    const char                           *m_selected = "unknown";
+    bool                                  m_force_thp = false;
+  };
+
+}}}
+
+#endif // MONERO_TREZOR_THP_AUTO_DETECT_H

--- a/src/device_trezor/trezor/thp/framing.cpp
+++ b/src/device_trezor/trezor/thp/framing.cpp
@@ -1,0 +1,231 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "framing.hpp"
+#include "device_trezor/trezor/exceptions.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+#include <boost/crc.hpp>
+
+namespace hw {
+namespace trezor {
+namespace thp {
+
+  // Initiation packets carry: control(1) + cid(2) + length(2) + payload-prefix
+  static constexpr size_t INITIATION_HEADER_BYTES   = 5;
+  // Continuation packets carry: control(1) + cid(2) + payload
+  static constexpr size_t CONTINUATION_HEADER_BYTES = 3;
+  // Trailer is a CRC-32 appended to the payload before chunking. The
+  // checksum is CRC-32/ISO-HDLC over control || cid || length || payload.
+  static constexpr size_t CRC32_BYTES = 4;
+
+  std::vector<uint8_t> encode_frame(uint8_t control_byte, uint16_t channel_id,
+                                    const uint8_t *payload, size_t payload_len,
+                                    size_t chunk_size)
+  {
+    if (chunk_size <= INITIATION_HEADER_BYTES) {
+      throw std::invalid_argument("chunk_size too small for THP initiation header");
+    }
+    if ((control_byte & CTRL_CONTINUATION_BIT) != 0) {
+      throw std::invalid_argument("encode_frame: control byte indicates continuation");
+    }
+
+    // The "length" encoded in the header is payload_len + CRC32_BYTES.
+    // Bounds-check payload_len on its own BEFORE the addition and the
+    // narrowing, so an oversized value can neither wrap the size_t sum
+    // nor the 16-bit field.
+    if (payload_len > 0xFFFF - CRC32_BYTES) {
+      throw std::invalid_argument("THP frame length exceeds 16-bit field");
+    }
+    const size_t length_field = payload_len + CRC32_BYTES;
+
+    uint8_t header[INITIATION_HEADER_BYTES];
+    header[0] = control_byte;
+    write_be16(header + 1, channel_id);
+    write_be16(header + 3, static_cast<uint16_t>(length_field));
+
+    boost::crc_32_type crc;
+    crc.process_bytes(header, sizeof(header));
+    if (payload_len > 0) {
+      crc.process_bytes(payload, payload_len);
+    }
+    uint8_t crc_be[CRC32_BYTES]; write_be32(crc_be, crc.checksum());
+
+    // The transport body is payload || crc_be; it is chunked in place
+    // rather than concatenated first.
+    auto copy_body = [&](uint8_t *dst, size_t offset, size_t take) {
+      if (offset < payload_len) {
+        const size_t n = std::min(take, payload_len - offset);
+        std::memcpy(dst, payload + offset, n);
+        dst    += n;
+        offset += n;
+        take   -= n;
+      }
+      if (take > 0) {
+        std::memcpy(dst, crc_be + (offset - payload_len), take);
+      }
+    };
+
+    // The first chunk carries the initiation header (control + cid +
+    // length); subsequent chunks carry the continuation header (control
+    // with bit-7 set + cid).
+    std::vector<uint8_t> out;
+    size_t offset = 0;
+    bool first = true;
+    while (first || offset < length_field) {
+      const size_t header_bytes = first ? INITIATION_HEADER_BYTES
+                                        : CONTINUATION_HEADER_BYTES;
+      const size_t room = chunk_size - header_bytes;
+      const size_t take = std::min(room, length_field - offset);
+
+      const size_t base = out.size();
+      out.resize(base + chunk_size, 0); // pre-pad with zeros
+
+      uint8_t *p = out.data() + base;
+      if (first) {
+        std::memcpy(p, header, INITIATION_HEADER_BYTES);
+        copy_body(p + INITIATION_HEADER_BYTES, offset, take);
+      } else {
+        // Per THP spec: continuation packet control byte is exactly 0x80;
+        // the low 7 bits are reserved and must be zero on transmit.
+        p[0] = CTRL_CONTINUATION_BIT;
+        write_be16(p + 1, channel_id);
+        copy_body(p + CONTINUATION_HEADER_BYTES, offset, take);
+      }
+
+      offset += take;
+      first = false;
+    }
+
+    return out;
+  }
+
+  void FrameAssembler::reset()
+  {
+    m_started = false;
+    m_complete = false;
+    m_control = 0;
+    m_channel = 0;
+    m_declared_len = 0;
+    m_buf.clear();
+  }
+
+  bool FrameAssembler::feed_chunk(const uint8_t *chunk, size_t chunk_size)
+  {
+    if (m_complete) {
+      throw exc::CommunicationException("THP: feed_chunk after frame completion (call take/reset)");
+    }
+    if (!chunk || chunk_size <= CONTINUATION_HEADER_BYTES) {
+      throw exc::CommunicationException("THP: chunk too small");
+    }
+
+    if (!m_started) {
+      // The initiation header is 5 bytes (ctrl + cid + len). The generic guard
+      // above only rejects chunk_size <= CONTINUATION_HEADER_BYTES (3), so a
+      // 4-byte chunk would let the read_be16(chunk+3) below read one byte out
+      // of bounds. Require the full header; a chunk of exactly the header size
+      // (no payload yet) is valid and handled by the declared-length logic.
+      if (chunk_size < INITIATION_HEADER_BYTES) {
+        throw exc::CommunicationException("THP: initiation chunk too small");
+      }
+      const uint8_t ctrl = chunk[0];
+      if ((ctrl & CTRL_CONTINUATION_BIT) != 0) {
+        throw exc::CommunicationException("THP: first chunk must be an initiation packet");
+      }
+      m_control = ctrl;
+      m_channel = read_be16(chunk + 1);
+      m_declared_len = read_be16(chunk + 3); // includes CRC32 trailer
+
+      const size_t available = chunk_size - INITIATION_HEADER_BYTES;
+      const size_t want = std::min<size_t>(m_declared_len, available);
+      m_buf.insert(m_buf.end(), chunk + INITIATION_HEADER_BYTES,
+                   chunk + INITIATION_HEADER_BYTES + want);
+      m_started = true;
+    } else {
+      const uint8_t ctrl = chunk[0];
+      if ((ctrl & CTRL_CONTINUATION_BIT) == 0) {
+        throw exc::CommunicationException("THP: continuation chunk missing continuation bit");
+      }
+      const uint16_t cid = read_be16(chunk + 1);
+      if (cid != m_channel) {
+        throw exc::CommunicationException("THP: continuation chunk channel mismatch");
+      }
+      const size_t available = chunk_size - CONTINUATION_HEADER_BYTES;
+      const size_t remaining = m_declared_len - m_buf.size();
+      const size_t want = std::min(available, remaining);
+      m_buf.insert(m_buf.end(), chunk + CONTINUATION_HEADER_BYTES,
+                   chunk + CONTINUATION_HEADER_BYTES + want);
+    }
+
+    if (m_buf.size() < m_declared_len) {
+      return false;
+    }
+
+    // Frame is fully received. Verify CRC.
+    if (m_buf.size() < CRC32_BYTES) {
+      throw exc::CommunicationException("THP: declared length below CRC trailer");
+    }
+    const size_t payload_len = m_buf.size() - CRC32_BYTES;
+    const uint32_t got_crc = read_be32(m_buf.data() + payload_len);
+
+    // Reconstruct the CRC input: control || cid || length || payload.
+    uint8_t header[INITIATION_HEADER_BYTES];
+    header[0] = m_control;
+    write_be16(header + 1, m_channel);
+    write_be16(header + 3, static_cast<uint16_t>(m_declared_len));
+
+    boost::crc_32_type crc;
+    crc.process_bytes(header, sizeof(header));
+    if (payload_len > 0) {
+      crc.process_bytes(m_buf.data(), payload_len);
+    }
+    if (crc.checksum() != got_crc) {
+      throw exc::CommunicationException("THP: CRC mismatch on assembled frame");
+    }
+
+    m_buf.resize(payload_len);
+    m_complete = true;
+    return true;
+  }
+
+  Frame FrameAssembler::take()
+  {
+    if (!m_complete) {
+      throw exc::CommunicationException("THP: take() called before frame complete");
+    }
+    Frame f;
+    f.control_byte = m_control;
+    f.channel_id   = m_channel;
+    f.payload      = std::move(m_buf);
+    reset();
+    return f;
+  }
+
+}}}

--- a/src/device_trezor/trezor/thp/framing.hpp
+++ b/src/device_trezor/trezor/thp/framing.hpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef MONERO_TREZOR_THP_FRAMING_H
+#define MONERO_TREZOR_THP_FRAMING_H
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include <boost/endian/conversion.hpp>
+
+namespace hw {
+namespace trezor {
+namespace thp {
+
+  // Wire format constants (THP specification, data transfer layer).
+
+  // USB always uses 64-byte packets.
+  constexpr size_t USB_CHUNK_SIZE = 64;
+
+  // Control-byte masks. Bit 7 distinguishes initiation (0) vs continuation (1).
+  constexpr uint8_t CTRL_CONTINUATION_BIT = 0x80;
+  // Per THP spec, "Transport packet structure":
+  //   - DATA packets (handshake_*, encrypted_transport): bit 4 (0x10) is the
+  //     sequence bit; bit 3 (0x08) is the optional piggyback-ACK bit.
+  //   - ACK packets: bit 3 (0x08) is the sequence bit (which seq is being
+  //     acknowledged); there is no piggyback bit.
+  // The single-bit names match Python trezorlib/thp/control_byte.py.
+  constexpr uint8_t CTRL_DATA_SEQ_BIT = 0x10;
+  constexpr uint8_t CTRL_DATA_ACK_BIT = 0x08;
+  constexpr uint8_t CTRL_ACK_SEQ_BIT  = 0x08;
+  // Property masks used to identify the message type ignoring seq/ack bits.
+  constexpr uint8_t CTRL_DATA_MASK = 0xE7;  // strips seq (0x10) and ack (0x08)
+  constexpr uint8_t CTRL_ACK_MASK  = 0xF7;  // strips seq (0x08)
+
+  // Reserved channel identifiers per THP spec.
+  constexpr uint16_t CID_BROADCAST = 0xFFFF;
+  constexpr uint16_t CID_RESERVED_LOW = 0xFFF0;
+  constexpr uint16_t CID_INVALID = 0x0000;
+
+  // Selected control-byte values (initiation packets).
+  enum InitiationControl : uint8_t {
+    CTRL_CHANNEL_ALLOC_REQUEST  = 0x40,
+    CTRL_CHANNEL_ALLOC_RESPONSE = 0x41,
+    CTRL_TRANSPORT_ERROR        = 0x42,
+    CTRL_PING                   = 0x43,
+    CTRL_PONG                   = 0x44,
+
+    // ACK with sequence bit cleared / set.
+    CTRL_ACK_SEQ0               = 0x20,
+    CTRL_ACK_SEQ1               = 0x28,
+
+    // Handshake init/completion. The low bits encode a request/response
+    // and (for some) the sequence bit.
+    CTRL_HANDSHAKE_INIT_REQ     = 0x00,
+    CTRL_HANDSHAKE_INIT_RESP    = 0x01,
+    CTRL_HANDSHAKE_COMP_REQ     = 0x02,
+    CTRL_HANDSHAKE_COMP_RESP    = 0x03,
+
+    // Encrypted application traffic. Sequence bit (CTRL_DATA_SEQ_BIT 0x10)
+    // toggles between consecutive frames (yielding 0x04 / 0x14). The
+    // optional piggyback-ACK bit (CTRL_DATA_ACK_BIT 0x08) may also be set.
+    CTRL_ENCRYPTED_TRANSPORT    = 0x04,
+  };
+
+  // Transport error codes carried in TRANSPORT_ERROR frames.
+  enum TransportError : uint8_t {
+    TRANSPORT_ERR_BUSY                  = 1,
+    TRANSPORT_ERR_UNALLOCATED_CHANNEL   = 2,
+    TRANSPORT_ERR_DECRYPTION_FAILED     = 3,
+    TRANSPORT_ERR_DEVICE_LOCKED         = 5,
+  };
+
+  // A reassembled THP frame at the data-transfer layer. The CRC has been
+  // verified and stripped. `payload` is the message body (transport-layer
+  // contents, *not* yet decrypted).
+  struct Frame {
+    uint8_t  control_byte = 0;
+    uint16_t channel_id   = 0;
+    std::vector<uint8_t> payload;
+
+    bool is_continuation() const { return (control_byte & CTRL_CONTINUATION_BIT) != 0; }
+    bool is_ack() const          { return (control_byte & CTRL_ACK_MASK) == CTRL_ACK_SEQ0; }
+    // For DATA packets (handshake_*, encrypted_transport): sequence bit is at 0x10.
+    uint8_t data_seq_bit() const { return (control_byte & CTRL_DATA_SEQ_BIT) ? 1 : 0; }
+    // For DATA packets: piggyback-ACK bit is at 0x08.
+    uint8_t data_ack_bit() const { return (control_byte & CTRL_DATA_ACK_BIT) ? 1 : 0; }
+    // For ACK packets: sequence bit is at 0x08.
+    uint8_t ack_seq_bit()  const { return (control_byte & CTRL_ACK_SEQ_BIT)  ? 1 : 0; }
+  };
+
+  // Build the wire bytes for a single transport-layer frame. Splits the
+  // frame into one initiation chunk plus zero or more continuation chunks
+  // of `chunk_size` bytes each (default 64 for USB), pads the final chunk
+  // with zeros, and appends the CRC-32 to the payload before splitting.
+  //
+  // Output layout (concatenated):
+  //   chunk_0 = ctrl || cid_be || len_be || payload[0..min(59,len)]      -> padded to chunk_size
+  //   chunk_1 = 0x80 || cid_be || payload[59..min(59+61,len)]            -> padded to chunk_size
+  //   ...
+  // where len includes the appended CRC-32.
+  //
+  // Throws std::invalid_argument on impossible sizes.
+  std::vector<uint8_t> encode_frame(uint8_t control_byte, uint16_t channel_id,
+                                    const uint8_t *payload, size_t payload_len,
+                                    size_t chunk_size = USB_CHUNK_SIZE);
+
+  // Stateful assembler that consumes raw chunks (USB reads) and yields a
+  // complete Frame once all continuation packets have arrived. The CRC is
+  // verified at the end; mismatched CRC raises CommunicationException via
+  // the caller's error-handling layer.
+  class FrameAssembler {
+  public:
+    FrameAssembler() = default;
+
+    // Reset internal state. Call between frames.
+    void reset();
+
+    // Feed a single raw chunk of exactly chunk_size bytes. Returns true
+    // when the frame is complete (caller may then call take()).
+    bool feed_chunk(const uint8_t *chunk, size_t chunk_size);
+
+    // Take the assembled frame. Resets internal state. Only valid after
+    // feed_chunk() returned true; otherwise throws.
+    Frame take();
+
+    // Whether a frame is currently being assembled but not yet complete.
+    bool in_progress() const { return m_started && !m_complete; }
+
+  private:
+    bool      m_started   = false;
+    bool      m_complete  = false;
+    uint8_t   m_control   = 0;
+    uint16_t  m_channel   = 0;
+    uint32_t  m_declared_len = 0; // includes CRC trailer
+    std::vector<uint8_t> m_buf;   // payload accumulator (without CRC trailer)
+  };
+
+  // Header fields are big-endian per THP spec and are not word-aligned on
+  // the wire, hence the memcpy.
+  inline uint16_t read_be16(const uint8_t *p) {
+    uint16_t wire;
+    std::memcpy(&wire, p, sizeof(wire));
+    return boost::endian::big_to_native(wire);
+  }
+  inline uint32_t read_be32(const uint8_t *p) {
+    uint32_t wire;
+    std::memcpy(&wire, p, sizeof(wire));
+    return boost::endian::big_to_native(wire);
+  }
+  inline void write_be16(uint8_t *p, uint16_t v) {
+    const uint16_t wire = boost::endian::native_to_big(v);
+    std::memcpy(p, &wire, sizeof(wire));
+  }
+  inline void write_be32(uint8_t *p, uint32_t v) {
+    const uint32_t wire = boost::endian::native_to_big(v);
+    std::memcpy(p, &wire, sizeof(wire));
+  }
+
+}}}
+
+#endif // MONERO_TREZOR_THP_FRAMING_H

--- a/src/device_trezor/trezor/thp/noise.cpp
+++ b/src/device_trezor/trezor/thp/noise.cpp
@@ -1,0 +1,621 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "noise.hpp"
+#include "device_trezor/trezor/exceptions.hpp"
+
+#include "crypto/crypto.h"
+#include "memwipe.h"
+#include "misc_log_ex.h"
+
+#include <sodium/crypto_auth_hmacsha256.h>
+#include <sodium/crypto_hash_sha256.h>
+#include <sodium/crypto_scalarmult.h>
+#include <sodium/utils.h>
+
+#include <openssl/evp.h>
+
+#include <climits>
+#include <cstdint>
+#include <cstring>
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "device.trezor.thp"
+
+namespace hw {
+namespace trezor {
+namespace thp {
+
+  // Per specification.md, Common definitions: the protocol name is the ASCII
+  // string `Noise_XX_25519_AESGCM_SHA256` followed by four NUL bytes. It is
+  // both the initial chaining key and the prefix of h. This is stock Noise
+  // section 5.2: the name is 28 bytes, which padded to HASHLEN is used
+  // verbatim rather than hashed.
+  static const uint8_t PROTOCOL_NAME[] = {
+    'N','o','i','s','e','_','X','X','_','2','5','5','1','9',
+    '_','A','E','S','G','C','M','_','S','H','A','2','5','6',
+    0x00, 0x00, 0x00, 0x00,
+  };
+  static_assert(sizeof(PROTOCOL_NAME) == 32,
+                "THP protocol name must be 32 bytes (28 ASCII + 4 zero)");
+
+  namespace noise_crypto {
+
+    void sha256(const uint8_t *data, size_t len, NoiseHash &out)
+    {
+      crypto_hash_sha256(out.data(), data, len);
+    }
+
+    void hmac_sha256(const uint8_t *key, size_t key_len,
+                     const uint8_t *data, size_t data_len,
+                     NoiseHash &out)
+    {
+      // The single-shot crypto_auth_hmacsha256() requires a 32-byte key. The
+      // streaming API performs the RFC 2104 key schedule for other lengths.
+      crypto_auth_hmacsha256_state st;
+      crypto_auth_hmacsha256_init(&st, key, key_len);
+      crypto_auth_hmacsha256_update(&st, data, data_len);
+      crypto_auth_hmacsha256_final(&st, out.data());
+    }
+
+    void thp_hkdf(const uint8_t *ck, size_t ck_len,
+                  const uint8_t *ikm, size_t ikm_len,
+                  NoiseKey &out1, NoiseKey &out2)
+    {
+      // Per specification.md, Common definitions:
+      //   temp_key = HMAC-SHA-256(ck, input)
+      //   output_1 = HMAC-SHA-256(temp_key, 0x01)
+      //   output_2 = HMAC-SHA-256(temp_key, output_1 || 0x02)
+      NoiseHash temp_key{};
+      hmac_sha256(ck, ck_len, ikm, ikm_len, temp_key);
+
+      const uint8_t one = 0x01;
+      NoiseHash o1{};
+      hmac_sha256(temp_key.data(), temp_key.size(), &one, 1, o1);
+      std::memcpy(out1.data(), o1.data(), out1.size());
+
+      tools::scrubbed_arr<uint8_t, NOISE_HASHLEN + 1> o1_with_two{};
+      std::memcpy(o1_with_two.data(), o1.data(), NOISE_HASHLEN);
+      o1_with_two[NOISE_HASHLEN] = 0x02;
+      NoiseHash o2{};
+      hmac_sha256(temp_key.data(), temp_key.size(),
+                  o1_with_two.data(), o1_with_two.size(), o2);
+      std::memcpy(out2.data(), o2.data(), out2.size());
+    }
+
+    void x25519(const NoisePrivKey &priv, const NoisePubKey &peer,
+                NoisePubKey &out)
+    {
+      // crypto_scalarmult returns -1 for an all-zero result. Per RFC 7748
+      // 6.1 that indicates a degenerate peer key and MUST be an error.
+      if (crypto_scalarmult(out.data(), priv.data(), peer.data()) != 0) {
+        throw exc::SecurityException("THP: X25519 produced all-zero output (low-order peer key)");
+      }
+    }
+
+    void x25519_keypair(NoisePubKey &pub, NoisePrivKey &priv)
+    {
+      crypto::generate_random_bytes_thread_safe(priv.size(), priv.data());
+      // Clamp per RFC 7748 section 5.
+      priv[0]  &= 248;
+      priv[31] &= 127;
+      priv[31] |= 64;
+      crypto_scalarmult_base(pub.data(), priv.data());
+    }
+
+    void iv_for_nonce(uint64_t counter, NoiseIv &out)
+    {
+      // 12-byte IV: 4 zero bytes then the counter big-endian. That is stock
+      // Noise (section 12.4 specifies big-endian AESGCM nonces; the
+      // little-endian rule in 12.3 is ChaChaPoly's), and it reproduces the
+      // spec's notation of 0^96 for counter 0 and 0^95||1 for counter 1.
+      std::memset(out.data(), 0, out.size());
+      out[4]  = uint8_t(counter >> 56);
+      out[5]  = uint8_t(counter >> 48);
+      out[6]  = uint8_t(counter >> 40);
+      out[7]  = uint8_t(counter >> 32);
+      out[8]  = uint8_t(counter >> 24);
+      out[9]  = uint8_t(counter >> 16);
+      out[10] = uint8_t(counter >>  8);
+      out[11] = uint8_t(counter);
+    }
+
+    namespace {
+      // RAII wrapper around EVP_CIPHER_CTX (avoids leaks on throw).
+      struct EvpCtx {
+        EVP_CIPHER_CTX *p = EVP_CIPHER_CTX_new();
+        ~EvpCtx() { if (p) EVP_CIPHER_CTX_free(p); }
+        EvpCtx() = default;
+        EvpCtx(const EvpCtx &) = delete;
+        EvpCtx &operator=(const EvpCtx &) = delete;
+      };
+    }
+
+    bool aes256gcm_encrypt(const NoiseKey &key, const NoiseIv &iv,
+                           const uint8_t *aad, size_t aad_len,
+                           const uint8_t *plaintext, size_t plaintext_len,
+                           std::vector<uint8_t> &ciphertext)
+    {
+      // EVP takes int lengths. THP frames cap both at 0xFFFF, but this is a
+      // public function with no other stated precondition.
+      if (aad_len > INT_MAX || plaintext_len > INT_MAX) return false;
+
+      EvpCtx ctx;
+      if (!ctx.p) return false;
+      if (EVP_EncryptInit_ex(ctx.p, EVP_aes_256_gcm(), nullptr, nullptr, nullptr) != 1)
+        return false;
+      if (EVP_CIPHER_CTX_ctrl(ctx.p, EVP_CTRL_GCM_SET_IVLEN, (int)iv.size(), nullptr) != 1)
+        return false;
+      if (EVP_EncryptInit_ex(ctx.p, nullptr, nullptr, key.data(), iv.data()) != 1)
+        return false;
+
+      ciphertext.resize(plaintext_len + NOISE_TAGLEN);
+      int dummy_outl = 0;
+      if (aad_len) {
+        // AAD pass: EVP reports the AAD length here, no ciphertext is written.
+        if (EVP_EncryptUpdate(ctx.p, nullptr, &dummy_outl, aad, (int)aad_len) != 1)
+          return false;
+      }
+      int ct_outl = 0;
+      if (plaintext_len) {
+        if (EVP_EncryptUpdate(ctx.p, ciphertext.data(), &ct_outl,
+                              plaintext, (int)plaintext_len) != 1)
+          return false;
+      }
+      int ct_finall = 0;
+      if (EVP_EncryptFinal_ex(ctx.p, ciphertext.data() + ct_outl, &ct_finall) != 1)
+        return false;
+      // AES-GCM has no padding, so this must hold exactly.
+      if (size_t(ct_outl + ct_finall) != plaintext_len)
+        return false;
+      if (EVP_CIPHER_CTX_ctrl(ctx.p, EVP_CTRL_GCM_GET_TAG, NOISE_TAGLEN,
+                              ciphertext.data() + plaintext_len) != 1)
+        return false;
+      return true;
+    }
+
+    bool aes256gcm_decrypt(const NoiseKey &key, const NoiseIv &iv,
+                           const uint8_t *aad, size_t aad_len,
+                           const uint8_t *ciphertext, size_t ciphertext_len,
+                           std::vector<uint8_t> &plaintext)
+    {
+      if (aad_len > INT_MAX || ciphertext_len > INT_MAX) return false;
+      if (ciphertext_len < NOISE_TAGLEN) return false;
+      const size_t plain_len = ciphertext_len - NOISE_TAGLEN;
+
+      EvpCtx ctx;
+      if (!ctx.p) return false;
+      if (EVP_DecryptInit_ex(ctx.p, EVP_aes_256_gcm(), nullptr, nullptr, nullptr) != 1)
+        return false;
+      if (EVP_CIPHER_CTX_ctrl(ctx.p, EVP_CTRL_GCM_SET_IVLEN, (int)iv.size(), nullptr) != 1)
+        return false;
+      if (EVP_DecryptInit_ex(ctx.p, nullptr, nullptr, key.data(), iv.data()) != 1)
+        return false;
+
+      plaintext.resize(plain_len);
+      int dummy_outl = 0;
+      if (aad_len) {
+        if (EVP_DecryptUpdate(ctx.p, nullptr, &dummy_outl, aad, (int)aad_len) != 1)
+          return false;
+      }
+      int pt_outl = 0;
+      if (plain_len) {
+        if (EVP_DecryptUpdate(ctx.p, plaintext.data(), &pt_outl,
+                              ciphertext, (int)plain_len) != 1)
+          return false;
+      }
+      // Set the expected tag; EVP_DecryptFinal_ex then verifies it.
+      // EVP_CTRL_GCM_SET_TAG wants a non-const pointer but does not write.
+      if (EVP_CIPHER_CTX_ctrl(ctx.p, EVP_CTRL_GCM_SET_TAG, NOISE_TAGLEN,
+                              const_cast<uint8_t *>(ciphertext + plain_len)) != 1)
+        return false;
+      // The empty-payload tag check runs on every handshake, so plain_len is
+      // routinely 0 and plaintext.data() is then null: keep the pointer
+      // arithmetic and the wipe off a null pointer.
+      uint8_t *final_out = plain_len ? plaintext.data() + pt_outl : nullptr;
+      int pt_finall = 0;
+      if (EVP_DecryptFinal_ex(ctx.p, final_out, &pt_finall) != 1) {
+        if (plain_len) memwipe(plaintext.data(), plaintext.size());
+        plaintext.clear();
+        return false;
+      }
+      if (size_t(pt_outl + pt_finall) != plain_len) {
+        if (plain_len) memwipe(plaintext.data(), plaintext.size());
+        plaintext.clear();
+        return false;
+      }
+      return true;
+    }
+
+    void trezor_mask_static(const NoisePubKey &trezor_static_pub,
+                            const NoisePubKey &trezor_ephemeral_pub,
+                            NoisePubKey &out_masked)
+    {
+      // mask = SHA-256(static_pub || ephemeral_pub)
+      std::array<uint8_t, NOISE_DHLEN * 2> concat{};
+      std::memcpy(concat.data(),               trezor_static_pub.data(),    NOISE_DHLEN);
+      std::memcpy(concat.data() + NOISE_DHLEN, trezor_ephemeral_pub.data(), NOISE_DHLEN);
+      NoiseHash mask{};
+      sha256(concat.data(), concat.size(), mask);
+
+      NoisePrivKey scalar{};
+      std::memcpy(scalar.data(), mask.data(), NOISE_DHLEN);
+      x25519(scalar, trezor_static_pub, out_masked);
+    }
+
+  } // namespace noise_crypto
+
+  NoiseXxInitiator::NoiseXxInitiator() = default;
+
+  NoiseXxInitiator::~NoiseXxInitiator()
+  {
+    // Every key member scrubs itself; a std::vector cannot, and the known
+    // devices carry their own scrubbing destructor.
+    if (!m_pairing_credential.empty())
+      memwipe(m_pairing_credential.data(), m_pairing_credential.size());
+  }
+
+  void NoiseXxInitiator::set_device_properties(const uint8_t *data, size_t len)
+  {
+    m_device_properties.clear();
+    if (len) m_device_properties.assign(data, data + len);
+    m_have_device_properties = true;
+  }
+
+  void NoiseXxInitiator::set_host_static_key(const HostStaticKey &host_static)
+  {
+    m_host_static = host_static;
+    m_have_host_static = true;
+  }
+
+  void NoiseXxInitiator::set_known_devices(std::vector<KnownDevice> known)
+  {
+    m_known_devices = std::move(known);
+  }
+
+  void NoiseXxInitiator::mix_hash(const uint8_t *data, size_t len)
+  {
+    // h = SHA-256(h || data)
+    std::vector<uint8_t> buf;
+    buf.reserve(NOISE_HASHLEN + len);
+    buf.insert(buf.end(), m_h.begin(), m_h.end());
+    if (len) buf.insert(buf.end(), data, data + len);
+    noise_crypto::sha256(buf.data(), buf.size(), m_h);
+  }
+
+  std::vector<uint8_t> NoiseXxInitiator::build_init_request(bool try_to_unlock)
+  {
+    if (!m_have_host_static) {
+      throw exc::ProtocolException("THP: build_init_request without host static key");
+    }
+    if (!m_have_device_properties) {
+      throw exc::ProtocolException("THP: build_init_request without device properties");
+    }
+
+    // Starting a second handshake on the same object must not inherit the
+    // ordering flags of the first.
+    m_have_ephemeral         = false;
+    m_consumed_init_response = false;
+    m_built_completion       = false;
+    m_complete               = false;
+    m_paired                 = false;
+
+    noise_crypto::x25519_keypair(m_host_ephemeral_pub, m_host_ephemeral_priv);
+    m_have_ephemeral = true;
+    m_try_to_unlock  = try_to_unlock;
+
+    std::vector<uint8_t> body;
+    body.reserve(NOISE_DHLEN + 1);
+    body.insert(body.end(), m_host_ephemeral_pub.begin(), m_host_ephemeral_pub.end());
+    body.push_back(try_to_unlock ? 0x01 : 0x00);
+    return body;
+  }
+
+  void NoiseXxInitiator::consume_init_response(const uint8_t *body, size_t len)
+  {
+    if (!m_have_ephemeral) {
+      throw exc::ProtocolException("THP: consume_init_response before build_init_request");
+    }
+    // HandshakeInitiationResponse layout: 32 + 48 + 16 = 96.
+    constexpr size_t TREZOR_EPH_OFF       = 0;
+    constexpr size_t ENC_STATIC_OFF       = NOISE_DHLEN;
+    constexpr size_t ENC_STATIC_LEN       = NOISE_DHLEN + NOISE_TAGLEN; // 48
+    constexpr size_t TAG_OFF              = ENC_STATIC_OFF + ENC_STATIC_LEN;
+    constexpr size_t TAG_LEN              = NOISE_TAGLEN;
+    constexpr size_t EXPECTED_LEN         = TAG_OFF + TAG_LEN;
+    if (len != EXPECTED_LEN) {
+      throw exc::ProtocolException("THP: HandshakeInitResponse wrong size");
+    }
+
+    // h = SHA-256(protocol_name || device_properties). Mixing the device
+    // properties is stock MixHash(prologue), Noise section 5.3.
+    std::vector<uint8_t> hash_in;
+    hash_in.reserve(sizeof(PROTOCOL_NAME) + m_device_properties.size());
+    hash_in.insert(hash_in.end(), PROTOCOL_NAME, PROTOCOL_NAME + sizeof(PROTOCOL_NAME));
+    hash_in.insert(hash_in.end(), m_device_properties.begin(), m_device_properties.end());
+    noise_crypto::sha256(hash_in.data(), hash_in.size(), m_h);
+
+    mix_hash(m_host_ephemeral_pub.data(), m_host_ephemeral_pub.size());
+    {
+      const uint8_t b = m_try_to_unlock ? 0x01 : 0x00;
+      mix_hash(&b, 1);
+    }
+
+    std::memcpy(m_trezor_ephemeral_pub.data(), body + TREZOR_EPH_OFF, NOISE_DHLEN);
+    mix_hash(m_trezor_ephemeral_pub.data(), m_trezor_ephemeral_pub.size());
+
+    // (ck, k) = HKDF(protocol_name, X25519(host_eph_priv, trezor_eph_pub))
+    NoisePubKey ee{};
+    noise_crypto::x25519(m_host_ephemeral_priv, m_trezor_ephemeral_pub, ee);
+    NoiseKey ck{}, k{};
+    noise_crypto::thp_hkdf(PROTOCOL_NAME, sizeof(PROTOCOL_NAME),
+                           ee.data(), ee.size(), ck, k);
+    memwipe(ee.data(), ee.size());
+    m_ck_or_zero  = ck;
+    m_k_handshake = k;
+
+    // Decrypt encrypted_trezor_static_pubkey at IV=0^96, AAD=h.
+    noise_crypto::NoiseIv iv{};
+    noise_crypto::iv_for_nonce(0, iv);
+    std::vector<uint8_t> dec_masked;
+    if (!noise_crypto::aes256gcm_decrypt(m_k_handshake, iv,
+                                         m_h.data(), m_h.size(),
+                                         body + ENC_STATIC_OFF, ENC_STATIC_LEN,
+                                         dec_masked)) {
+      throw exc::SecurityException("THP: HandshakeInitResponse: enc_static tag invalid");
+    }
+    if (dec_masked.size() != NOISE_DHLEN) {
+      throw exc::ProtocolException("THP: HandshakeInitResponse: bad enc_static plaintext size");
+    }
+    std::memcpy(m_trezor_masked_static.data(), dec_masked.data(), NOISE_DHLEN);
+
+    mix_hash(body + ENC_STATIC_OFF, ENC_STATIC_LEN);
+
+    // (ck, k) = HKDF(ck, X25519(host_eph_priv, trezor_masked_static_pubkey))
+    NoisePubKey se{};
+    noise_crypto::x25519(m_host_ephemeral_priv, m_trezor_masked_static, se);
+    noise_crypto::thp_hkdf(m_ck_or_zero.data(), m_ck_or_zero.size(),
+                           se.data(), se.size(), ck, k);
+    memwipe(se.data(), se.size());
+    m_ck_or_zero  = ck;
+    m_k_handshake = k;
+
+    // Decrypt the empty-payload tag at IV=0^96, AAD=h.
+    noise_crypto::iv_for_nonce(0, iv);
+    std::vector<uint8_t> empty_payload;
+    if (!noise_crypto::aes256gcm_decrypt(m_k_handshake, iv,
+                                         m_h.data(), m_h.size(),
+                                         body + TAG_OFF, TAG_LEN,
+                                         empty_payload)) {
+      throw exc::SecurityException("THP: HandshakeInitResponse: trailing tag invalid");
+    }
+    if (!empty_payload.empty()) {
+      throw exc::ProtocolException("THP: HandshakeInitResponse: trailing payload not empty");
+    }
+    mix_hash(body + TAG_OFF, TAG_LEN);
+
+    // HH1 step 11: identify a paired device. The masked static pubkey rotates
+    // every session because it is X25519(SHA-256(static_pub || trezor_eph_pub),
+    // static_pub) over a fresh ephemeral, so a stored masked value would be
+    // useless: re-mask each stored unmasked static with this session's
+    // ephemeral and compare against the value just decrypted.
+    m_paired = false;
+    m_pairing_credential.clear();
+    for (const auto &kd : m_known_devices) {
+      NoisePubKey expected_masked{};
+      try {
+        noise_crypto::trezor_mask_static(kd.trezor_static_pubkey,
+                                         m_trezor_ephemeral_pub,
+                                         expected_masked);
+      } catch (const std::exception &e) {
+        // An all-zero or low-order stored pubkey makes X25519 fail. Skipping
+        // that record keeps one corrupt entry from aborting the scan for
+        // every other device on every future connect.
+        MWARNING("THP: skipping unusable known-device record: " << e.what());
+        continue;
+      }
+      if (sodium_memcmp(expected_masked.data(),
+                        m_trezor_masked_static.data(),
+                        NOISE_DHLEN) == 0)
+      {
+        m_paired             = true;
+        m_host_static        = kd.host_static;
+        m_have_host_static   = true;
+        m_pairing_credential = kd.pairing_credential;
+        break;
+      }
+    }
+    m_consumed_init_response = true;
+  }
+
+  std::vector<uint8_t> NoiseXxInitiator::build_completion_request()
+  {
+    if (!m_consumed_init_response) {
+      throw exc::ProtocolException("THP: build_completion_request before init response");
+    }
+    if (!m_have_host_static) {
+      throw exc::ProtocolException("THP: build_completion_request without host static key");
+    }
+
+    // Encrypt host_static_pubkey at IV=0^95||1, AAD=h.
+    noise_crypto::NoiseIv iv{};
+    noise_crypto::iv_for_nonce(1, iv);
+    std::vector<uint8_t> enc_host_static;
+    if (!noise_crypto::aes256gcm_encrypt(m_k_handshake, iv,
+                                         m_h.data(), m_h.size(),
+                                         m_host_static.pub.data(), m_host_static.pub.size(),
+                                         enc_host_static)) {
+      throw exc::ProtocolException("THP: AES-GCM encrypt failed (host_static)");
+    }
+    mix_hash(enc_host_static.data(), enc_host_static.size());
+
+    // (ck, k) = HKDF(ck, X25519(host_static_priv, trezor_eph_pub))
+    NoisePubKey ss{};
+    noise_crypto::x25519(m_host_static.priv, m_trezor_ephemeral_pub, ss);
+    NoiseKey ck{}, k{};
+    noise_crypto::thp_hkdf(m_ck_or_zero.data(), m_ck_or_zero.size(),
+                           ss.data(), ss.size(), ck, k);
+    memwipe(ss.data(), ss.size());
+    m_ck_or_zero  = ck;
+    m_k_handshake = k;
+
+    // ThpHandshakeCompletionReqNoisePayload. The unpaired flow omits
+    // host_pairing_credential, which serialises to zero bytes; the paired
+    // flow emits field 1 as a length-delimited byte string. Encoded by hand
+    // because this layer stays free of the generated message types.
+    std::vector<uint8_t> payload_binary;
+    if (m_paired && !m_pairing_credential.empty()) {
+      payload_binary.push_back(0x0A); // field 1, wire type 2
+      size_t n = m_pairing_credential.size();
+      while (n >= 0x80) {
+        payload_binary.push_back(uint8_t((n & 0x7F) | 0x80));
+        n >>= 7;
+      }
+      payload_binary.push_back(uint8_t(n));
+      payload_binary.insert(payload_binary.end(),
+                            m_pairing_credential.begin(),
+                            m_pairing_credential.end());
+    }
+
+    noise_crypto::iv_for_nonce(0, iv);
+    std::vector<uint8_t> enc_payload;
+    if (!noise_crypto::aes256gcm_encrypt(m_k_handshake, iv,
+                                         m_h.data(), m_h.size(),
+                                         payload_binary.data(), payload_binary.size(),
+                                         enc_payload)) {
+      throw exc::ProtocolException("THP: AES-GCM encrypt failed (completion payload)");
+    }
+    mix_hash(enc_payload.data(), enc_payload.size());
+
+    std::vector<uint8_t> body;
+    body.reserve(enc_host_static.size() + enc_payload.size());
+    body.insert(body.end(), enc_host_static.begin(), enc_host_static.end());
+    body.insert(body.end(), enc_payload.begin(),     enc_payload.end());
+    m_built_completion = true;
+    return body;
+  }
+
+  void NoiseXxInitiator::consume_completion_response(const uint8_t *body,
+                                                     size_t len)
+  {
+    if (!m_consumed_init_response) {
+      throw exc::ProtocolException("THP: consume_completion_response before init response");
+    }
+    if (!m_built_completion) {
+      throw exc::ProtocolException("THP: consume_completion_response before build_completion_request");
+    }
+    // (key_request, key_response) = HKDF(ck, empty_string)
+    NoiseKey key_request{}, key_response{};
+    noise_crypto::thp_hkdf(m_ck_or_zero.data(), m_ck_or_zero.size(),
+                           nullptr, 0, key_request, key_response);
+
+    // trezor_state = AES-GCM-DECRYPT(key_response, IV=0^96, ad=empty, body)
+    noise_crypto::NoiseIv iv{};
+    noise_crypto::iv_for_nonce(0, iv);
+    std::vector<uint8_t> trezor_state;
+    if (!noise_crypto::aes256gcm_decrypt(key_response, iv,
+                                         nullptr, 0,
+                                         body, len,
+                                         trezor_state)) {
+      throw exc::SecurityException("THP: HandshakeCompletionResponse: tag invalid");
+    }
+    if (trezor_state.size() != 1) {
+      throw exc::ProtocolException("THP: HandshakeCompletionResponse: bad state plaintext size");
+    }
+    m_trezor_state = trezor_state[0];
+
+    m_keys.key_request    = key_request;
+    m_keys.key_response   = key_response;
+    m_keys.handshake_hash = m_h;
+    m_complete            = true;
+  }
+
+  const HandshakeKeys &NoiseXxInitiator::keys() const
+  {
+    if (!m_complete) {
+      throw exc::ProtocolException("THP: keys() called before handshake completion");
+    }
+    return m_keys;
+  }
+
+  TransportCipher::TransportCipher(const NoiseKey &key, uint64_t initial_nonce)
+    : m_key(key), m_counter(initial_nonce) {}
+
+  void TransportCipher::seal(const uint8_t *aad, size_t aad_len,
+                             const uint8_t *plaintext, size_t plaintext_len,
+                             std::vector<uint8_t> &out)
+  {
+    if (m_failed) {
+      throw exc::SecurityException("THP: transport cipher failed closed");
+    }
+    // Fail-closed nonce-exhaustion guard: reusing a nonce under one AES-GCM
+    // key is catastrophic, so refuse rather than wrap. Unreachable at 2^64-1
+    // frames. The counter must not advance past here.
+    if (m_counter == UINT64_MAX) {
+      m_failed = true;
+      throw exc::SecurityException("THP: transport cipher nonce exhausted (seal)");
+    }
+    noise_crypto::NoiseIv iv{};
+    noise_crypto::iv_for_nonce(m_counter, iv);
+    if (!noise_crypto::aes256gcm_encrypt(m_key, iv, aad, aad_len,
+                                         plaintext, plaintext_len, out)) {
+      m_failed = true;
+      throw exc::ProtocolException("THP: AES-GCM seal failed");
+    }
+    // One counter per cipherstate (key_request / key_response), advanced only
+    // after a successful operation.
+    ++m_counter;
+  }
+
+  bool TransportCipher::open(const uint8_t *aad, size_t aad_len,
+                             const uint8_t *ciphertext, size_t ciphertext_len,
+                             std::vector<uint8_t> &out)
+  {
+    // A peer that has failed authentication once does not get to keep
+    // streaming frames: the Noise spec and Trezor's own host both terminate
+    // on a decryption failure.
+    if (m_failed) {
+      return false;
+    }
+    if (m_counter == UINT64_MAX) {
+      m_failed = true;
+      return false;
+    }
+    noise_crypto::NoiseIv iv{};
+    noise_crypto::iv_for_nonce(m_counter, iv);
+    if (!noise_crypto::aes256gcm_decrypt(m_key, iv, aad, aad_len,
+                                         ciphertext, ciphertext_len, out)) {
+      m_failed = true;
+      return false;
+    }
+    ++m_counter;
+    return true;
+  }
+
+}}}

--- a/src/device_trezor/trezor/thp/noise.hpp
+++ b/src/device_trezor/trezor/thp/noise.hpp
@@ -1,0 +1,262 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef MONERO_TREZOR_THP_NOISE_H
+#define MONERO_TREZOR_THP_NOISE_H
+
+#include "memwipe.h"
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace hw {
+namespace trezor {
+namespace thp {
+
+  // Sizes of the Noise primitives used by THP (Noise_XX_25519_AESGCM_SHA256).
+  constexpr size_t NOISE_DHLEN   = 32; // X25519 public/private key
+  constexpr size_t NOISE_HASHLEN = 32; // SHA-256 digest
+  constexpr size_t NOISE_KEYLEN  = 32; // AES-256 key
+  constexpr size_t NOISE_TAGLEN  = 16; // AES-GCM authentication tag
+
+  // Key material, and the handshake hash the pairing-code derivation mixes
+  // in, scrub themselves on destruction, so a copy left behind by container
+  // growth or by an unwound stack frame does not survive in the clear.
+  // Public keys are not secret and stay plain arrays.
+  using NoiseKey     = tools::scrubbed_arr<uint8_t, NOISE_KEYLEN>;
+  using NoiseHash    = tools::scrubbed_arr<uint8_t, NOISE_HASHLEN>;
+  using NoisePrivKey = tools::scrubbed_arr<uint8_t, NOISE_DHLEN>;
+  using NoisePubKey  = std::array<uint8_t, NOISE_DHLEN>;
+
+  // Output of a successful handshake. The two AES-GCM keys carry the
+  // application traffic; handshake_hash is the final value of h.
+  struct HandshakeKeys {
+    NoiseKey  key_request;   // host -> device direction
+    NoiseKey  key_response;  // device -> host direction
+    NoiseHash handshake_hash;
+  };
+
+  // The host's static keypair, persisted across sessions per the spec.
+  struct HostStaticKey {
+    NoisePubKey  pub{};
+    NoisePrivKey priv{};
+  };
+
+  // A previously-established pairing: the *unmasked* Trezor static pubkey
+  // observed during an earlier handshake, the host static keypair used with
+  // that device, and the opaque pairing credential Trezor issued.
+  //
+  // The masked form rotates per session (it depends on the device's fresh
+  // ephemeral pubkey), so the unmasked pubkey is what we persist, re-masking
+  // it each session before comparing. See specification.md HH1 step 11.
+  struct KnownDevice {
+    NoisePubKey   trezor_static_pubkey{};
+    HostStaticKey host_static{};
+    std::vector<uint8_t> pairing_credential; // opaque to the host
+
+    // host_static.priv scrubs itself; a std::vector cannot, and the
+    // credential is what authenticates this host to the device.
+    ~KnownDevice() {
+      if (!pairing_credential.empty())
+        memwipe(pairing_credential.data(), pairing_credential.size());
+    }
+  };
+
+  // Low-level Noise primitives, exposed for the unit tests. Deliberately not
+  // called "crypto": that name is Monero's global namespace.
+  namespace noise_crypto {
+    void sha256(const uint8_t *data, size_t len, NoiseHash &out);
+    void hmac_sha256(const uint8_t *key, size_t key_len,
+                     const uint8_t *data, size_t data_len,
+                     NoiseHash &out);
+
+    // The HKDF defined in specification.md, Common definitions. Returns two
+    // 32-byte outputs derived from a chaining key and input keying material.
+    void thp_hkdf(const uint8_t *ck, size_t ck_len,
+                  const uint8_t *ikm, size_t ikm_len,
+                  NoiseKey &out1, NoiseKey &out2);
+
+    // X25519 scalar multiplication. Throws on a degenerate peer key.
+    void x25519(const NoisePrivKey &priv, const NoisePubKey &peer,
+                NoisePubKey &out);
+
+    // Generate a fresh X25519 keypair (clamps the private key per RFC 7748).
+    void x25519_keypair(NoisePubKey &pub, NoisePrivKey &priv);
+
+    // AES-256-GCM AEAD with the 12-byte IV the spec notates as a bit string
+    // ("0^96", "0^95||1"). iv_for_nonce builds it from a 64-bit counter.
+    using NoiseIv = std::array<uint8_t, 12>;
+    void iv_for_nonce(uint64_t counter, NoiseIv &out);
+
+    // Both return false on failure; decrypt returns false on tag mismatch
+    // and leaves no plaintext behind.
+    bool aes256gcm_encrypt(const NoiseKey &key, const NoiseIv &iv,
+                           const uint8_t *aad, size_t aad_len,
+                           const uint8_t *plaintext, size_t plaintext_len,
+                           std::vector<uint8_t> &ciphertext);
+    bool aes256gcm_decrypt(const NoiseKey &key, const NoiseIv &iv,
+                           const uint8_t *aad, size_t aad_len,
+                           const uint8_t *ciphertext, size_t ciphertext_len,
+                           std::vector<uint8_t> &plaintext);
+
+    // Trezor's static key masking (specification.md, Handshake phase):
+    //   masked = X25519(SHA-256(static_pub || ephemeral_pub), static_pub)
+    // Pure function; also used by the paired-device lookup (HH1 step 11).
+    void trezor_mask_static(const NoisePubKey &trezor_static_pub,
+                            const NoisePubKey &trezor_ephemeral_pub,
+                            NoisePubKey &out_masked);
+  }
+
+  // THP host-side handshake driver: the Noise XX initiator role specialised
+  // for the THP state machine (specification.md, Host's state machine).
+  //
+  //   NoiseXxInitiator h;
+  //   h.set_device_properties(ChannelAllocationResponse.device_properties);
+  //   h.set_host_static_key(persisted_or_freshly_generated_keypair);
+  //   h.set_known_devices(persisted_credentials);
+  //   auto req1 = h.build_init_request(try_to_unlock);  // send, then:
+  //   h.consume_init_response(resp1.data(), resp1.size());
+  //   auto req2 = h.build_completion_request();         // send, then:
+  //   h.consume_completion_response(resp2.data(), resp2.size());
+  class NoiseXxInitiator {
+  public:
+    NoiseXxInitiator();
+    ~NoiseXxInitiator();
+    NoiseXxInitiator(const NoiseXxInitiator &) = delete;
+    NoiseXxInitiator &operator=(const NoiseXxInitiator &) = delete;
+
+    // ChannelAllocationResponse.device_properties, which the handshake mixes
+    // in as the Noise prologue. MUST be called before build_init_request().
+    void set_device_properties(const uint8_t *data, size_t len);
+
+    // The host's persistent static X25519 keypair: freshly generated for a
+    // first-time pairing, or loaded from the credential store.
+    void set_host_static_key(const HostStaticKey &host_static);
+
+    // Previously-paired Trezors, so the handshake can recognise one by its
+    // masked static pubkey (HH1 step 11). May be empty.
+    void set_known_devices(std::vector<KnownDevice> known);
+
+    // Step 1 (HH0): generate the ephemeral keypair, build the request body.
+    std::vector<uint8_t> build_init_request(bool try_to_unlock);
+
+    // Step 2 (HH1, partial): decrypt the masked Trezor static pubkey and the
+    // empty-payload tag, mix in the se DH.
+    void consume_init_response(const uint8_t *body, size_t len);
+
+    // Step 3 (HH1, completion): paired vs. unpaired flow is selected from the
+    // masked pubkey lookup done in consume_init_response.
+    std::vector<uint8_t> build_completion_request();
+
+    // Step 4 (HH2/HH3): finalise. keys() and trezor_state() valid afterwards.
+    void consume_completion_response(const uint8_t *body, size_t len);
+
+    // Whether the init response matched a previously-paired device (HH2).
+    // False means the unpaired flow (HH3) and that pairing must follow.
+    bool is_known_device() const { return m_paired; }
+
+    // The masked Trezor static pubkey decrypted from the init response.
+    const NoisePubKey &trezor_masked_static_pubkey() const {
+      return m_trezor_masked_static;
+    }
+
+    // HandshakeCompletionResponse state byte:
+    //   0x00 = STATE_UNPAIRED, 0x01 = STATE_PAIRED, 0x02 = STATE_PAIRED_AUTOCONNECT
+    uint8_t trezor_state() const { return m_trezor_state; }
+
+    bool is_complete() const { return m_complete; }
+    const HandshakeKeys &keys() const;
+
+    // The host static keypair in use after consume_init_response. On the
+    // paired flow this is the keypair from the matching KnownDevice, so the
+    // caller's outer copy is stale and should be re-synced from here.
+    const HostStaticKey &host_static_in_use() const { return m_host_static; }
+
+  private:
+    // h = SHA-256(h || data)
+    void mix_hash(const uint8_t *data, size_t len);
+
+    bool                 m_have_device_properties = false;
+    bool                 m_have_host_static       = false;
+    bool                 m_have_ephemeral         = false;
+    bool                 m_consumed_init_response = false;
+    bool                 m_built_completion       = false;
+    bool                 m_complete               = false;
+    bool                 m_paired                 = false;
+    uint8_t              m_trezor_state           = 0;
+
+    std::vector<uint8_t> m_device_properties;
+    HostStaticKey        m_host_static{};
+    NoisePubKey          m_host_ephemeral_pub{};
+    NoisePrivKey         m_host_ephemeral_priv{};
+    NoisePubKey          m_trezor_ephemeral_pub{};
+    NoisePubKey          m_trezor_masked_static{};
+    bool                 m_try_to_unlock          = false;
+
+    std::vector<KnownDevice>  m_known_devices;
+    // Copy of the matched entry's credential when m_paired, else empty.
+    std::vector<uint8_t>      m_pairing_credential;
+
+    // Symmetric state (h, ck, k) per the spec.
+    NoiseHash m_h{};
+    NoiseKey  m_ck_or_zero{};   // re-used as ck after the first HKDF
+    NoiseKey  m_k_handshake{};  // current handshake AES-GCM key
+
+    HandshakeKeys m_keys{};
+  };
+
+  // Application-traffic AES-GCM cipherstate: a key plus a 64-bit counter.
+  // Fails closed permanently after any seal() or open() failure, as the
+  // Noise spec and Trezor's own host both do.
+  class TransportCipher {
+  public:
+    explicit TransportCipher(const NoiseKey &key, uint64_t initial_nonce = 0);
+    TransportCipher(const TransportCipher &) = delete;
+    TransportCipher &operator=(const TransportCipher &) = delete;
+
+    void seal(const uint8_t *aad, size_t aad_len,
+              const uint8_t *plaintext, size_t plaintext_len,
+              std::vector<uint8_t> &out);
+
+    bool open(const uint8_t *aad, size_t aad_len,
+              const uint8_t *ciphertext, size_t ciphertext_len,
+              std::vector<uint8_t> &out);
+
+    uint64_t nonce() const { return m_counter; }
+
+  private:
+    NoiseKey m_key;
+    uint64_t m_counter;
+    bool     m_failed = false;
+  };
+
+}}}
+
+#endif // MONERO_TREZOR_THP_NOISE_H

--- a/src/device_trezor/trezor/thp/pairing.cpp
+++ b/src/device_trezor/trezor/thp/pairing.cpp
@@ -1,0 +1,476 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "pairing.hpp"
+#include "device_trezor/trezor/exceptions.hpp"
+
+#include "crypto/crypto.h"
+#include "memwipe.h"
+
+extern "C"
+{
+#include "crypto/crypto-ops.h"
+}
+
+#include <sodium/crypto_hash_sha256.h>
+#include <sodium/crypto_hash_sha512.h>
+#include <sodium/utils.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace hw {
+namespace trezor {
+namespace thp {
+
+  namespace {
+
+    // The CPace generator is a deterministic function of the pairing code, so
+    // 32 recovered generator bytes recover the code in a million trials. Every
+    // code-derived buffer therefore lives in a self-scrubbing array, which
+    // also covers the throwing paths.
+    using CodeDerived32 = tools::scrubbed_arr<uint8_t, 32>;
+
+    // J = 486662, the Montgomery coefficient of Curve25519 (RFC 7748
+    // section 4.1), in ref10 limb form: limb 0 carries weight 1.
+    const fe FE_J = {486662, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    // ref10's fe_copy. crypto-ops.c declares it static, so it is restated
+    // here over the fe type crypto-ops.h does export.
+    void fe_copy(fe h, const fe f)
+    {
+      for (int i = 0; i < 10; ++i) {
+        h[i] = f[i];
+      }
+    }
+
+    // ref10's fe_cmov, likewise static in crypto-ops.c. Replaces f with g
+    // when b == 1 and leaves f unchanged when b == 0, using an arithmetic
+    // mask rather than a branch, as RFC 9380 section 4 requires of CMOV.
+    // b must be 0 or 1.
+    void fe_cmov(fe f, const fe g, unsigned int b)
+    {
+      const int32_t mask = -(int32_t) b;
+      for (int i = 0; i < 10; ++i) {
+        f[i] ^= (f[i] ^ g[i]) & mask;
+      }
+    }
+
+    // ref10's fe_frombytes. crypto-ops.h exports only fe_frombytes_vartime,
+    // which additionally rejects the 19 encodings in [p, 2^255 - 1] and so
+    // branches on its input; that rejection is dropped here, leaving a
+    // non-canonical encoding to be reduced by the field arithmetic that
+    // follows. Bit 255 is masked off, per RFC 7748 section 5.
+    void fe_frombytes(fe h, const unsigned char *s)
+    {
+      int64_t h0 = load_4(s);
+      int64_t h1 = load_3(s + 4) << 6;
+      int64_t h2 = load_3(s + 7) << 5;
+      int64_t h3 = load_3(s + 10) << 3;
+      int64_t h4 = load_3(s + 13) << 2;
+      int64_t h5 = load_4(s + 16);
+      int64_t h6 = load_3(s + 20) << 7;
+      int64_t h7 = load_3(s + 23) << 5;
+      int64_t h8 = load_3(s + 26) << 4;
+      int64_t h9 = (load_3(s + 29) & 8388607) << 2;
+
+      const int64_t carry9 = (h9 + (int64_t) (1 << 24)) >> 25; h0 += carry9 * 19; h9 -= carry9 << 25;
+      const int64_t carry1 = (h1 + (int64_t) (1 << 24)) >> 25; h2 += carry1; h1 -= carry1 << 25;
+      const int64_t carry3 = (h3 + (int64_t) (1 << 24)) >> 25; h4 += carry3; h3 -= carry3 << 25;
+      const int64_t carry5 = (h5 + (int64_t) (1 << 24)) >> 25; h6 += carry5; h5 -= carry5 << 25;
+      const int64_t carry7 = (h7 + (int64_t) (1 << 24)) >> 25; h8 += carry7; h7 -= carry7 << 25;
+
+      const int64_t carry0 = (h0 + (int64_t) (1 << 25)) >> 26; h1 += carry0; h0 -= carry0 << 26;
+      const int64_t carry2 = (h2 + (int64_t) (1 << 25)) >> 26; h3 += carry2; h2 -= carry2 << 26;
+      const int64_t carry4 = (h4 + (int64_t) (1 << 25)) >> 26; h5 += carry4; h4 -= carry4 << 26;
+      const int64_t carry6 = (h6 + (int64_t) (1 << 25)) >> 26; h7 += carry6; h6 -= carry6 << 26;
+      const int64_t carry8 = (h8 + (int64_t) (1 << 25)) >> 26; h9 += carry8; h8 -= carry8 << 26;
+
+      h[0] = (int32_t) h0;
+      h[1] = (int32_t) h1;
+      h[2] = (int32_t) h2;
+      h[3] = (int32_t) h3;
+      h[4] = (int32_t) h4;
+      h[5] = (int32_t) h5;
+      h[6] = (int32_t) h6;
+      h[7] = (int32_t) h7;
+      h[8] = (int32_t) h8;
+      h[9] = (int32_t) h9;
+    }
+
+    // Constant-time test for h == 0 in F. fe_tobytes reduces fully mod p and
+    // has no input-dependent branch, and folding the 32 canonical bytes
+    // together with OR reads all of them whatever their values are. acc is at
+    // most 255, so acc - 1 borrows into the high bit exactly when acc is 0.
+    unsigned int fe_is_zero(const fe h)
+    {
+      unsigned char enc[32];
+      fe_tobytes(enc, h);
+      uint32_t acc = 0;
+      for (size_t i = 0; i < sizeof(enc); ++i) {
+        acc |= enc[i];
+      }
+      memwipe(enc, sizeof(enc));
+      return (unsigned int) ((uint32_t) (acc - 1u) >> 31);
+    }
+
+    // z^((p-5)/8) = z^(2^252 - 3), the ref10 fe_pow22523 addition chain.
+    // crypto-ops.c carries it inline inside the static fe_divpowm1, so it is
+    // restated here. Every step is a squaring or a multiplication, so the
+    // sequence of operations does not depend on z.
+    void fe_pow22523(fe out, const fe z)
+    {
+      fe t0, t1, t2;
+      int i;
+
+      fe_sq(t0, z);
+      fe_sq(t1, t0);
+      fe_sq(t1, t1);
+      fe_mul(t1, z, t1);
+      fe_mul(t0, t0, t1);
+      fe_sq(t0, t0);
+      fe_mul(t0, t1, t0);
+      fe_sq(t1, t0);
+      for (i = 0; i < 4; ++i) {
+        fe_sq(t1, t1);
+      }
+      fe_mul(t0, t1, t0);
+      fe_sq(t1, t0);
+      for (i = 0; i < 9; ++i) {
+        fe_sq(t1, t1);
+      }
+      fe_mul(t1, t1, t0);
+      fe_sq(t2, t1);
+      for (i = 0; i < 19; ++i) {
+        fe_sq(t2, t2);
+      }
+      fe_mul(t1, t2, t1);
+      for (i = 0; i < 10; ++i) {
+        fe_sq(t1, t1);
+      }
+      fe_mul(t0, t1, t0);
+      fe_sq(t1, t0);
+      for (i = 0; i < 49; ++i) {
+        fe_sq(t1, t1);
+      }
+      fe_mul(t1, t1, t0);
+      fe_sq(t2, t1);
+      for (i = 0; i < 99; ++i) {
+        fe_sq(t2, t2);
+      }
+      fe_mul(t1, t2, t1);
+      for (i = 0; i < 50; ++i) {
+        fe_sq(t1, t1);
+      }
+      fe_mul(t0, t1, t0);
+      fe_sq(t0, t0);
+      fe_sq(t0, t0);
+      fe_mul(out, t0, z);
+
+      memwipe(t0, sizeof(t0));
+      memwipe(t1, sizeof(t1));
+      memwipe(t2, sizeof(t2));
+    }
+
+    // RFC 9380 section 4: is_square(x) is true when x^((q - 1) / 2) is 0 or 1
+    // in F, which Euler's criterion makes computable in constant time. Here
+    // q = 2^255 - 19, so (q - 1) / 2 = 2^254 - 10 = 4 * (2^252 - 3) + 2 and
+    // the exponentiation is the chain above squared twice, times x^2. The
+    // result is 0, 1 or q - 1, so adding 1 gives zero exactly for the
+    // non-squares. Zero is a square, which keeps gx1 == 0 on the x1 branch.
+    unsigned int fe_is_square(const fe x)
+    {
+      fe e, xx, one;
+
+      fe_pow22523(e, x);
+      fe_sq(e, e);
+      fe_sq(e, e);
+      fe_sq(xx, x);
+      fe_mul(e, e, xx);
+      fe_1(one);
+      fe_add(e, e, one);
+
+      const unsigned int nonsquare = fe_is_zero(e);
+      memwipe(e, sizeof(e));
+      memwipe(xx, sizeof(xx));
+      return nonsquare ^ 1u;
+    }
+
+  } // anon
+
+  // Elligator 2 for Curve25519: RFC 9380 section 6.7.1 with the parameters
+  // Appendix G.2.1 fixes for this curve, J = 486662, K = 1 and Z = 2.
+  // draft-irtf-cfrg-cpace-10 section 7.2 makes this the generator step of
+  // CPace and discards the v coordinate, so no square root is taken.
+  //
+  // The input is a deterministic function of the pairing code, so no step
+  // branches on it or indexes memory with it: draft-irtf-cfrg-cpace-10
+  // section 9.8 singles out calculate_generator as the substep to compute in
+  // constant time, and RFC 9380 section 4 requires the same of CMOV and
+  // is_square. The field arithmetic is Monero's ref10 implementation and
+  // every selection is an arithmetic conditional move.
+  void elligator2_curve25519(const uint8_t r_bytes[32], uint8_t out_u[32])
+  {
+    fe one; fe_1(one);
+
+    // RFC 7748 section 5 decodeUCoordinate: clear bit 255 before reading the
+    // little-endian bytes as a field element. draft-irtf-cfrg-cpace-10
+    // section 7.2 applies it to the hashed generator string, and trezorlib
+    // does the same in curve25519.decode_coordinate. Without the mask we
+    // derive a different u than the device whenever the truncated SHA-512
+    // high bit is set, i.e. about half of all pairings, and the CPace tags
+    // mismatch.
+    CodeDerived32 masked{};
+    std::memcpy(masked.data(), r_bytes, 32);
+    masked[31] &= 0x7F;
+
+    fe u;
+    fe_frombytes(u, masked.data());
+
+    // d = 1 + Z * u^2. 2 * u^2 is formed as (u + u) * u because chaining two
+    // fe_add calls would exceed the |f| <= 1.1*2^25 input bound ref10
+    // documents for fe_add.
+    fe d;
+    fe_add(d, u, u);
+    fe_mul(d, d, u);
+    fe_add(d, d, one);
+
+    // Step 1: x1 = -(J / K) * inv0(1 + Z * u^2), K = 1. fe_invert is
+    // z^(p - 2), which is inv0: it maps 0 to 0 (RFC 9380 section 4).
+    fe neg_J; fe_neg(neg_J, FE_J);
+    fe x1;    fe_invert(x1, d);
+              fe_mul(x1, neg_J, x1);
+
+    // Step 2: if x1 == 0, set x1 = -(J / K). x1 is zero only when d is, i.e.
+    // when u^2 == -1/2; -1 is a square mod p and 2 is not, so -1/2 is a
+    // non-square and no such u exists. Section 6.7.1 records the same, noting
+    // that the exceptional case arises only when q = 3 (mod 4), whereas
+    // p = 5 (mod 8) and so p = 1 (mod 4).
+    const unsigned int x1_is_zero = fe_is_zero(x1);
+    fe_cmov(x1, neg_J, x1_is_zero);
+
+    // Step 3: gx1 = x1^3 + (J / K) * x1^2 + x1 / K^2, K = 1, evaluated as
+    // x1 * (x1 * (x1 + J) + 1).
+    fe tv;  fe_add(tv, x1, FE_J);
+            fe_mul(tv, x1, tv);
+            fe_add(tv, tv, one);
+    fe gx1; fe_mul(gx1, x1, tv);
+
+    // Step 4: x2 = -x1 - (J / K).
+    fe x2; fe_neg(x2, x1);
+           fe_sub(x2, x2, FE_J);
+
+    // Steps 6 and 7: x = x1 if gx1 is square, x2 otherwise. The y those steps
+    // also produce, step 5's gx2 and step 9's t make up the discarded v
+    // coordinate; step 8 is s = x * K with K = 1.
+    const unsigned int nonsquare = fe_is_square(gx1) ^ 1u;
+    fe x; fe_copy(x, x1);
+    fe_cmov(x, x2, nonsquare);
+
+    fe_tobytes(out_u, x);
+
+    // Each of these is a deterministic function of the pairing code, so 32
+    // recovered bytes of any of them recover the code in a million trials.
+    memwipe(u, sizeof(u));
+    memwipe(d, sizeof(d));
+    memwipe(x1, sizeof(x1));
+    memwipe(tv, sizeof(tv));
+    memwipe(gx1, sizeof(gx1));
+    memwipe(x2, sizeof(x2));
+    memwipe(x, sizeof(x));
+  }
+
+  void cpace_derive_generator(const std::string &code,
+                              const NoiseHash    &handshake_hash,
+                              uint8_t out_generator[32])
+  {
+    // Per specification.md, Notes:
+    //   prefix  = 0x08 "CPace255" 0x06                          (10 bytes)
+    //             (the IRTF CPACE-X25519-SHA512 DSI tag in the symmetric
+    //             setting; the trailing 0x06 is prepend_len(PRS))
+    //   padding = 0x6f || 0x00 * 111 || 0x20                    (113 bytes)
+    //   pregenerator = SHA-512(prefix || code || padding || handshake_hash || 0x00)[:32]
+    //   generator    = ELLIGATOR2(pregenerator)
+    static const uint8_t PREFIX[10] = {
+      0x08, 0x43, 0x50, 0x61, 0x63, 0x65, 0x32, 0x35, 0x35, 0x06,
+    };
+    static const size_t  PADDING_ZERO_BYTES = 111;
+
+    // Both constants are fixed for a six-digit code: the 0x06 above is the
+    // declared code length and the padding is 128 - (9 + (1 + 6) + 1). Any
+    // other length would silently derive a different domain, so refuse it,
+    // as firmware's own assertion does.
+    if (code.size() != 6) {
+      throw exc::ProtocolException("THP pairing: CPace code must be exactly 6 digits");
+    }
+
+    std::vector<uint8_t> input;
+    input.reserve(sizeof(PREFIX) + code.size() + 1 + PADDING_ZERO_BYTES + 1
+                  + handshake_hash.size() + 1);
+    input.insert(input.end(), PREFIX, PREFIX + sizeof(PREFIX));
+    input.insert(input.end(), code.begin(), code.end());
+    input.push_back(0x6f);
+    input.insert(input.end(), PADDING_ZERO_BYTES, 0x00);
+    input.push_back(0x20);
+    input.insert(input.end(), handshake_hash.begin(), handshake_hash.end());
+    input.push_back(0x00);
+
+    tools::scrubbed_arr<uint8_t, crypto_hash_sha512_BYTES> hash{};
+    crypto_hash_sha512(hash.data(), input.data(), input.size());
+    // The hash input carries the code; scrub it before anything can throw.
+    memwipe(input.data(), input.size());
+
+    CodeDerived32 pregenerator{};
+    std::memcpy(pregenerator.data(), hash.data(), pregenerator.size());
+    elligator2_curve25519(pregenerator.data(), out_generator);
+  }
+
+  CodeEntryPairing::CodeEntryPairing(const NoiseHash &handshake_hash)
+    : m_h(handshake_hash) {}
+
+  CodeEntryPairing::~CodeEntryPairing()
+  {
+    // m_h scrubs itself; a std::string cannot, and the code is the secret
+    // this whole exchange protects.
+    if (!m_code.empty()) {
+      memwipe(&m_code[0], m_code.size());
+    }
+  }
+
+  void CodeEntryPairing::consume_commitment_build_challenge(
+      const uint8_t *commitment, size_t len)
+  {
+    if (len != 32) {
+      throw exc::ProtocolException("THP pairing: ThpCodeEntryCommitment.commitment must be 32 bytes");
+    }
+    std::memcpy(m_commitment.data(), commitment, 32);
+    crypto::generate_random_bytes_thread_safe(m_challenge.size(), m_challenge.data());
+  }
+
+  void CodeEntryPairing::consume_cpace_trezor(const uint8_t *cpace_trezor_pub, size_t len)
+  {
+    if (len != 32) {
+      throw exc::ProtocolException("THP pairing: ThpCodeEntryCpaceTrezor.cpace_trezor_public_key must be 32 bytes");
+    }
+    std::memcpy(m_cpace_trezor_pub.data(), cpace_trezor_pub, 32);
+    m_have_trezor_pub = true;
+  }
+
+  CpaceHostTag CodeEntryPairing::build_host_tag(const epee::wipeable_string &code)
+  {
+    if (!m_have_trezor_pub) {
+      throw exc::ProtocolException("THP pairing: build_host_tag before ThpCodeEntryCpaceTrezor");
+    }
+    if (code.empty() || code.size() > 6) {
+      throw exc::ProtocolException("THP pairing: code must be 1 to 6 digits");
+    }
+    for (size_t i = 0; i < code.size(); ++i) {
+      const char c = code.data()[i];
+      if (c < '0' || c > '9') {
+        throw exc::ProtocolException("THP pairing: code must be ASCII digits");
+      }
+    }
+    // The device hashes the code as exactly six ASCII digits, zero-padded on
+    // the left, so a user who drops a leading zero still pairs. trezorlib
+    // demands six characters from its caller; being lenient costs nothing
+    // because the device remains the authority - a wrong code of any length
+    // fails its own tag check. Built in place so there is no second copy of
+    // the code to scrub, and six characters never leave the string's own
+    // storage.
+    m_code.assign(6 - code.size(), '0');
+    m_code.append(code.data(), code.size());
+
+    // generator = ELLIGATOR2(SHA-512(prefix || code || padding || h || 0x00)[:32])
+    CodeDerived32 generator{};
+    cpace_derive_generator(m_code, m_h, generator.data());
+
+    // CPace does not clamp its scalar, but libsodium's X25519 clamps
+    // unconditionally; the IRTF draft allows this and the reference
+    // implementation behaves the same way.
+    NoisePrivKey priv{};
+    crypto::generate_random_bytes_thread_safe(priv.size(), priv.data());
+
+    CpaceHostTag out{};
+    // cpace_host_public_key = X25519(cpace_host_private_key, generator)
+    noise_crypto::x25519(priv, generator, out.cpace_host_public_key);
+
+    // tag = SHA-256(X25519(cpace_host_private_key, cpace_trezor_public_key))
+    CodeDerived32 shared{};
+    noise_crypto::x25519(priv, m_cpace_trezor_pub, shared);
+    crypto_hash_sha256(out.tag.data(), shared.data(), shared.size());
+
+    m_have_host_tag = true;
+    return out;
+  }
+
+  bool CodeEntryPairing::consume_secret(const uint8_t *secret, size_t len)
+  {
+    if (!m_have_host_tag) {
+      throw exc::ProtocolException("THP pairing: consume_secret before host tag sent");
+    }
+    if (len != 16) {
+      throw exc::ProtocolException("THP pairing: ThpCodeEntrySecret.secret must be 16 bytes");
+    }
+
+    // (a) commitment == SHA-256(secret)
+    NoiseHash expected_commit{};
+    crypto_hash_sha256(expected_commit.data(), secret, len);
+    if (sodium_memcmp(expected_commit.data(), m_commitment.data(), 32) != 0) {
+      return false;
+    }
+
+    // (b) code == SHA-256(ThpPairingMethod_CodeEntry || h || secret || challenge)
+    //     read big-endian, mod 1000000. CodeEntry is enum value 2 and the
+    //     hash input takes the raw enum number as one byte.
+    std::vector<uint8_t> chash_in;
+    chash_in.reserve(1 + m_h.size() + len + m_challenge.size());
+    chash_in.push_back(0x02);
+    chash_in.insert(chash_in.end(), m_h.begin(), m_h.end());
+    chash_in.insert(chash_in.end(), secret, secret + len);
+    chash_in.insert(chash_in.end(), m_challenge.begin(), m_challenge.end());
+    NoiseHash code_hash{};
+    crypto_hash_sha256(code_hash.data(), chash_in.data(), chash_in.size());
+    memwipe(chash_in.data(), chash_in.size());
+
+    uint64_t derived = 0;
+    for (uint8_t b : code_hash) derived = (derived * 256 + b) % 1000000;
+
+    // m_code was validated as digits by build_host_tag.
+    uint64_t entered = 0;
+    for (char c : m_code) entered = entered * 10 + uint64_t(c - '0');
+
+    if (entered != derived) {
+      return false;
+    }
+    m_paired = true;
+    return true;
+  }
+
+}}}

--- a/src/device_trezor/trezor/thp/pairing.hpp
+++ b/src/device_trezor/trezor/thp/pairing.hpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef MONERO_TREZOR_THP_PAIRING_H
+#define MONERO_TREZOR_THP_PAIRING_H
+
+#include "noise.hpp"
+#include "wipeable_string.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+namespace hw {
+namespace trezor {
+namespace thp {
+
+  // Elligator 2 map for Curve25519 (RFC 9380 section 6.7.1 and Appendix
+  // G.2.1 / draft-irtf-cfrg-cpace-10 section 7.2, CPaceMontgomery). Maps a
+  // uniform 32-byte input to a Curve25519 u-coordinate, which is the
+  // password-binding step of CPace.
+  //
+  // `r_bytes` is interpreted little-endian with bit 255 cleared and reduced
+  // mod p = 2^255 - 19; the u-coordinate is encoded little-endian.
+  //
+  // `r_bytes` carries the pairing code, so the map runs in constant time:
+  // no branch and no memory index depends on it.
+  void elligator2_curve25519(const uint8_t r_bytes[32], uint8_t out_u[32]);
+
+  // CPace generator derivation per the THP spec, matching the IRTF
+  // CPACE-X25519-SHA512 symmetric-setting suite:
+  //   pregenerator = SHA-512(prefix || code || padding || handshake_hash || 0x00)[:32]
+  //   generator    = ELLIGATOR2(pregenerator)
+  // `prefix` and `padding` are the constants in specification.md, Notes,
+  // under "Code Entry pairing sequence".
+  //
+  // `code` must be exactly six ASCII digits, e.g. "001234": the length is
+  // baked into both constants, so any other length silently derives a
+  // different domain. Throws otherwise. `handshake_hash` is the
+  // post-handshake h.
+  void cpace_derive_generator(const std::string &code,
+                              const NoiseHash    &handshake_hash,
+                              uint8_t out_generator[32]);
+
+  // Contents of ThpCodeEntryCpaceHostTag, for the caller to place into the
+  // generated protobuf message.
+  struct CpaceHostTag {
+    std::array<uint8_t, 32> cpace_host_public_key{};
+    std::array<uint8_t, 32> tag{};
+  };
+
+  // Host side of the CodeEntry pairing FSM: states HP2 -> HP3a -> HP4 -> HP5
+  // -> HC0 of specification.md. The preceding ThpPairingRequest /
+  // ThpSelectMethod exchange (HP0 -> HP2) is the caller's.
+  class CodeEntryPairing {
+  public:
+    explicit CodeEntryPairing(const NoiseHash &handshake_hash);
+    ~CodeEntryPairing();
+
+    // HP2 -> HP3a: consume ThpCodeEntryCommitment and draw the random
+    // 16-byte challenge, which the caller then sends.
+    void consume_commitment_build_challenge(const uint8_t *commitment, size_t len);
+
+    // HP3a -> HP4: consume ThpCodeEntryCpaceTrezor.
+    void consume_cpace_trezor(const uint8_t *cpace_trezor_pub, size_t len);
+
+    // HP4 -> HP5: derive the ThpCodeEntryCpaceHostTag fields from the
+    // user-entered `code` (one to six ASCII digits, left-padded to six).
+    CpaceHostTag build_host_tag(const epee::wipeable_string &code);
+
+    // HP5 -> HC0: consume ThpCodeEntrySecret. Verifies that the commitment
+    // matches SHA-256(secret) and that the user-entered code matches the
+    // SHA-256 derivation. Returns false if either check fails.
+    bool consume_secret(const uint8_t *secret, size_t len);
+
+    bool is_paired() const { return m_paired; }
+    const std::array<uint8_t, 16> &challenge() const { return m_challenge; }
+
+  private:
+    NoiseHash                m_h{};
+    std::array<uint8_t, 16>  m_challenge{};
+    std::array<uint8_t, 32>  m_commitment{};
+    std::array<uint8_t, 32>  m_cpace_trezor_pub{};
+    std::string              m_code;
+    bool                     m_have_trezor_pub = false;
+    bool                     m_have_host_tag   = false;
+    bool                     m_paired          = false;
+  };
+
+}}}
+
+#endif // MONERO_TREZOR_THP_PAIRING_H

--- a/src/device_trezor/trezor/thp/protocol_v2.cpp
+++ b/src/device_trezor/trezor/thp/protocol_v2.cpp
@@ -1,0 +1,632 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "protocol_v2.hpp"
+#include "framing.hpp"
+#include "device_trezor/trezor/exceptions.hpp"
+
+#include "crypto/crypto.h"
+
+#include <cstdio>
+#include <cstring>
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "device.trezor.thp"
+
+namespace hw {
+namespace trezor {
+namespace thp {
+
+  static constexpr size_t NONCE_BYTES = 8;
+  static constexpr size_t ALLOC_RESPONSE_FIXED_BYTES = NONCE_BYTES + sizeof(uint16_t);
+
+  // Budget for the whole handshake, in milliseconds. Nothing in it waits on
+  // the user, so a device that stops answering must not hold the device lock
+  // for longer than this.
+  static constexpr unsigned int HANDSHAKE_TIMEOUT_MS = 30000;
+  // Budget for one application-level exchange. A response may wait on an
+  // on-device confirmation, hence the generous value; it exists only so the
+  // wallet cannot block forever on a wedged device.
+  static constexpr unsigned int EXCHANGE_TIMEOUT_MS = 300000;
+
+  // Chunks read during one channel allocation, and frames tolerated within
+  // one exchange, before the operation is abandoned.
+  static constexpr unsigned int MAX_ALLOC_CHUNKS = 64;
+  static constexpr unsigned int MAX_FRAMES_PER_EXCHANGE = 16;
+
+  using Deadline = std::chrono::steady_clock::time_point;
+
+  static Deadline deadline_in(unsigned int timeout_ms)
+  {
+    return std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+  }
+
+  // Milliseconds left before `deadline`, zero once it has passed. Callers
+  // must not pass zero on to Transport::read_chunk, where it means "no
+  // timeout".
+  static unsigned int remaining_ms(const Deadline &deadline)
+  {
+    const auto left = std::chrono::duration_cast<std::chrono::milliseconds>(
+        deadline - std::chrono::steady_clock::now()).count();
+    return left > 0 ? static_cast<unsigned int>(left) : 0;
+  }
+
+  // A protocol-v1 device answers the broadcast allocation request with a
+  // codec_v1 report, which always starts with the magic '?','#','#'.
+  static bool is_codec_v1_report(const uint8_t *chunk, size_t len)
+  {
+    return len >= 3 && chunk[0] == '?' && chunk[1] == '#' && chunk[2] == '#';
+  }
+
+  AllocationResult allocate_channel(Transport &transport, AllocatedChannel &out,
+                                    unsigned int timeout_ms)
+  {
+    AllocatedChannel alloc;
+    alloc.nonce.resize(NONCE_BYTES);
+    crypto::generate_random_bytes_thread_safe(alloc.nonce.size(), alloc.nonce.data());
+
+    const size_t cs = transport.chunk_size();
+    auto wire = encode_frame(CTRL_CHANNEL_ALLOC_REQUEST, CID_BROADCAST,
+                             alloc.nonce.data(), alloc.nonce.size(), cs);
+    for (size_t off = 0; off < wire.size(); off += cs) {
+      transport.write_chunk(wire.data() + off, cs);
+    }
+
+    // Allocation read loop. Chunks that do not parse as THP are discarded
+    // rather than fatal: this is the probe, and a protocol-v1 device answers
+    // it with codec_v1 line noise that must not abort the connection. The
+    // encrypted-transport loop in recv_frame() below deliberately does the
+    // opposite.
+    //
+    // Per THP spec, "Allocation layer": a response whose nonce differs from
+    // the one sent is ignored and the host keeps waiting. The same applies to
+    // stale frames left in the USB buffer by a previous session.
+    const Deadline deadline = deadline_in(timeout_ms);
+    FrameAssembler asm_;
+    std::vector<uint8_t> chunk(cs);
+    unsigned int chunks = 0;
+
+    while (chunks++ < MAX_ALLOC_CHUNKS) {
+      const unsigned int left = remaining_ms(deadline);
+      if (left == 0) {
+        return AllocationResult::no_response;
+      }
+
+      size_t got = 0;
+      try {
+        got = transport.read_chunk(chunk.data(), cs, left);
+      } catch (const exc::TimeoutException &) {
+        return AllocationResult::no_response;
+      }
+      if (got == 0) {
+        throw exc::CommunicationException("THP: zero-length chunk during channel allocation");
+      }
+      if (is_codec_v1_report(chunk.data(), got)) {
+        MDEBUG("THP alloc: codec_v1 reply to the broadcast probe; legacy device");
+        return AllocationResult::codec_v1_reply;
+      }
+
+      Frame f;
+      try {
+        if (!asm_.feed_chunk(chunk.data(), got)) {
+          continue;
+        }
+        f = asm_.take();
+      } catch (const exc::CommunicationException &e) {
+        MDEBUG("THP alloc: discarding unparseable chunk (" << e.what() << ")");
+        asm_.reset();
+        continue;
+      }
+
+      if (f.channel_id != CID_BROADCAST) {
+        MDEBUG("THP alloc: ignoring frame on non-broadcast channel 0x"
+               << std::hex << f.channel_id);
+        continue;
+      }
+      if (f.control_byte != CTRL_CHANNEL_ALLOC_RESPONSE) {
+        MDEBUG("THP alloc: ignoring frame with control byte 0x"
+               << std::hex << int(f.control_byte));
+        continue;
+      }
+      if (f.payload.size() < ALLOC_RESPONSE_FIXED_BYTES) {
+        MDEBUG("THP alloc: ignoring truncated alloc response (size=" << f.payload.size() << ")");
+        continue;
+      }
+      if (std::memcmp(f.payload.data(), alloc.nonce.data(), NONCE_BYTES) != 0) {
+        MDEBUG("THP alloc: ignoring response with mismatched nonce (likely stale from previous session)");
+        continue;
+      }
+
+      alloc.channel_id = read_be16(f.payload.data() + NONCE_BYTES);
+      if (alloc.channel_id == CID_INVALID || alloc.channel_id >= CID_RESERVED_LOW) {
+        throw exc::CommunicationException("THP: device returned reserved CID");
+      }
+
+      // The remaining bytes are the protobuf-encoded device properties; the
+      // caller decodes them lazily.
+      if (f.payload.size() > ALLOC_RESPONSE_FIXED_BYTES) {
+        alloc.device_properties_pb.assign(f.payload.begin() + ALLOC_RESPONSE_FIXED_BYTES,
+                                          f.payload.end());
+      }
+      out = std::move(alloc);
+      return AllocationResult::allocated;
+    }
+
+    MDEBUG("THP alloc: no usable response within " << MAX_ALLOC_CHUNKS << " chunks");
+    return AllocationResult::no_response;
+  }
+
+  ProtocolV2::ProtocolV2() = default;
+
+  void ProtocolV2::send_frame(Transport &transport, uint8_t control_byte,
+                              const uint8_t *payload, size_t payload_len)
+  {
+    const size_t cs = transport.chunk_size();
+    auto wire = encode_frame(control_byte, m_channel.channel_id,
+                             payload, payload_len, cs);
+    for (size_t off = 0; off < wire.size(); off += cs) {
+      transport.write_chunk(wire.data() + off, cs);
+    }
+  }
+
+  Frame ProtocolV2::recv_frame(Transport &transport, const Deadline &deadline)
+  {
+    FrameAssembler asm_;
+    const size_t cs = transport.chunk_size();
+    std::vector<uint8_t> chunk(cs);
+
+    // Encrypted-transport read loop. Unlike the allocation probe above,
+    // nothing is discarded here: the channel is established, so a chunk that
+    // does not parse is a genuine fault and must abort the exchange.
+    while (true) {
+      const unsigned int left = remaining_ms(deadline);
+      if (left == 0) {
+        throw exc::TimeoutException("THP: timed out waiting for a device frame");
+      }
+      const size_t got = transport.read_chunk(chunk.data(), cs, left);
+      if (got == 0) {
+        throw exc::CommunicationException("THP: zero-length chunk in recv_frame");
+      }
+      // Some carriers deliver chunks shorter than cs; FrameAssembler ends
+      // the frame on the declared length rather than on the chunk count.
+      if (asm_.feed_chunk(chunk.data(), got)) {
+        return asm_.take();
+      }
+    }
+  }
+
+  void ProtocolV2::set_host_static_key(const HostStaticKey &key)
+  {
+    m_host_static = key;
+    m_have_host_static = true;
+  }
+
+  void ProtocolV2::set_known_devices(std::vector<KnownDevice> known)
+  {
+    m_known_devices = std::move(known);
+  }
+
+  void ProtocolV2::adopt_allocation(const AllocatedChannel &allocation)
+  {
+    m_channel         = allocation;
+    m_have_allocation = true;
+  }
+
+  void ProtocolV2::session_begin(Transport &transport) {
+    if (m_session_open) {
+      return;
+    }
+    if (!m_have_host_static) {
+      // Without a persisted key the unpaired (TOFU) flow still has to run;
+      // the device-glue layer persists this one and passes it back via
+      // set_host_static_key on the next session.
+      MINFO("THP: no persisted host static key; generating a fresh one (TOFU)");
+      noise_crypto::x25519_keypair(m_host_static.pub, m_host_static.priv);
+      m_have_host_static = true;
+    }
+
+    // 1. Channel allocation on the broadcast CID, unless the auto-detect
+    //    layer already did it as part of the probe.
+    if (!m_have_allocation) {
+      if (allocate_channel(transport, m_channel) != AllocationResult::allocated) {
+        throw exc::TimeoutException("THP: no channel allocation response from device");
+      }
+    }
+    MTRACE("THP: allocated channel " << m_channel.channel_id);
+
+    // 2. Wire device properties + persisted credentials into the handshake.
+    m_handshake.set_device_properties(m_channel.device_properties_pb.data(),
+                                      m_channel.device_properties_pb.size());
+    m_handshake.set_host_static_key(m_host_static);
+    m_handshake.set_known_devices(std::move(m_known_devices));
+
+    // Per THP spec (docs/common/thp/specification.md, "Transport packet
+    // structure" table):
+    //  - DATA-packet type mask is 0xE7. Bit 4 (0x10) is the sequence bit;
+    //    bit 3 (0x08) is the optional piggyback-ACK bit. Both must be
+    //    masked off when matching the message type.
+    //  - ACK packets are matched via Frame::is_ack() below; the 0xF7 ACK
+    //    type-mask is encoded inside that helper, so it is not needed
+    //    as a local constant here.
+    constexpr uint8_t MSG_TYPE_MASK = CTRL_DATA_MASK; // 0xE7
+    auto hex2 = [](uint8_t b){ char s[5]; std::snprintf(s, sizeof(s), "%02x", b); return std::string(s); };
+
+    // The handshake never waits on the user, so the whole of it shares one
+    // budget.
+    const Deadline deadline = deadline_in(HANDSHAKE_TIMEOUT_MS);
+
+    auto recv_specific = [&](uint8_t want_base, const char *what) -> Frame {
+      unsigned int frames = 0;
+      while (true) {
+        if (frames++ >= MAX_FRAMES_PER_EXCHANGE) {
+          throw exc::ProtocolException(std::string("THP: too many unexpected frames waiting for ") + what);
+        }
+        Frame fr = recv_frame(transport, deadline);
+        MTRACE("THP: rx ctrl=0x" << hex2(fr.control_byte)
+               << " cid=0x" << std::hex << fr.channel_id << std::dec
+               << " len=" << fr.payload.size()
+               << " (waiting for " << what << ")");
+        if (fr.channel_id != m_channel.channel_id) {
+          MDEBUG("THP: dropping frame on unexpected channel " << fr.channel_id);
+          continue;
+        }
+        if ((fr.control_byte & MSG_TYPE_MASK) == (want_base & MSG_TYPE_MASK)) {
+          return fr;
+        }
+        if (fr.is_ack()) {
+          MDEBUG("THP: stray ACK 0x" << hex2(fr.control_byte) << " while waiting for " << what);
+          continue;
+        }
+        if (fr.control_byte == CTRL_TRANSPORT_ERROR) {
+          throw exc::ProtocolException(std::string("THP: transport error during ") + what);
+        }
+        throw exc::ProtocolException(std::string("THP: unexpected frame waiting for ") + what +
+                                     " (got control 0x" + hex2(fr.control_byte) + ")");
+      }
+    };
+
+    auto consume_ack = [&](uint8_t want_seq, const char *what) {
+      unsigned int frames = 0;
+      while (true) {
+        if (frames++ >= MAX_FRAMES_PER_EXCHANGE) {
+          throw exc::ProtocolException(std::string("THP: too many unexpected frames waiting for ACK after ") + what);
+        }
+        Frame fr = recv_frame(transport, deadline);
+        MTRACE("THP: rx ctrl=0x" << hex2(fr.control_byte)
+               << " cid=0x" << std::hex << fr.channel_id << std::dec
+               << " (waiting for ACK seq=" << int(want_seq) << " after " << what << ")");
+        if (fr.channel_id != m_channel.channel_id) {
+          continue;
+        }
+        // ACK match must check is_ack() (under CTRL_ACK_MASK 0xF7, which
+        // strips bit 3 / the seq bit) AND then read the seq bit from the
+        // raw control byte. Comparing the masked value to an unmasked
+        // CTRL_ACK_SEQ1 (=0x28) would always fail because the mask clears
+        // the seq bit on the left side of the equality.
+        if (fr.is_ack()) {
+          if (fr.ack_seq_bit() == want_seq) {
+            return;
+          }
+          MDEBUG("THP: ignoring ACK 0x" << hex2(fr.control_byte) << " (wrong seq) after " << what);
+          continue;
+        }
+        throw exc::ProtocolException(std::string("THP: expected ACK after ") + what +
+                                     " (got control 0x" + hex2(fr.control_byte) + ")");
+      }
+    };
+
+    MINFO("THP: starting handshake on channel " << m_channel.channel_id);
+
+    // 3. host -> device: HandshakeInitiationRequest (base 0x00, seq=0).
+    auto init_req = m_handshake.build_init_request(/*try_to_unlock=*/false);
+    MTRACE("THP: tx HandshakeInitRequest len=" << init_req.size());
+    send_frame(transport, CTRL_HANDSHAKE_INIT_REQ,
+               init_req.data(), init_req.size());
+    // 3a. device ACKs the request (seq=0).
+    consume_ack(0, "HandshakeInitRequest");
+
+    // 4. device -> host: HandshakeInitiationResponse (base 0x01, device seq=0).
+    Frame init_resp = recv_specific(CTRL_HANDSHAKE_INIT_RESP, "HandshakeInitResponse");
+    m_handshake.consume_init_response(init_resp.payload.data(),
+                                      init_resp.payload.size());
+    // 4a. host ACKs the response (seq=0).
+    send_frame(transport, CTRL_ACK_SEQ0, nullptr, 0);
+
+    // 5. host -> device: HandshakeCompletionRequest (base 0x02, seq=1, wire 0x12).
+    //    Per THP spec, the data-packet sequence bit lives at 0x10, not 0x08.
+    //    Bit 0x08 is the optional piggyback-ACK bit and must remain 0 here
+    //    (host has already sent a standalone ACK_SEQ0 for the init response).
+    auto comp_req = m_handshake.build_completion_request();
+    MTRACE("THP: tx HandshakeCompletionRequest len=" << comp_req.size() << " ctrl=0x12");
+    send_frame(transport, CTRL_HANDSHAKE_COMP_REQ | CTRL_DATA_SEQ_BIT,
+               comp_req.data(), comp_req.size());
+    // 5a. device ACKs (seq=1).
+    consume_ack(1, "HandshakeCompletionRequest");
+
+    // 6. device -> host: HandshakeCompletionResponse (base 0x03, device seq=1, wire 0x13).
+    Frame comp_resp = recv_specific(CTRL_HANDSHAKE_COMP_RESP, "HandshakeCompletionResponse");
+    m_handshake.consume_completion_response(comp_resp.payload.data(),
+                                            comp_resp.payload.size());
+    // 6a. host ACKs (seq=1).
+    send_frame(transport, CTRL_ACK_SEQ1, nullptr, 0);
+
+    MINFO("THP: handshake complete on channel " << m_channel.channel_id);
+
+    // If consume_init_response matched a previously-paired device, the
+    // handshake's internal host_static was swapped to the credential
+    // we'd persisted for that device. Pull that authoritative copy back
+    // up so host_static() returns the correct keypair for the duration
+    // of this session.
+    m_host_static = m_handshake.host_static_in_use();
+
+    // 7. Build cipherstates per specification.md (encryption_state: nonce
+    //    counters start at 0 for outgoing requests and 1 for incoming
+    //    responses, since the HandshakeCompletionResponse already consumed
+    //    the response counter at 0).
+    const HandshakeKeys &keys = m_handshake.keys();
+    m_send_cipher = std::make_unique<TransportCipher>(keys.key_request,  /*nonce=*/0);
+    m_recv_cipher = std::make_unique<TransportCipher>(keys.key_response, /*nonce=*/1);
+    m_send_seq = 0;
+    m_recv_seq = 0;
+    m_have_pending_frame = false;
+    m_pending_frame = Frame{};
+
+    if (!m_handshake.is_known_device() &&
+        m_handshake.trezor_state() == STATE_UNPAIRED) {
+      // First-time pairing is required to upgrade to an authenticated
+      // session.  The caller (ProtocolAutoDetect) drives the CodeEntry
+      // pairing FSM right after this returns; until that succeeds the
+      // channel must be treated as unauthenticated.
+      MINFO("THP: device is unpaired; CodeEntry pairing follows");
+    }
+    m_session_open = true;
+  }
+
+  void ProtocolV2::session_end(Transport & /*transport*/) {
+    m_send_cipher.reset();
+    m_recv_cipher.reset();
+    m_have_pending_frame = false;
+    m_pending_frame = Frame{};
+    m_session_open = false;
+  }
+
+  void ProtocolV2::write(Transport &transport,
+                         const google::protobuf::Message &req) {
+    if (!m_session_open || !m_send_cipher) {
+      throw exc::ProtocolException("THP: write before session_begin");
+    }
+    if (m_have_pending_frame) {
+      // The caller issued a new request without reading the previous
+      // response; the parked frame is now stale.
+      MDEBUG("THP: discarding unconsumed response frame on new write");
+      m_pending_frame      = Frame{};
+      m_have_pending_frame = false;
+    }
+
+    // Plaintext layout for THP application messages (matches the canonical
+    // Python `trezorlib.thp.client` HEADER_FMT = ">BH"):
+    //   byte 0    : session_id (1 byte). 0x00 is the implicit seedless
+    //                                    management session (pairing /
+    //                                    credential / GetFeatures);
+    //                                    application traffic that needs seed
+    //                                    access must run on a session
+    //                                    allocated via ThpCreateNewSession.
+    //   bytes 1-2 : message_type wire number (uint16, big-endian)
+    //   bytes 3.. : protobuf-serialized payload
+    constexpr size_t  PLAIN_HEADER_LEN      = 3;
+    uint16_t wire_num = MessageMapper::get_message_wire_number(req);
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+    size_t msg_size = req.ByteSize();
+#else
+    size_t msg_size = req.ByteSizeLong();
+#endif
+
+    // V1-vs-V2 message translation. Monero's device_trezor_base unconditionally
+    // sends a management::Initialize (msg_type 0) at the start of every command
+    // chain. THP devices reject Initialize as Failure_UnexpectedMessage; the
+    // canonical trezorlib client uses GetFeatures (msg_type 55) instead. The
+    // Initialize.session_id field is meaningless under THP (sessions are
+    // multiplexed via the encrypted plaintext header byte, not in-protobuf),
+    // so we drop the body and send an empty GetFeatures.
+    bool translated_initialize = false;
+    if (wire_num == static_cast<uint16_t>(messages::MessageType_Initialize)) {
+      wire_num = static_cast<uint16_t>(messages::MessageType_GetFeatures);
+      msg_size = 0; // GetFeatures has no fields
+      translated_initialize = true;
+    }
+
+    std::vector<uint8_t> plain;
+    plain.resize(PLAIN_HEADER_LEN + msg_size);
+    plain[0] = m_session_id;
+    write_be16(plain.data() + 1, wire_num);
+    if (!translated_initialize && msg_size > 0) {
+      if (!req.SerializeToArray(plain.data() + PLAIN_HEADER_LEN, msg_size)) {
+        throw exc::EncodingException("THP: protobuf serialize failed");
+      }
+    }
+
+    std::vector<uint8_t> sealed;
+    m_send_cipher->seal(/*aad=*/nullptr, /*aad_len=*/0,
+                        plain.data(), plain.size(), sealed);
+
+    const uint8_t control = CTRL_ENCRYPTED_TRANSPORT |
+                            (m_send_seq ? CTRL_DATA_SEQ_BIT : 0);
+    send_frame(transport, control, sealed.data(), sealed.size());
+
+    // Wait for the device to acknowledge the alternating bit.  USB does
+    // not reorder, but ACKs can be duplicated or piggybacked, so accept
+    // every spec-legal way the device can signal receipt instead of
+    // demanding the very next frame be the exact standalone ACK:
+    //   - skip frames addressed to other channels,
+    //   - skip duplicate ACKs bearing the previous sequence bit,
+    //   - re-ACK and drop a retransmission of the response we already
+    //     consumed (our earlier ACK may have been lost),
+    //   - treat a response data frame as implicit acknowledgement (the
+    //     spec allows piggybacking the ACK bit on data; and a response
+    //     proves the request was received either way) and park it for
+    //     the next read().
+    // Host-side retransmission-on-timeout is not implemented; like the
+    // pre-existing v1 protocol we rely on the carrier being reliable.
+    const Deadline deadline = deadline_in(EXCHANGE_TIMEOUT_MS);
+    unsigned int frames = 0;
+    while (true) {
+      if (frames++ >= MAX_FRAMES_PER_EXCHANGE) {
+        throw exc::ProtocolException("THP: too many unexpected frames while waiting for write ACK");
+      }
+      Frame fr = recv_frame(transport, deadline);
+      if (fr.channel_id != m_channel.channel_id) {
+        MDEBUG("THP: dropping frame on unexpected channel " << fr.channel_id
+               << " while waiting for write ACK");
+        continue;
+      }
+      if (fr.is_ack()) {
+        if (fr.ack_seq_bit() == m_send_seq) {
+          break;
+        }
+        MDEBUG("THP: ignoring duplicate ACK (seq " << int(fr.ack_seq_bit())
+               << ") while waiting for write ACK");
+        continue;
+      }
+      if ((fr.control_byte & CTRL_DATA_MASK) == CTRL_ENCRYPTED_TRANSPORT) {
+        if (fr.data_seq_bit() != m_recv_seq) {
+          // Retransmission of the previous response: our ACK for it was
+          // lost.  Re-ACK with the frame's own sequence bit and keep
+          // waiting.
+          MDEBUG("THP: re-ACKing retransmitted response (seq "
+                 << int(fr.data_seq_bit()) << ") while waiting for write ACK");
+          send_frame(transport,
+                     fr.data_seq_bit() ? CTRL_ACK_SEQ1 : CTRL_ACK_SEQ0,
+                     nullptr, 0);
+          continue;
+        }
+        // The device's response to the request we just sent is an implicit
+        // acknowledgement.  Hand it to the next read().
+        m_pending_frame      = std::move(fr);
+        m_have_pending_frame = true;
+        break;
+      }
+      if (fr.control_byte == CTRL_TRANSPORT_ERROR) {
+        throw exc::ProtocolException("THP: transport error while waiting for write ACK");
+      }
+      throw exc::ProtocolException("THP: missing or mismatched ACK after write");
+    }
+    m_send_seq ^= 1;
+  }
+
+  void ProtocolV2::read(Transport &transport,
+                        std::shared_ptr<google::protobuf::Message> &msg,
+                        messages::MessageType *msg_type) {
+    if (!m_session_open || !m_recv_cipher) {
+      throw exc::ProtocolException("THP: read before session_begin");
+    }
+
+    // A write() may have parked the device's response here when the ACK
+    // was piggybacked on it; otherwise read from the wire, tolerating
+    // duplicated ACKs and retransmitted frames (re-ACK and drop) instead
+    // of aborting the session mid-operation.
+    Frame f;
+    if (m_have_pending_frame) {
+      f = std::move(m_pending_frame);
+      m_pending_frame      = Frame{};
+      m_have_pending_frame = false;
+    } else {
+      const Deadline deadline = deadline_in(EXCHANGE_TIMEOUT_MS);
+      unsigned int frames = 0;
+      while (true) {
+        if (frames++ >= MAX_FRAMES_PER_EXCHANGE) {
+          throw exc::ProtocolException("THP: too many unexpected frames during read");
+        }
+        f = recv_frame(transport, deadline);
+        if (f.channel_id != m_channel.channel_id) {
+          MDEBUG("THP: dropping frame on unexpected channel " << f.channel_id
+                 << " during read");
+          continue;
+        }
+        if (f.is_ack()) {
+          MDEBUG("THP: ignoring stray ACK during read");
+          continue;
+        }
+        // Match encrypted_transport under the spec's DATA_MASK (0xE7),
+        // which strips both the seq bit (0x10) and the optional
+        // piggyback-ACK bit (0x08). Using 0xF7 here would reject every
+        // frame with seq=1.
+        if ((f.control_byte & CTRL_DATA_MASK) != CTRL_ENCRYPTED_TRANSPORT) {
+          throw exc::ProtocolException("THP: read got unexpected frame type");
+        }
+        if (f.data_seq_bit() != m_recv_seq) {
+          // Retransmission of the previous frame: the device did not see
+          // our ACK.  Per the alternating-bit protocol, re-ACK it and
+          // keep waiting for the frame we actually expect.
+          MDEBUG("THP: re-ACKing retransmitted frame (seq "
+                 << int(f.data_seq_bit()) << ") during read");
+          send_frame(transport,
+                     f.data_seq_bit() ? CTRL_ACK_SEQ1 : CTRL_ACK_SEQ0,
+                     nullptr, 0);
+          continue;
+        }
+        break;
+      }
+    }
+
+    std::vector<uint8_t> plain;
+    if (!m_recv_cipher->open(/*aad=*/nullptr, /*aad_len=*/0,
+                             f.payload.data(), f.payload.size(), plain)) {
+      throw exc::SecurityException("THP: AES-GCM decrypt failed");
+    }
+    // Plaintext: session_id(1) || msg_type(2 BE) || protobuf payload.
+    constexpr size_t PLAIN_HEADER_LEN = 3;
+    if (plain.size() < PLAIN_HEADER_LEN) {
+      throw exc::ProtocolException("THP: decrypted payload too small");
+    }
+    // The device mirrors the request's session id; a mismatch would mean
+    // a reply routed from a different session.  Warn rather than throw:
+    // the host drives strictly one request/response pair at a time, and
+    // the message itself authenticated under the channel keys.
+    if (plain[0] != m_session_id) {
+      MWARNING("THP: response carries session id " << int(plain[0])
+               << " but session " << int(m_session_id) << " is active");
+    }
+    const uint16_t wire_num = read_be16(plain.data() + 1);
+
+    std::shared_ptr<google::protobuf::Message> wrap(MessageMapper::get_message(wire_num));
+    if (!wrap->ParseFromArray(plain.data() + PLAIN_HEADER_LEN,
+                              plain.size() - PLAIN_HEADER_LEN)) {
+      throw exc::EncodingException("THP: protobuf parse failed");
+    }
+    msg = wrap;
+    if (msg_type) {
+      *msg_type = static_cast<messages::MessageType>(wire_num);
+    }
+
+    // ACK the frame.
+    const uint8_t ack_ctrl = m_recv_seq ? CTRL_ACK_SEQ1 : CTRL_ACK_SEQ0;
+    send_frame(transport, ack_ctrl, nullptr, 0);
+    m_recv_seq ^= 1;
+  }
+
+}}}

--- a/src/device_trezor/trezor/thp/protocol_v2.hpp
+++ b/src/device_trezor/trezor/thp/protocol_v2.hpp
@@ -1,0 +1,201 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef MONERO_TREZOR_THP_PROTOCOL_V2_H
+#define MONERO_TREZOR_THP_PROTOCOL_V2_H
+
+#include "device_trezor/trezor/transport.hpp"
+#include "framing.hpp"
+#include "noise.hpp"
+
+#include <chrono>
+#include <memory>
+
+namespace hw {
+namespace trezor {
+namespace thp {
+
+  // Trezor's reported state byte from HandshakeCompletionResponse.
+  // Per specification.md these are the only documented values.
+  constexpr uint8_t STATE_UNPAIRED            = 0x00;
+  constexpr uint8_t STATE_PAIRED              = 0x01;
+  constexpr uint8_t STATE_PAIRED_AUTOCONNECT  = 0x02;
+
+  // Budget for a whole channel allocation, in milliseconds. A Safe 7
+  // answers in milliseconds; a protocol-v1 device never answers at all,
+  // and the caller falls back to ProtocolV1 once this expires.
+  constexpr unsigned int ALLOC_TIMEOUT_MS = 3000;
+
+  // Information returned by the device in a ChannelAllocationResponse.
+  // device_properties_pb is an opaque protobuf payload (DeviceProperties
+  // from trezor-firmware) that the higher protocol layer decodes.
+  struct AllocatedChannel {
+    uint16_t channel_id = 0;      // allocated CID, in 0x0001..0xFFEF
+    std::vector<uint8_t> nonce;   // 8-byte nonce echoed by the device
+    std::vector<uint8_t> device_properties_pb;
+  };
+
+  // Outcome of a channel allocation attempt.
+  enum class AllocationResult {
+    allocated,
+    no_response,    // the budget expired without a usable response
+    codec_v1_reply, // the device answered with a codec_v1 report
+  };
+
+  // Allocate a new channel on the broadcast CID 0xFFFF: send a
+  // ChannelAllocationRequest carrying a random 8-byte nonce and wait for the
+  // ChannelAllocationResponse that echoes it back with a CID.
+  //
+  // timeout_ms bounds the whole operation rather than each read, so a device
+  // that answers promptly with unusable data cannot keep the call alive.
+  // `out` is assigned only when the result is AllocationResult::allocated;
+  // transport I/O failures propagate as exceptions.
+  //
+  // AllocationResult::codec_v1_reply means the device answered with the
+  // codec_v1 magic '?','#','#', which only a protocol-v1 device (Model T /
+  // Safe 3 / Safe 5) emits. Recognising it lets the caller select ProtocolV1
+  // immediately instead of waiting out the budget.
+  AllocationResult allocate_channel(Transport &transport, AllocatedChannel &out,
+                                    unsigned int timeout_ms = ALLOC_TIMEOUT_MS);
+
+  // ProtocolV2 implements the Protocol interface (write/read of protobuf
+  // messages) on top of the THP wire format. Unlike ProtocolV1 it is
+  // stateful: a single instance is bound to one device session for the
+  // lifetime of an open connection.
+  //
+  // Lifecycle:
+  //   1. set_host_static_key() / set_known_devices()  (before session_begin)
+  //   2. session_begin(transport) -> alloc, handshake
+  //   3. caller drives pairing FSM (if unpaired) and ThpEndRequest exchange
+  //      using write/read on the implicit session 0 (pairing/credential phase)
+  //   4. caller calls set_session_id(1), sends ThpCreateNewSession via write,
+  //      reads Success, promoting the channel to a seeded application session
+  //   5. write/read pairs        -> AES-GCM-sealed protobuf exchange on sid=1
+  //   6. session_end(transport)
+  class ProtocolV2 : public Protocol {
+  public:
+    ProtocolV2();
+
+    // Provide the host's persistent X25519 keypair (loaded from disk or
+    // freshly generated). MUST be called before session_begin.
+    void set_host_static_key(const HostStaticKey &key);
+
+    // Provide previously-paired devices. May be empty for first-time pairing.
+    void set_known_devices(std::vector<KnownDevice> known);
+
+    // Skip the channel allocation step on session_begin; reuse the
+    // allocation that the probe already obtained.  Used by
+    // ProtocolAutoDetect; callers that go straight to ProtocolV2 should
+    // not need this.
+    void adopt_allocation(const AllocatedChannel &allocation);
+
+    // Read-only access to the host static keypair currently in use
+    // (either the value passed to set_host_static_key or, in TOFU mode,
+    // a freshly-generated one).
+    const HostStaticKey &host_static() const { return m_host_static; }
+
+    void session_begin(Transport &transport) override;
+    void session_end  (Transport &transport) override;
+
+    void write(Transport &transport,
+               const google::protobuf::Message &req) override;
+    void read (Transport &transport,
+               std::shared_ptr<google::protobuf::Message> &msg,
+               messages::MessageType *msg_type = nullptr) override;
+
+    // Per THP application-layer sessions.md: after ThpEndResponse the channel
+    // is in encrypted-transport state with only an implicit seedless management
+    // session at session_id=0. Application traffic that needs seed derivation
+    // must be sent on a session allocated via ThpCreateNewSession. The
+    // session_id is the byte the host writes into the encrypted-transport
+    // plaintext header (struct ">BH": session_id, msg_type). Callers (auto-
+    // detect) flip this from 0 to 1 after the ThpEndRequest exchange and
+    // before sending ThpCreateNewSession itself, so that the firmware's
+    // SeedlessSessionContext for session_id=1 is the one that runs the
+    // ThpCreateNewSession handler.
+    void set_session_id(uint8_t sid) { m_session_id = sid; }
+    uint8_t session_id() const { return m_session_id; }
+
+    // For diagnostics / pairing UX.
+    uint16_t                      channel_id()             const { return m_channel.channel_id; }
+    const std::vector<uint8_t>   &device_properties()      const { return m_channel.device_properties_pb; }
+    const NoisePubKey            &trezor_masked_static()   const { return m_handshake.trezor_masked_static_pubkey(); }
+    uint8_t                       trezor_state()           const { return m_handshake.trezor_state(); }
+    bool                          is_known_device()        const { return m_handshake.is_known_device(); }
+    const NoiseHash              &handshake_hash()         const { return m_handshake.keys().handshake_hash; }
+
+  private:
+    // Encode one transport-layer frame and write it to the wire in
+    // chunk_size()-sized pieces. Pure output: the caller is responsible
+    // for setting any sequence bit in control_byte and for the ACK
+    // exchange that may follow (see write()).
+    void send_frame(Transport &transport, uint8_t control_byte,
+                    const uint8_t *payload, size_t payload_len);
+
+    // Read one transport-layer frame, giving up at `deadline`. The payload
+    // has already been CRC-validated by the assembler.
+    Frame recv_frame(Transport &transport,
+                     const std::chrono::steady_clock::time_point &deadline);
+
+    AllocatedChannel  m_channel;
+    bool              m_have_allocation = false;
+    NoiseXxInitiator  m_handshake;
+    HostStaticKey     m_host_static{};
+    bool              m_have_host_static = false;
+    std::vector<KnownDevice> m_known_devices;
+    std::unique_ptr<TransportCipher> m_send_cipher;
+    std::unique_ptr<TransportCipher> m_recv_cipher;
+    // Alternating-bit sequence counters for the encrypted-transport phase.
+    // Both start at 0 because by the time encrypted transport begins, the
+    // handshake has already toggled sync_bit_send twice (init_req to 0,
+    // comp_req to 1) and sync_bit_receive twice (init_resp to 0, comp_resp
+    // to 1), bringing both back to 0. See THP spec, "Alternating Bit
+    // Protocol".
+    uint8_t           m_send_seq = 0;
+    uint8_t           m_recv_seq = 0;
+    // One-frame lookahead for the encrypted-transport phase: the device
+    // may acknowledge our last write by piggybacking the ACK bit on its
+    // response data frame, or hand us the response while we still wait
+    // for the standalone ACK (our request was clearly received either
+    // way).  write() parks such a frame here and read() consumes it
+    // before touching the wire.
+    bool              m_have_pending_frame = false;
+    Frame             m_pending_frame;
+    bool              m_session_open = false;
+    // THP application session identifier. 0x00 is the seedless management
+    // session used for pairing-context and management messages only.
+    // ProtocolAutoDetect promotes this to 0x01 via set_session_id() before
+    // sending ThpCreateNewSession; afterwards write() embeds it in every
+    // encrypted plaintext header so the device routes the message to the
+    // correct seed-derived wallet session.
+    uint8_t           m_session_id = 0x00;
+  };
+
+}}}
+
+#endif // MONERO_TREZOR_THP_PROTOCOL_V2_H

--- a/src/device_trezor/trezor/thp/store.cpp
+++ b/src/device_trezor/trezor/thp/store.cpp
@@ -1,0 +1,564 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "store.hpp"
+
+#include "device_trezor/trezor/exceptions.hpp"
+#include "common/util.h"
+#include "file_io_utils.h"
+#include "memwipe.h"
+#include "misc_log_ex.h"
+#include "string_tools.h"
+
+#include <boost/filesystem.hpp>
+#include "crypto/crypto.h"
+
+#include <sodium/utils.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <exception>
+#include <string>
+
+#if defined(_WIN32)
+#  include <windows.h>
+#else
+#  include <fcntl.h>
+#  include <sys/stat.h>
+#  include <unistd.h>
+#endif
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "device.trezor.thp.store"
+
+namespace hw {
+namespace trezor {
+namespace thp {
+
+  namespace {
+
+    // 1-byte tag, varint length, `length` bytes. Tag 0 ends the stream.
+    constexpr uint8_t TAG_END                       = 0;
+    constexpr uint8_t TAG_HOST_STATIC_PUB           = 1;
+    constexpr uint8_t TAG_HOST_STATIC_PRIV          = 2;
+    constexpr uint8_t TAG_KNOWN_DEVICE              = 3;
+    // Inside KNOWN_DEVICE. Tag 1 held the masked static in MTHPSTR1, which
+    // rotates per session; MTHPSTR2 persists the unmasked one instead.
+    constexpr uint8_t KD_TAG_END                    = 0;
+    constexpr uint8_t KD_TAG_TREZOR_STATIC          = 1;
+    constexpr uint8_t KD_TAG_PAIRING_CREDENTIAL     = 2;
+    constexpr uint8_t KD_TAG_HOST_STATIC_PUB        = 3;
+    constexpr uint8_t KD_TAG_HOST_STATIC_PRIV       = 4;
+    // Tag 5 was last_path, written but never read; dropped again, and older
+    // stores carrying it still load because unknown tags are skipped.
+
+    // MTHPSTR1 would load a masked static as if it were the real one, so the
+    // bump forces a re-pair on upgrade.
+    constexpr uint8_t MAGIC[8] = {
+      'M','T','H','P','S','T','R','2'
+    };
+
+    // Every known device costs a SHA-256 and an X25519 on every connect
+    // (NoiseXxInitiator::consume_init_response).
+    constexpr size_t MAX_KNOWN_DEVICES              = 64;
+    // An opaque device-issued blob, well under 100 bytes in current firmware.
+    constexpr size_t MAX_PAIRING_CREDENTIAL_BYTES   = 1024;
+    // Above a full store of maximum-size records (~72 KiB).
+    constexpr size_t MAX_STORE_FILE_BYTES           = 128 * 1024;
+
+    const char TMP_SUFFIX[] = ".tmp.";
+    // Old enough that a save in flight in another process is never swept.
+    constexpr std::time_t STALE_TEMP_AGE_SECONDS    = 3600;
+
+    // HostStaticKey and KnownDevice scrub themselves (noise.hpp); the raw
+    // byte buffers here do not.
+    void wipe_string(std::string &s) {
+      if (!s.empty()) memwipe(&s[0], s.size());
+    }
+
+    struct string_wiper {
+      std::string &buf;
+      ~string_wiper() { wipe_string(buf); }
+    };
+
+    // The one case ~KnownDevice cannot cover: assigning a shorter credential
+    // over a longer one leaves the tail of the old buffer intact.
+    void wipe_device_secrets(KnownDevice &kd) {
+      if (!kd.pairing_credential.empty())
+        memwipe(kd.pairing_credential.data(), kd.pairing_credential.size());
+    }
+
+    // An all-zero X25519 public key is not a valid point: crypto_scalarmult
+    // fails on it, and the known-device scan runs ahead of any per-device
+    // error handling, so one such record disables Trezor support outright.
+    bool is_zero_key(const uint8_t *p, size_t n) {
+      uint8_t acc = 0;
+      for (size_t i = 0; i < n; ++i) acc |= p[i];
+      return acc == 0;
+    }
+
+    // False (out empty) if the file is missing, unreadable, not regular, or
+    // implausibly large for a credential store.
+    bool read_store_file(const std::string &path, std::string &out)
+    {
+      out.clear();
+      boost::system::error_code ec;
+      // load_file_to_string opens without O_NONBLOCK, so a FIFO planted at
+      // the store path would block the wallet forever. Symlinks are followed.
+      if (!boost::filesystem::is_regular_file(path, ec)) return false;
+      if (!epee::file_io_utils::load_file_to_string(path, out, MAX_STORE_FILE_BYTES)) {
+        wipe_string(out);
+        out.clear();
+        return false;
+      }
+      return true;
+    }
+
+    size_t varint_size(uint64_t v) {
+      size_t n = 1;
+      while (v >= 0x80) { v >>= 7; ++n; }
+      return n;
+    }
+
+    size_t record_size(size_t len) {
+      return 1 + varint_size(len) + len;
+    }
+
+    size_t device_blob_size(const KnownDevice &kd) {
+      return record_size(kd.trezor_static_pubkey.size()) +
+             record_size(kd.host_static.pub.size()) +
+             record_size(kd.host_static.priv.size()) +
+             record_size(kd.pairing_credential.size()) +
+             1;  // KD_TAG_END
+    }
+
+    void write_varint(std::string &buf, uint64_t v) {
+      while (v >= 0x80) { buf.push_back(char((v & 0x7F) | 0x80)); v >>= 7; }
+      buf.push_back(char(v));
+    }
+
+    // Canonical (shortest) encodings only.
+    bool read_varint(const std::string &buf, size_t &off, uint64_t &v) {
+      v = 0;
+      int shift = 0;
+      const size_t start = off;
+      while (off < buf.size()) {
+        const uint8_t b = uint8_t(buf[off++]);
+        if (shift == 63 && (b & 0x7F) > 1) return false;
+        v |= uint64_t(b & 0x7F) << shift;
+        if ((b & 0x80) == 0) return b != 0 || off == start + 1;
+        shift += 7;
+        if (shift > 63) return false;
+      }
+      return false;
+    }
+
+    void write_record(std::string &buf, uint8_t tag,
+                      const uint8_t *data, size_t len) {
+      buf.push_back(char(tag));
+      write_varint(buf, len);
+      if (len) buf.append(reinterpret_cast<const char *>(data), len);
+    }
+
+    std::string serialise(const HostStaticKey &host,
+                          const std::vector<KnownDevice> &known)
+    {
+      // Reserve exactly: a reallocation part-way through would leave an
+      // unscrubbed copy of a host static private key on the heap.
+      size_t total = sizeof(MAGIC) + 1 /* TAG_END */ +
+                     record_size(host.pub.size()) +
+                     record_size(host.priv.size());
+      for (const auto &kd : known)
+        total += record_size(device_blob_size(kd));
+
+      std::string buf;
+      buf.reserve(total);
+      buf.append(reinterpret_cast<const char *>(MAGIC), sizeof(MAGIC));
+      write_record(buf, TAG_HOST_STATIC_PUB,  host.pub.data(),  host.pub.size());
+      write_record(buf, TAG_HOST_STATIC_PRIV, host.priv.data(), host.priv.size());
+
+      std::string inner;
+      string_wiper inner_wiper{inner};  // holds a host static private key
+      for (const auto &kd : known) {
+        inner.clear();
+        inner.reserve(device_blob_size(kd));
+        write_record(inner, KD_TAG_TREZOR_STATIC,
+                     kd.trezor_static_pubkey.data(),
+                     kd.trezor_static_pubkey.size());
+        write_record(inner, KD_TAG_HOST_STATIC_PUB,
+                     kd.host_static.pub.data(),  kd.host_static.pub.size());
+        write_record(inner, KD_TAG_HOST_STATIC_PRIV,
+                     kd.host_static.priv.data(), kd.host_static.priv.size());
+        write_record(inner, KD_TAG_PAIRING_CREDENTIAL,
+                     kd.pairing_credential.data(),
+                     kd.pairing_credential.size());
+        inner.push_back(char(KD_TAG_END));
+        write_record(buf, TAG_KNOWN_DEVICE,
+                     reinterpret_cast<const uint8_t *>(inner.data()), inner.size());
+        wipe_string(inner);
+      }
+      buf.push_back(char(TAG_END));
+      return buf;
+    }
+
+    void deserialise(const std::string &buf,
+                     HostStaticKey &host,
+                     std::vector<KnownDevice> &known)
+    {
+      known.clear();
+      if (buf.size() < sizeof(MAGIC) ||
+          std::memcmp(buf.data(), MAGIC, sizeof(MAGIC)) != 0) {
+        throw exc::EncodingException("THP store: bad magic header");
+      }
+      size_t off = sizeof(MAGIC);
+
+      while (off < buf.size()) {
+        const uint8_t tag = uint8_t(buf[off++]);
+        if (tag == TAG_END) break;
+        uint64_t len = 0;
+        // Subtract rather than add: len is attacker-controlled, and off + len
+        // would wrap past buf.size(). off <= buf.size() holds here.
+        if (!read_varint(buf, off, len) || len > buf.size() - off) {
+          throw exc::EncodingException("THP store: truncated record");
+        }
+        if (tag == TAG_HOST_STATIC_PUB && len == host.pub.size()) {
+          std::memcpy(host.pub.data(), buf.data() + off, len);
+        } else if (tag == TAG_HOST_STATIC_PRIV && len == host.priv.size()) {
+          std::memcpy(host.priv.data(), buf.data() + off, len);
+        } else if (tag == TAG_KNOWN_DEVICE) {
+          KnownDevice kd;
+          size_t inner_off = 0;
+          while (inner_off < len) {
+            const uint8_t itag = uint8_t(buf[off + inner_off++]);
+            if (itag == KD_TAG_END) break;
+            uint64_t ilen = 0;
+            // read_varint bounds against buf.size(), not the inner record,
+            // so a hostile store could spill the varint into the next outer
+            // record; reject that explicitly.
+            size_t parent_off = off + inner_off;
+            if (!read_varint(buf, parent_off, ilen)) {
+              throw exc::EncodingException("THP store: truncated inner varint");
+            }
+            if (parent_off - off > len) {
+              throw exc::EncodingException("THP store: inner varint past record");
+            }
+            inner_off = parent_off - off;
+            // Again subtract rather than add: ilen is attacker-controlled.
+            if (ilen > len - inner_off) {
+              throw exc::EncodingException("THP store: inner record overflow");
+            }
+            const uint8_t *idata =
+              reinterpret_cast<const uint8_t *>(buf.data()) + off + inner_off;
+            if (itag == KD_TAG_TREZOR_STATIC && ilen == kd.trezor_static_pubkey.size())
+              std::memcpy(kd.trezor_static_pubkey.data(), idata, ilen);
+            else if (itag == KD_TAG_HOST_STATIC_PUB  && ilen == kd.host_static.pub.size())
+              std::memcpy(kd.host_static.pub.data(),  idata, ilen);
+            else if (itag == KD_TAG_HOST_STATIC_PRIV && ilen == kd.host_static.priv.size())
+              std::memcpy(kd.host_static.priv.data(), idata, ilen);
+            else if (itag == KD_TAG_PAIRING_CREDENTIAL) {
+              if (ilen > MAX_PAIRING_CREDENTIAL_BYTES) {
+                throw exc::EncodingException("THP store: oversized pairing credential");
+              }
+              kd.pairing_credential.assign(idata, idata + ilen);
+            }
+            // else: forward-compat, skip unknown tag
+            inner_off += ilen;
+          }
+          if (is_zero_key(kd.trezor_static_pubkey.data(),
+                          kd.trezor_static_pubkey.size())) {
+            MWARNING("THP store: dropping a device record with an all-zero static key");
+          } else if (known.size() >= MAX_KNOWN_DEVICES) {
+            throw exc::EncodingException("THP store: too many device records");
+          } else {
+            known.push_back(std::move(kd));
+          }
+        }
+        // else: forward-compat, skip unknown tag
+        off += len;
+      }
+    }
+
+    // Fold devices present on disk but absent from `mine` into `mine`, so two
+    // wallet processes sharing the store do not clobber each other's
+    // credentials.  The in-memory entry wins on a conflict; we may have just
+    // re-paired it.  The on-disk top-level host static key is deliberately
+    // not adopted: each KnownDevice carries the keypair it was paired with.
+    void merge_devices_from_disk(const std::string &path,
+                                 std::vector<KnownDevice> &mine)
+    {
+      std::string image;
+      string_wiper image_wiper{image};
+      if (!read_store_file(path, image)) return;
+
+      HostStaticKey            disk_host{};
+      std::vector<KnownDevice> disk_known;
+      try {
+        deserialise(image, disk_host, disk_known);
+      } catch (const std::exception &) {
+        disk_known.clear();  // corrupt on-disk state; ours wins wholesale
+      }
+      for (const auto &dk : disk_known) {
+        if (mine.size() >= MAX_KNOWN_DEVICES) break;
+        bool known = false;
+        for (const auto &mk : mine) {
+          if (sodium_memcmp(mk.trezor_static_pubkey.data(),
+                            dk.trezor_static_pubkey.data(),
+                            dk.trezor_static_pubkey.size()) == 0) {
+            known = true;
+            break;
+          }
+        }
+        if (!known) mine.push_back(dk);
+      }
+    }
+
+    // Only a directory we created ourselves is tightened to owner-only, so
+    // this can never lock down one the wallet does not own.
+    void ensure_store_directory(const boost::filesystem::path &dir)
+    {
+      namespace fs = boost::filesystem;
+      if (dir.empty()) return;
+
+      boost::system::error_code ec;
+      const bool created = fs::create_directories(dir, ec);
+      if (ec && !fs::is_directory(dir, ec)) {
+        throw exc::CommunicationException("THP store: cannot create directory " +
+                                          dir.string() + ": " + ec.message());
+      }
+#if !defined(_WIN32)
+      // create_directories() honours the umask, so tighten afterwards.
+      if (created && ::chmod(dir.string().c_str(), S_IRWXU) != 0) {
+        MWARNING("THP store: cannot restrict " << dir.string()
+                 << " to its owner: " << std::strerror(errno));
+      }
+#else
+      // A new directory inherits the parent's ACL, which is owner-only under
+      // the per-user data directory default_path() requires and is not under
+      // a machine-wide one. Hence the requirement, rather than a DACL here.
+      (void)created;
+#endif
+    }
+
+    // Unguessable, so a temp file planted in advance is out of reach.
+    std::string unique_temp_suffix()
+    {
+      uint8_t r[8];
+      crypto::generate_random_bytes_thread_safe(sizeof(r), r);
+      return epee::string_tools::buff_to_hex_nodelimer(
+        std::string(reinterpret_cast<const char *>(r), sizeof(r)));
+    }
+
+    // A crash between creating the temp file and renaming it strands a copy
+    // of the host static private key under a name nothing else removes.
+    void remove_stale_temp_files(const boost::filesystem::path &store)
+    {
+      namespace fs = boost::filesystem;
+      const std::string prefix = store.filename().string() + TMP_SUFFIX;
+      const std::time_t cutoff = std::time(nullptr) - STALE_TEMP_AGE_SECONDS;
+
+      boost::system::error_code ec;
+      fs::directory_iterator it(store.parent_path(), ec), end;
+      for (; !ec && it != end; it.increment(ec)) {
+        const std::string name = it->path().filename().string();
+        if (name.size() <= prefix.size() ||
+            name.compare(0, prefix.size(), prefix) != 0) continue;
+        boost::system::error_code stat_ec;
+        const std::time_t mtime = fs::last_write_time(it->path(), stat_ec);
+        if (stat_ec || mtime > cutoff) continue;
+        boost::system::error_code ignored;
+        fs::remove(it->path(), ignored);
+      }
+    }
+
+#if defined(_WIN32)
+    // epee's writer does not reach stable storage on its own.
+    void flush_to_disk(const std::string &path)
+    {
+      std::wstring wide;
+      try {
+        wide = epee::string_tools::utf8_to_utf16(path);
+      } catch (const std::exception &e) {
+        MWARNING("THP store: cannot flush " << path << ": " << e.what());
+        return;
+      }
+      HANDLE fh = ::CreateFileW(wide.c_str(), GENERIC_WRITE, 0, nullptr,
+                                OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+      if (fh == INVALID_HANDLE_VALUE) {
+        MWARNING("THP store: cannot reopen " << path << " to flush (error "
+                 << ::GetLastError() << ")");
+        return;
+      }
+      if (!::FlushFileBuffers(fh))
+        MWARNING("THP store: FlushFileBuffers failed: " << ::GetLastError());
+      ::CloseHandle(fh);
+    }
+#endif
+
+  } // anon
+
+  std::string ThpStore::default_path(const std::string &user_data_dir)
+  {
+    boost::filesystem::path p(user_data_dir);
+    p /= ".trezor";
+    p /= "thp_store.bin";
+    return p.string();
+  }
+
+  void ThpStore::load_or_init(const std::string &path)
+  {
+    auto reset_empty = [this]() {
+      m_host_static = HostStaticKey{};
+      m_known_devices.clear();
+    };
+
+    remove_stale_temp_files(boost::filesystem::path(path));
+
+    std::string image;
+    string_wiper image_wiper{image};  // the raw image holds the host static private key
+    if (!read_store_file(path, image)) {
+      if (boost::filesystem::exists(path))
+        MWARNING("THP store: cannot read " << path << "; treating as empty");
+      reset_empty();
+      return;
+    }
+    try {
+      deserialise(image, m_host_static, m_known_devices);
+    } catch (const std::exception &e) {
+      // Corrupt or older-format (e.g. MTHPSTR1): re-pair, don't brick open.
+      MWARNING("THP store: failed to parse " << path << " (" << e.what()
+               << "); discarding and re-initialising. The Trezor will "
+                  "need to be re-paired.");
+      reset_empty();
+    }
+  }
+
+  void ThpStore::save(const std::string &path) const
+  {
+    namespace fs = boost::filesystem;
+    const fs::path p(path);
+    ensure_store_directory(p.parent_path());
+
+    // Fold in whatever another process persisted since we loaded.
+    std::vector<KnownDevice> devices = m_known_devices;
+    merge_devices_from_disk(path, devices);
+
+    std::string image = serialise(m_host_static, devices);
+    string_wiper image_wiper{image};
+
+    // Unique temp file in the same directory, renamed over the destination.
+    const fs::path tmp = p.parent_path() /
+                         (p.filename().string() + TMP_SUFFIX + unique_temp_suffix());
+
+#if !defined(_WIN32)
+    // private_file::create() with O_EXCL gives an exclusively-created,
+    // owner-only, flock-held file and unlinks it from its destructor, so no
+    // path out of here strands the host static private key in a temp file.
+    tools::private_file file = tools::private_file::create(tmp.string(), O_EXCL);
+    if (!file.handle()) {
+      throw exc::CommunicationException("THP store: cannot create " + tmp.string());
+    }
+    std::FILE *fh = file.handle();
+    if (std::fwrite(image.data(), 1, image.size(), fh) != image.size() ||
+        std::fflush(fh) != 0) {
+      throw exc::CommunicationException("THP store: cannot write " + tmp.string());
+    }
+    // private_file does not reach stable storage on its own; without this
+    // the rename can expose a zero-length store after a crash.
+    if (::fsync(::fileno(fh)) != 0 && errno != EINVAL /* tmpfs */) {
+      MWARNING("THP store: fsync failed: " << std::strerror(errno));
+    }
+    const std::error_code ec = tools::replace_file(tmp.string(), path);
+    if (ec) {
+      throw exc::CommunicationException("THP store: cannot replace " + path +
+                                        ": " + ec.message());
+    }
+    // file's destructor now unlinks a name the rename already consumed: a
+    // no-op here, the cleanup path on every failure above.
+#else
+    // tools::private_file is unusable here: it opens with
+    // FILE_FLAG_DELETE_ON_CLOSE, so the file cannot survive the close that
+    // has to precede the rename.
+    if (!epee::file_io_utils::save_string_to_file(tmp.string(), image)) {
+      boost::system::error_code ignored;
+      fs::remove(tmp, ignored);
+      throw exc::CommunicationException("THP store: cannot write " + tmp.string());
+    }
+    flush_to_disk(tmp.string());
+    const std::error_code ec = tools::replace_file(tmp.string(), path);
+    if (ec) {
+      boost::system::error_code ignored;
+      fs::remove(tmp, ignored);
+      throw exc::CommunicationException("THP store: cannot replace " + path +
+                                        ": " + ec.message());
+    }
+#endif
+
+#if !defined(_WIN32)
+    // The rename is a directory-metadata update, so a credential issued
+    // moments ago only survives a crash if the parent is synced too.
+    if (!p.parent_path().empty()) {
+      const int dfd = ::open(p.parent_path().string().c_str(),
+                             O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+      if (dfd >= 0) {
+        ::fsync(dfd);
+        ::close(dfd);
+      }
+    }
+#endif
+  }
+
+  void ThpStore::upsert_known_device(const KnownDevice &kd)
+  {
+    if (is_zero_key(kd.trezor_static_pubkey.data(),
+                    kd.trezor_static_pubkey.size())) {
+      MWARNING("THP store: refusing to store a device with an all-zero static key");
+      return;
+    }
+    for (auto &existing : m_known_devices) {
+      if (sodium_memcmp(existing.trezor_static_pubkey.data(),
+                        kd.trezor_static_pubkey.data(),
+                        kd.trezor_static_pubkey.size()) == 0) {
+        if (&existing == &kd) return;
+        wipe_device_secrets(existing);
+        existing = kd;
+        return;
+      }
+    }
+    if (m_known_devices.size() >= MAX_KNOWN_DEVICES) {
+      // Drop the oldest rather than refuse the new one.
+      wipe_device_secrets(m_known_devices.front());
+      m_known_devices.erase(m_known_devices.begin());
+    }
+    m_known_devices.push_back(kd);
+  }
+
+}
+}
+}

--- a/src/device_trezor/trezor/thp/store.hpp
+++ b/src/device_trezor/trezor/thp/store.hpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef MONERO_TREZOR_THP_STORE_H
+#define MONERO_TREZOR_THP_STORE_H
+
+#include "noise.hpp"
+
+#include <string>
+#include <vector>
+
+namespace hw {
+namespace trezor {
+namespace thp {
+
+  // Disk-backed cache of the host's static X25519 keypair and any THP
+  // pairing credentials previously issued by Trezor devices, held in a small
+  // tag-length-value binary file.
+  //
+  // Layout (tag-prefixed records; unknown tags are skipped on load so the
+  // format can grow - see store.cpp for the tag constants):
+  //   tag 1: bytes host_static_pub  (32)
+  //   tag 2: bytes host_static_priv (32)
+  //   tag 3: repeated KnownDevice blob, itself tag-prefixed:
+  //     inner tag 1: bytes trezor_static_pubkey (32)
+  //     inner tag 2: bytes pairing_credential (variable)
+  //     inner tag 3: bytes host_static_pub  (32)
+  //     inner tag 4: bytes host_static_priv (32)
+  //
+  // The host static private key is written to disk in plaintext, matching
+  // the existing Trezor v1 flow, which persists hardware-wallet state
+  // without additional encryption. That only holds up while the file lives
+  // somewhere no other local account can read, which is why default_path()
+  // requires a per-user directory.
+  class ThpStore {
+  public:
+    ThpStore() = default;
+
+    // Loads the file from `path`. A missing, unreadable, or malformed file
+    // resets the store to the empty initial state instead of throwing: the
+    // worst case is that the device is re-paired.
+    void load_or_init(const std::string &path);
+
+    // Atomically writes the current state to `path` (unique temp file in the
+    // same directory, flushed to stable storage, renamed over the
+    // destination). Devices present on disk but unknown to this instance are
+    // folded in rather than dropped, so a second wallet process does not
+    // usually lose the credential this one just persisted. There is no
+    // locking, so two saves that overlap can still lose one entry; the cost
+    // is one re-pair. On POSIX the file is created owner-only; on Windows it
+    // inherits the owner-only ACL of the per-user directory default_path()
+    // requires.
+    void save(const std::string &path) const;
+
+    // A store that never had a key (fresh init, or a file written before
+    // the key existed) reports an all-zero keypair; callers detect this
+    // and generate + set_host_static() a fresh one.
+    const HostStaticKey            &host_static()    const { return m_host_static; }
+    const std::vector<KnownDevice> &known_devices()  const { return m_known_devices; }
+
+    // Replace or insert a known device, keyed on its Trezor static pubkey.
+    // An all-zero pubkey is refused: it is not a valid X25519 point and
+    // would make every subsequent handshake fail. At most MAX_KNOWN_DEVICES
+    // entries are kept, oldest dropped first.
+    void upsert_known_device(const KnownDevice &kd);
+
+    // Set host static key (called once when an empty store is initialised).
+    void set_host_static(const HostStaticKey &key) { m_host_static = key; }
+
+    // Location of the store inside `user_data_dir`.
+    //
+    // The caller MUST pass a directory private to the current user and
+    // specific to the network in use. The file holds the host static private
+    // key and every pairing credential in the clear, and save() merges
+    // whatever it finds on disk into the caller's state, so a machine-wide
+    // directory lets local accounts read and cross-pollinate each other's
+    // credentials. On Windows tools::get_default_data_dir() resolves to
+    // CSIDL_COMMON_APPDATA (C:\ProgramData\bitmonero) and is NOT suitable.
+    static std::string default_path(const std::string &user_data_dir);
+
+  private:
+    // Both types scrub themselves on destruction (noise.hpp), which is what
+    // makes vector growth and the corrupt-file reset paths safe here.
+    HostStaticKey              m_host_static{};
+    std::vector<KnownDevice>   m_known_devices;
+  };
+
+}
+}
+}
+
+#endif // MONERO_TREZOR_THP_STORE_H

--- a/src/device_trezor/trezor/transport.cpp
+++ b/src/device_trezor/trezor/transport.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <algorithm>
+#include <cstdlib>
 #include <functional>
 #include <boost/endian/conversion.hpp>
 #include <boost/asio/ip/udp.hpp>
@@ -40,6 +41,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include "common/apply_permutation.h"
 #include "transport.hpp"
+#include "thp/auto_detect.hpp"
 #include "messages/messages-common.pb.h"
 
 // https://github.com/Tencent/rapidjson/issues/1448
@@ -120,6 +122,15 @@ namespace trezor{
     uint16_t id_product;
   } trezor_usb_desc_t;
 
+  // trezor_type values:
+  //   1 - Trezor One (legacy v1 protocol)
+  //   2 - Trezor Model T / Safe 3 / Safe 5 / Safe 7 (legacy v1 OR THP, see note)
+  //   3 - Trezor Model T bootloader
+  //
+  // Note: the Trezor Safe 7 ships with the same USB VID/PID as the Model T
+  // (0x1209:0x53C1) but exclusively speaks the Trezor Host Protocol v2 (THP).
+  // The wire-format protocol is therefore selected at runtime via probe (or
+  // by setting TREZOR_FORCE_THP=1 in the environment); see thp/auto_detect.hpp.
   static trezor_usb_desc_t TREZOR_DESC_T1 = {1, 0x534C, 0x0001};
   static trezor_usb_desc_t TREZOR_DESC_T2 = {2, 0x1209, 0x53C1};
   static trezor_usb_desc_t TREZOR_DESC_T2_BL = {3, 0x1209, 0x53C0};
@@ -129,6 +140,25 @@ namespace trezor{
       TREZOR_DESC_T2,
       TREZOR_DESC_T2_BL,
   };
+
+  // Returns true when the user has explicitly forced THP (TREZOR_FORCE_THP=1).
+  // This is rarely needed in practice, since ProtocolAutoDetect probes the
+  // device and selects the right protocol, but we keep the env var as an
+  // escape hatch for diagnostics.  Forcing THP only disables the silent V1
+  // fallback; the probe, pairing, and session bring-up still run through
+  // ProtocolAutoDetect so the channel stays fully authenticated.
+  static bool force_thp_protocol() {
+    const char *v = std::getenv("TREZOR_FORCE_THP");
+    return v && v[0] && v[0] != '0';
+  }
+  // Returns true when the user has explicitly forced ProtocolV1 only
+  // (skip the probe).  Useful when the THP probe causes problems on a
+  // particular USB stack: set TREZOR_FORCE_V1=1 to fall straight to
+  // legacy framing.
+  static bool force_v1_protocol() {
+    const char *v = std::getenv("TREZOR_FORCE_V1");
+    return v && v[0] && v[0] != '0';
+  }
 
   static size_t TREZOR_DESCS_LEN = sizeof(TREZOR_DESCS)/sizeof(TREZOR_DESCS[0]);
 
@@ -377,7 +407,18 @@ namespace trezor{
     json bridge_res;
     std::string req;
 
-    bool req_status = invoke_bridge_http("/enumerate", req, bridge_res, m_http_client);
+    // Probe-only timeout: 2 s.  If standalone trezord-go is not
+    // running, the user almost certainly does not have it (Trezor
+    // deprecated the standalone Bridge installer in favour of the
+    // integrated nodeBridge in Suite).  The default 180 s timeout
+    // would hang the entire wallet open for three minutes when
+    // something silently drops the SYN packets to localhost:21325
+    // (firewall, container network, etc.), which is unacceptable for a
+    // non-Bridge user.  Real Bridge operations (call, post-read,
+    // etc.) keep the long timeout downstream.
+    bool req_status = invoke_bridge_http(
+        "/enumerate", req, bridge_res, m_http_client,
+        "POST", std::chrono::seconds(2));
     if (!req_status){
       throw exc::CommunicationException("Bridge enumeration failed");
     }
@@ -423,7 +464,10 @@ namespace trezor{
     json bridge_res;
     bool req_status = invoke_bridge_http(uri, req, bridge_res, m_http_client);
     if (!req_status){
-      throw exc::CommunicationException("Failed to acquire device");
+      // Typed so that connect() can move on to the next carrier: a Bridge
+      // that will not hand the device over is exactly the case the
+      // direct-USB candidates exist for.
+      throw exc::DeviceAcquireException("Failed to acquire device");
     }
 
     m_session = boost::make_optional(json_get_string(bridge_res["session"]));
@@ -559,7 +603,13 @@ namespace trezor{
       throw std::invalid_argument("Local endpoint allowed only");
     }
 
-    m_proto = proto ? proto.get() : std::make_shared<ProtocolV1>();
+    if (proto) {
+      m_proto = proto.get();
+    } else if (force_v1_protocol()) {
+      m_proto = std::make_shared<ProtocolV1>();
+    } else {
+      m_proto = std::make_shared<thp::ProtocolAutoDetect>(force_thp_protocol());
+    }
   }
 
   std::string UdpTransport::get_path() const {
@@ -599,18 +649,30 @@ namespace trezor{
   }
 
   void UdpTransport::enumerate(t_transport_vect & res) {
-    std::shared_ptr<UdpTransport> t = std::make_shared<UdpTransport>();
+    // Liveness probe only.  PINGPING/PONGPONG is an emulator transport
+    // feature below any wire protocol, so probe with ProtocolV1 (whose
+    // session_begin is a no-op) instead of the default auto-detect:
+    // running the THP probe/handshake here would abandon a half-open
+    // channel on a THP emulator and, with no pairing prompt configured
+    // at enumeration time, could never complete anyway.  The transport
+    // handed to the caller is a fresh default-constructed one, so the
+    // chosen device still gets the full auto-detect treatment in
+    // connect().
+    std::shared_ptr<UdpTransport> probe = std::make_shared<UdpTransport>(
+        boost::none,
+        boost::optional<std::shared_ptr<Protocol>>(
+            std::make_shared<ProtocolV1>()));
     bool t_works = false;
 
     try{
-      t->open();
-      t_works = t->ping();
+      probe->open();
+      t_works = probe->ping();
     } catch(...) {
 
     }
-    t->close();
+    probe->close();
     if (t_works){
-      res.push_back(t);
+      res.push_back(std::make_shared<UdpTransport>());
     }
   }
 
@@ -628,8 +690,11 @@ namespace trezor{
     m_deadline.expires_after(boost::asio::steady_timer::duration::max());
     check_deadline();
 
-    m_proto->session_begin(*this);
+    // The counter has to be raised before session_begin so that a throw
+    // from it still lets close() run; pre_close() returns false on a zero
+    // counter and the socket would never be released.
     m_open_counter = 1;
+    m_proto->session_begin(*this);
   }
 
   void UdpTransport::close() {
@@ -674,18 +739,29 @@ namespace trezor{
   }
 
   size_t UdpTransport::read_chunk(void * buff, size_t size){
+    return read_chunk(buff, size, 0 /* 0 == no timeout, unbounded read */);
+  }
+
+  size_t UdpTransport::read_chunk(void * buff, size_t size, unsigned int timeout_ms){
     require_socket();
     if (size < 64){
       throw std::invalid_argument("Buffer too small");
     }
 
+    // timeout_ms == 0 means "no timeout": block until a chunk arrives, mirroring
+    // WebUsbTransport (libusb treats 0 as no timeout). The explicit-timeout probe
+    // path still throws exc::TimeoutException on deadline expiry.
+    const boost::asio::steady_timer::duration deadline = (timeout_ms == 0)
+        ? boost::asio::steady_timer::duration::max()
+        : boost::asio::steady_timer::duration(std::chrono::milliseconds(timeout_ms));
+
     ssize_t len;
     while(true) {
       try {
         boost::system::error_code ec;
-        len = receive(buff, size, &ec, true);
+        len = receive(buff, size, &ec, true, deadline);
         if (ec == boost::asio::error::operation_aborted) {
-          continue;
+          throw exc::TimeoutException("UdpTransport read_chunk timeout");
         } else if (ec) {
           throw exc::CommunicationException(std::string("Comm error: ") + ec.message());
         }
@@ -879,7 +955,13 @@ namespace trezor{
       this->m_usb_device_desc.reset(desc);
     }
 
-    m_proto = proto ? proto.get() : std::make_shared<ProtocolV1>();
+    if (proto) {
+      m_proto = proto.get();
+    } else if (force_v1_protocol()) {
+      m_proto = std::make_shared<ProtocolV1>();
+    } else {
+      m_proto = std::make_shared<thp::ProtocolAutoDetect>(force_thp_protocol());
+    }
 
 #ifdef WITH_TREZOR_DEBUGGING
     m_debug_mode = false;
@@ -1139,12 +1221,21 @@ namespace trezor{
   };
 
   size_t WebUsbTransport::read_chunk(void * buff, size_t size) {
+    return read_chunk(buff, size, 0 /* infinite */);
+  }
+
+  size_t WebUsbTransport::read_chunk(void * buff, size_t size, unsigned int timeout_ms) {
     require_connected();
     unsigned char endpoint = get_endpoint();
     endpoint = (endpoint & ~LIBUSB_ENDPOINT_DIR_MASK) | LIBUSB_ENDPOINT_IN;
 
     int transferred = 0;
-    int r = libusb_interrupt_transfer(m_usb_device_handle, endpoint, (unsigned char*)buff, (int)size, &transferred, 0);
+    int r = libusb_interrupt_transfer(m_usb_device_handle, endpoint, (unsigned char*)buff,
+                                      (int)size, &transferred,
+                                      timeout_ms /* 0 == no timeout */);
+    if (r == LIBUSB_ERROR_TIMEOUT) {
+      throw exc::TimeoutException("WebUsbTransport read_chunk timeout");
+    }
     CHECK_AND_ASSERT_THROW_MES(r == 0, "Unable to transfer, r: " << r);
     if (transferred != (int)size){
       throw exc::CommunicationException("Could not read the chunk");
@@ -1176,11 +1267,21 @@ namespace trezor{
 #endif  // WITH_DEVICE_TREZOR_WEBUSB
 
   void enumerate(t_transport_vect & res){
+    // Bridge stays ahead of the direct-USB carriers, as it has been since
+    // this module was written. Where a Bridge (trezord-go, or the copy
+    // built into Trezor Suite) is running it already holds the device,
+    // and libusb_claim_interface() on Windows and macOS would take it
+    // away from whatever else is using it. A device that speaks THP is
+    // reached over WebUSB instead, because Bridge's /call endpoint only
+    // understands codec_v1 framing.
+    //
+    // Not finding a Bridge is the normal case on a modern install, so the
+    // failure is logged at WARNING rather than ERROR.
     BridgeTransport bt;
     try{
       bt.enumerate(res);
     } catch (const std::exception & e){
-      MERROR("BridgeTransport enumeration failed:" << e.what());
+      MWARNING("BridgeTransport enumeration failed: " << e.what());
     }
 
 #ifdef WITH_DEVICE_TREZOR_WEBUSB

--- a/src/device_trezor/trezor/transport.hpp
+++ b/src/device_trezor/trezor/transport.hpp
@@ -157,9 +157,35 @@ namespace trezor {
     virtual void write(const google::protobuf::Message & req) =0;
     virtual void read(std::shared_ptr<google::protobuf::Message> & msg, messages::MessageType * msg_type=nullptr) =0;
     virtual std::shared_ptr<Transport> find_debug() { return nullptr; };
+    // Inner Protocol object (ProtocolV1, ProtocolV2 or
+    // ProtocolAutoDetect).  Used by the device-glue layer to configure
+    // THP-specific options (pairing prompt, persistent store path)
+    // before the first open() call.  Returns nullptr for transports
+    // that don't carry a protocol.
+    virtual std::shared_ptr<Protocol> protocol() const { return nullptr; }
 
     virtual void write_chunk(const void * buff, size_t size) { };
     virtual size_t read_chunk(void * buff, size_t size) { return 0; };
+    // Same as read_chunk but with a soft timeout in milliseconds.
+    // Overriding transports throw exc::TimeoutException when the deadline
+    // expires.  This base default ignores the timeout and forwards to the
+    // unbounded read_chunk(), so any transport meant to carry
+    // ProtocolAutoDetect has to override it: the V1 fallback relies on the
+    // probe's read timing out against devices that stay silent on the THP
+    // allocation request.
+    virtual size_t read_chunk(void * buff, size_t size, unsigned int /*timeout_ms*/) {
+      return read_chunk(buff, size);
+    }
+    // Number of bytes per carrier packet for this transport.
+    //
+    // The THP framing layer (thp/framing.hpp) is parameterised on this:
+    // it pads every frame to a whole number of carrier packets.
+    // Subclasses override chunk_size() to report their carrier's packet
+    // size; the default is the long-standing 64-byte USB-HID report size
+    // shared by the WebUSB / HID / UDP / Bridge transports, so existing
+    // transports do not need to be touched.
+    static constexpr size_t DEFAULT_CHUNK_SIZE = 64;
+    virtual size_t chunk_size() const { return DEFAULT_CHUNK_SIZE; }
     virtual std::ostream& dump(std::ostream& o) const { return o << "Transport<>"; }
   protected:
     long m_open_counter;
@@ -229,6 +255,9 @@ namespace trezor {
 
     void write_chunk(const void * buff, size_t size) override;
     size_t read_chunk(void * buff, size_t size) override;
+    size_t read_chunk(void * buff, size_t size, unsigned int timeout_ms) override;
+
+    std::shared_ptr<Protocol> protocol() const override { return m_proto; }
 
     std::ostream& dump(std::ostream& o) const override;
 
@@ -277,6 +306,9 @@ namespace trezor {
 
     void write_chunk(const void * buff, size_t size) override;
     size_t read_chunk(void * buff, size_t size) override;
+    size_t read_chunk(void * buff, size_t size, unsigned int timeout_ms) override;
+
+    std::shared_ptr<Protocol> protocol() const override { return m_proto; }
 
     std::ostream& dump(std::ostream& o) const override;
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5543,6 +5543,18 @@ boost::optional<epee::wipeable_string> simple_wallet::on_device_pin_request()
   return pwd_container->password();
 }
 //----------------------------------------------------------------------------------------------------
+boost::optional<epee::wipeable_string> simple_wallet::on_device_pairing_code_request()
+{
+  // THP first-pairing over USB: the device displays a 6-digit code that the
+  // host must echo back. The code authenticates the CPace exchange, so it is
+  // read and handed on the same way as the device PIN.
+  PAUSE_READLINE();
+  std::string msg = tr("Enter the pairing code shown on your Trezor");
+  auto pwd_container = tools::password_container::prompt(false, msg.c_str());
+  THROW_WALLET_EXCEPTION_IF(!pwd_container, tools::error::password_entry_failed, tr("Failed to read device pairing code"));
+  return pwd_container->password();
+}
+//----------------------------------------------------------------------------------------------------
 boost::optional<epee::wipeable_string> simple_wallet::on_device_passphrase_request(bool & on_device)
 {
   if (on_device) {

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -342,6 +342,7 @@ namespace cryptonote
     virtual boost::optional<epee::wipeable_string> on_get_password(const char *reason);
     virtual void on_device_button_request(uint64_t code);
     virtual boost::optional<epee::wipeable_string> on_device_pin_request();
+    virtual boost::optional<epee::wipeable_string> on_device_pairing_code_request();
     virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool & on_device);
     //----------------------------------------------------------
 

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -42,6 +42,7 @@
 
 #include "mnemonics/electrum-words.h"
 #include "mnemonics/english.h"
+#include "device_trezor/trezor/exceptions.hpp"
 #include <boost/format.hpp>
 #include <sstream>
 #include <unordered_map>
@@ -153,6 +154,22 @@ namespace {
     }
     void checkMultisigWalletNotReady(const std::unique_ptr<tools::wallet2> &wallet) {
         return checkMultisigWalletNotReady(wallet.get());
+    }
+
+    // The device layer classifies its own exceptions; this only carries
+    // the result across the API boundary, where the exception types are
+    // not available.
+    Wallet::TrezorError toTrezorError(hw::trezor::exc::error_kind kind)
+    {
+        using hw::trezor::exc::error_kind;
+        static_assert(static_cast<int>(error_kind::none) == Wallet::TrezorError_None, "");
+        static_assert(static_cast<int>(error_kind::unreachable) == Wallet::TrezorError_Unreachable, "");
+        static_assert(static_cast<int>(error_kind::cancelled) == Wallet::TrezorError_Cancelled, "");
+        static_assert(static_cast<int>(error_kind::protocol) == Wallet::TrezorError_Protocol, "");
+        static_assert(static_cast<int>(error_kind::other) == Wallet::TrezorError_Other, "");
+        static_assert(static_cast<int>(error_kind::firmware_unsupported) == Wallet::TrezorError_FirmwareUnsupported, "");
+        static_assert(static_cast<int>(error_kind::pairing_rejected) == Wallet::TrezorError_PairingRejected, "");
+        return static_cast<Wallet::TrezorError>(kind);
     }
 }
 
@@ -286,6 +303,17 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
       } else {
         on_device = true;
+      }
+      return boost::none;
+    }
+
+    virtual boost::optional<epee::wipeable_string> on_device_pairing_code_request() override
+    {
+      if (m_listener) {
+        auto code = m_listener->onDevicePairingCodeRequest();
+        if (code) {
+          return boost::make_optional(epee::wipeable_string((*code).data(), (*code).size()));
+        }
       }
       return boost::none;
     }
@@ -430,6 +458,7 @@ void Wallet::error(const std::string &category, const std::string &str) {
 WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds)
     :m_wallet(nullptr)
     , m_status(Wallet::Status_Ok)
+    , m_trezorError(Wallet::TrezorError_None)
     , m_wallet2Callback(nullptr)
     , m_recoveringFromSeed(false)
     , m_recoveringFromDevice(false)
@@ -696,6 +725,7 @@ bool WalletImpl::recoverFromDevice(const std::string &path, const std::string &p
         LOG_PRINT_L1("Generated new wallet from device: " + device_name);
     }
     catch (const std::exception& e) {
+        setTrezorError(toTrezorError(::hw::trezor::exc::classify(e)));
         setStatusError(string(tr("failed to generate new wallet: ")) + e.what());
         return false;
     }
@@ -728,7 +758,17 @@ bool WalletImpl::open(const std::string &path, const std::string &password)
 
         m_password = password;
     } catch (const std::exception &e) {
-        LOG_ERROR("Error opening wallet: " << e.what());
+        // Demote LOG_ERROR to MWARNING for the Trezor failures a user
+        // resolves themselves (device off, cancelled, a mistyped pairing
+        // code) so the GUI log doesn't surface red errors for expected
+        // flows the Retry/Cancel splash will let them work through.
+        const auto kind = ::hw::trezor::exc::classify(e);
+        setTrezorError(toTrezorError(kind));
+        if (::hw::trezor::exc::is_expected_failure(kind)) {
+            MWARNING("Error opening wallet (user-recoverable): " << e.what());
+        } else {
+            LOG_ERROR("Error opening wallet: " << e.what());
+        }
         setStatusCritical(e.what());
     }
     return status() == Status_Ok;
@@ -842,6 +882,12 @@ void WalletImpl::statusWithErrorString(int& status, std::string& errorString) co
     boost::lock_guard<boost::mutex> l(m_statusMutex);
     status = m_status;
     errorString = m_errorString;
+}
+
+Wallet::TrezorError WalletImpl::trezorError() const
+{
+    boost::lock_guard<boost::mutex> l(m_statusMutex);
+    return m_trezorError;
 }
 
 bool WalletImpl::setPassword(const std::string &password)
@@ -2380,6 +2426,13 @@ void WalletImpl::clearStatus() const
     boost::lock_guard<boost::mutex> l(m_statusMutex);
     m_status = Status_Ok;
     m_errorString.clear();
+    m_trezorError = TrezorError_None;
+}
+
+void WalletImpl::setTrezorError(TrezorError trezorError) const
+{
+    boost::lock_guard<boost::mutex> l(m_statusMutex);
+    m_trezorError = trezorError;
 }
 
 void WalletImpl::setStatusError(const std::string& message) const

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -89,6 +89,7 @@ public:
     int status() const override;
     std::string errorString() const override;
     void statusWithErrorString(int& status, std::string& errorString) const override;
+    TrezorError trezorError() const override;
     bool setPassword(const std::string &password) override;
     const std::string& getPassword() const override;
     bool setDevicePin(const std::string &password) override;
@@ -238,6 +239,7 @@ private:
     void setStatusError(const std::string& message) const;
     void setStatusCritical(const std::string& message) const;
     void setStatus(int status, const std::string& message) const;
+    void setTrezorError(TrezorError trezorError) const;
     void refreshThreadFunc();
     void doRefresh();
     bool daemonSynced() const;
@@ -261,6 +263,7 @@ private:
     mutable boost::mutex m_statusMutex;
     mutable int m_status;
     mutable std::string m_errorString;
+    mutable TrezorError m_trezorError;
     // TODO: harden password handling in the wallet API, see relevant discussion
     // https://github.com/monero-project/monero-gui/issues/1537
     // https://github.com/feather-wallet/feather/issues/72#issuecomment-1405602142

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -405,6 +405,17 @@ struct WalletListener
     }
 
     /**
+     * @brief called by device when CodeEntry pairing requires the host
+     *        to prompt the user for the 6-digit code currently displayed
+     *        on the device.  Used during the THP first-pairing flow on
+     *        Trezor Safe 7.  Return the user-entered code as ASCII
+     *        digits, or an empty string to abort pairing.
+     */
+    virtual optional<std::string> onDevicePairingCodeRequest() {
+        return optional<std::string>();
+    }
+
+    /**
      * @brief Signalizes device operation progress
      */
     virtual void onDeviceProgress(const DeviceProgress & event) { (void)event; };
@@ -445,6 +456,20 @@ struct Wallet
         BackgroundSync_CustomPassword = 2
     };
 
+    //! Category of a Trezor failure met while opening or creating a
+    //! wallet, so a frontend can offer the recovery that fits without
+    //! matching the English text of an error.  Mirrors
+    //! hw::trezor::exc::error_kind, and both are append-only.
+    enum TrezorError {
+        TrezorError_None = 0,
+        TrezorError_Unreachable = 1,
+        TrezorError_Cancelled = 2,
+        TrezorError_Protocol = 3,
+        TrezorError_Other = 4,
+        TrezorError_FirmwareUnsupported = 5,
+        TrezorError_PairingRejected = 6
+    };
+
     virtual ~Wallet() = 0;
     virtual std::string seed(const std::string& seed_offset = "") const = 0;
     virtual std::string getSeedLanguage() const = 0;
@@ -455,6 +480,8 @@ struct Wallet
     virtual std::string errorString() const = 0; //deprecated: use safe alternative statusWithErrorString
     //! returns both error and error string atomically. suggested to use in instead of status() and errorString()
     virtual void statusWithErrorString(int& status, std::string& errorString) const = 0;
+    //! in case the last failure came from a Trezor, returns its category
+    virtual TrezorError trezorError() const { return TrezorError_None; }
     virtual bool setPassword(const std::string &password) = 0;
     virtual const std::string& getPassword() const = 0;
     virtual bool setDevicePin(const std::string &pin) { (void)pin; return false; };

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1202,6 +1202,13 @@ void wallet_device_callback::on_progress(const hw::device_progress& event)
     wallet->on_device_progress(event);
 }
 
+boost::optional<epee::wipeable_string> wallet_device_callback::on_pairing_code_request()
+{
+  if (wallet)
+    return wallet->on_device_pairing_code_request();
+  return boost::none;
+}
+
 wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory):
   m_http_client(http_client_factory->create()),
   m_upper_transaction_weight_limit(0),
@@ -1528,7 +1535,17 @@ bool wallet2::reconnect_device()
     return false;
   }
 
-  r = hwdev.connect();
+  try
+  {
+    r = hwdev.connect();
+  }
+  catch (const std::exception &e)
+  {
+    // A Trezor reports the reason by throwing; this entry point answers
+    // its callers with a boolean either way.
+    MERROR("Could not connect to the device: " << e.what());
+    return false;
+  }
   if (!r){
     MERROR("Could not connect to the device");
     return false;
@@ -15202,6 +15219,13 @@ boost::optional<epee::wipeable_string> wallet2::on_device_passphrase_request(boo
     return m_callback->on_device_passphrase_request(on_device);
   else
     on_device = true;
+  return boost::none;
+}
+//----------------------------------------------------------------------------------------------------
+boost::optional<epee::wipeable_string> wallet2::on_device_pairing_code_request()
+{
+  if (nullptr != m_callback)
+    return m_callback->on_device_pairing_code_request();
   return boost::none;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -136,6 +136,7 @@ private:
     virtual void on_device_button_pressed() {}
     virtual boost::optional<epee::wipeable_string> on_device_pin_request() { return boost::none; }
     virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool & on_device) { on_device = true; return boost::none; }
+    virtual boost::optional<epee::wipeable_string> on_device_pairing_code_request() { return boost::none; }
     virtual void on_device_progress(const hw::device_progress& event) {};
     virtual ~i_wallet2_callback() {}
   };
@@ -149,6 +150,7 @@ private:
     boost::optional<epee::wipeable_string> on_pin_request() override;
     boost::optional<epee::wipeable_string> on_passphrase_request(bool & on_device) override;
     void on_progress(const hw::device_progress& event) override;
+    boost::optional<epee::wipeable_string> on_pairing_code_request() override;
   private:
     wallet2 * wallet;
   };
@@ -1620,6 +1622,7 @@ private:
     void on_device_button_pressed();
     boost::optional<epee::wipeable_string> on_device_pin_request();
     boost::optional<epee::wipeable_string> on_device_passphrase_request(bool & on_device);
+    boost::optional<epee::wipeable_string> on_device_pairing_code_request();
     void on_device_progress(const hw::device_progress& event);
 
     bool should_expand(const cryptonote::subaddress_index &index) const;

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -44,6 +44,7 @@ set(unit_tests_sources
   cryptonote_format_utils.cpp
   decompose_amount_into_digits.cpp
   device.cpp
+  device_trezor_thp.cpp
   difficulty.cpp
   dns_resolver.cpp
   download.cpp
@@ -87,6 +88,7 @@ set(unit_tests_sources
   test_peerlist.cpp
   test_protocol_pack.cpp
   threadpool.cpp
+  trezor_exceptions.cpp
   tx_proof.cpp
   tx_verification_utils.cpp
   hardfork.cpp
@@ -121,6 +123,7 @@ target_link_libraries(unit_tests
     daemon_rpc_server
     blockchain_db
     fcmp_pp
+    device_trezor
     lmdb_lib
     rpc
     net

--- a/tests/unit_tests/device_trezor_thp.cpp
+++ b/tests/unit_tests/device_trezor_thp.cpp
@@ -1,0 +1,2619 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Unit tests for the Trezor Host Protocol v2 (THP) data-transfer and
+// secure-channel implementations.  Most tests in this file are entirely
+// deterministic; the handful that draw from the system RNG are noted where
+// they do.  None require an attached Trezor or trezor-emu instance.  They
+// cover:
+//
+//   - CRC-32 / framing round-trip (encode_frame -> FrameAssembler)
+//   - CRC mismatch detection (tampered byte triggers an error)
+//   - Reassembly across exactly-chunk-size boundaries
+//   - Cryptographic primitives against published RFC / NIST vectors
+//   - The Noise XX state machine, exercised by playing both the host and
+//     the (simulated) Trezor sides of the handshake described in
+//     specification.md.  This proves the handshake's symbolic correctness
+//     end-to-end without requiring hardware.
+//   - ProtocolV2's alternating-bit sequencing and ProtocolAutoDetect's
+//     v1/v2 selection, driven through a scripted Transport.
+
+#include "gtest/gtest.h"
+
+#if defined(DEVICE_TREZOR_READY)
+
+#include "device_trezor/trezor/exceptions.hpp"
+#include "device_trezor/trezor/thp/auto_detect.hpp"
+#include "device_trezor/trezor/thp/framing.hpp"
+#include "device_trezor/trezor/thp/noise.hpp"
+#include "device_trezor/trezor/thp/pairing.hpp"
+#include "device_trezor/trezor/thp/protocol_v2.hpp"
+#include "device_trezor/trezor/thp/store.hpp"
+#include "device_trezor/trezor/transport.hpp"
+
+#include <boost/crc.hpp>
+#include <boost/filesystem.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace hw::trezor::thp;
+
+// CRC-32/ISO-HDLC, the checksum a THP frame carries.  framing.cpp feeds
+// boost::crc_32_type incrementally to avoid copying header and payload
+// together; this one-shot form keeps the published vectors below readable.
+static uint32_t crc32_ieee(const void *data, size_t len) {
+  boost::crc_32_type crc;
+  if (len) crc.process_bytes(data, len);
+  return crc.checksum();
+}
+
+static std::vector<uint8_t> from_hex(const std::string &s) {
+  std::vector<uint8_t> out;
+  for (size_t i = 0; i + 1 < s.size(); i += 2) {
+    auto h = [](char c) -> int {
+      if (c >= '0' && c <= '9') return c - '0';
+      if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+      if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+      return 0;
+    };
+    out.push_back(uint8_t((h(s[i]) << 4) | h(s[i+1])));
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// CRC-32 (IEEE). The classic verification vector is CRC32("123456789")
+// = 0xCBF43926 for the IEEE polynomial / left-shift convention; boost::crc
+// uses the reflected form, which yields the same final checksum.
+// ---------------------------------------------------------------------------
+TEST(thp_crc32, check_vector_123456789)
+{
+  EXPECT_EQ(0xCBF43926u, crc32_ieee("123456789", 9));
+}
+
+// Mirrors trezor-firmware's THP checksum vectors, so our CRC matches the
+// device's expectation bit-for-bit, including the empty input.  Source:
+// trezor-firmware@bc97a6b2b00068cb36a13da27ddaba8306314870,
+// core/tests/test_trezor.wire.thp.checksum.py.  That revision is pinned
+// because 00ec9a7f8b6388f45e7825f48d6cb5b42d27d795 ("feat(core): switch
+// from Python THP implementation to Rust-based one") deleted the file and
+// the Rust replacement ships no vector tables.
+TEST(thp_crc32, trezor_firmware_checksum_vectors)
+{
+  EXPECT_EQ(0x00000000u, crc32_ieee("", 0));
+  EXPECT_EQ(0xE8B7BE43u, crc32_ieee("a", 1));
+  EXPECT_EQ(0x352441C2u, crc32_ieee("abc", 3));
+  const std::vector<uint8_t> zeros32(32, 0x00);
+  EXPECT_EQ(0x190A55ADu, crc32_ieee(zeros32.data(), zeros32.size()));
+  const char digits80[] =
+      "12345678901234567890123456789012345678901234567890"
+      "123456789012345678901234567890";
+  EXPECT_EQ(0x7CA94A72u, crc32_ieee(digits80, 80));
+  const char various[] = "various CRC algorithms input data";
+  EXPECT_EQ(0x9BD366AEu, crc32_ieee(various, 33));
+}
+
+// ---------------------------------------------------------------------------
+// Framing round-trip and chunk layout, across the sizes that matter.
+//
+// One table replaces the seven near-identical round-trip tests this file
+// used to carry.  Each row encodes a payload, feeds the wire bytes back
+// through the assembler one chunk at a time, and checks both the recovered
+// frame and the per-chunk layout: whole chunks out, completion only on the
+// final chunk, and a continuation control byte of exactly 0x80 carrying the
+// channel id.
+//
+// Per the THP spec ("Transport packet structure") a continuation packet's
+// control byte is 0x80 exactly, every other bit zero.  We once emitted
+// (initiation_ctrl | 0x80), which bled the message-type and sequence bits
+// into the continuation header and a strict device parser rejects it; the
+// rows with 0x14 (encrypted transport, seq=1) would catch that again.
+// ---------------------------------------------------------------------------
+TEST(thp_framing, round_trip_and_chunk_layout)
+{
+  struct Case {
+    const char *name;
+    size_t      chunk_size;
+    size_t      payload_len;
+    uint8_t     control_byte;
+    uint16_t    channel_id;
+  };
+  static const Case cases[] = {
+    { "short payload, one chunk",        64,   9, 0x40, 0xFFFF },
+    // 55 payload bytes plus the 4-byte CRC trailer is exactly 64 - 5, the
+    // largest body that still fits the initiation chunk; 56 is the first
+    // that does not, which is the off-by-one most likely to break the
+    // assembler.
+    { "exact one-chunk fit",             64,  55, 0x04, 0x4321 },
+    { "one byte past the one-chunk fit", 64,  56, 0x04, 0x4321 },
+    { "three chunks",                    64, 200, 0x04, 0x1234 },
+    { "sequence bit set on initiation",  64, 180, 0x14, 0x0042 },
+    // The framing layer is parameterised on the carrier's packet size; one
+    // non-default row keeps that parameterisation exercised.
+    { "non-default chunk size",         244, 600, 0x14, 0x4242 },
+  };
+
+  for (const Case &c : cases) {
+    SCOPED_TRACE(c.name);
+
+    std::vector<uint8_t> payload(c.payload_len);
+    for (size_t i = 0; i < payload.size(); ++i) payload[i] = uint8_t(i ^ 0x5A);
+
+    const auto wire = encode_frame(c.control_byte, c.channel_id,
+                                   payload.data(), payload.size(),
+                                   c.chunk_size);
+    ASSERT_EQ(0u, wire.size() % c.chunk_size)
+        << "encode_frame must emit a whole number of chunks";
+    ASSERT_GE(wire.size(), c.chunk_size);
+    EXPECT_EQ(c.control_byte, wire[0]);
+
+    FrameAssembler asm_;
+    bool done = false;
+    for (size_t off = 0; off < wire.size(); off += c.chunk_size) {
+      if (off > 0) {
+        EXPECT_EQ(0x80, wire[off]) << "continuation chunk at offset " << off;
+        EXPECT_EQ(c.channel_id, read_be16(wire.data() + off + 1));
+      }
+      done = asm_.feed_chunk(wire.data() + off, c.chunk_size);
+      EXPECT_EQ(off + c.chunk_size == wire.size(), done)
+          << "frame completed at the wrong chunk (offset " << off << ")";
+    }
+    ASSERT_TRUE(done);
+
+    Frame f = asm_.take();
+    EXPECT_EQ(c.control_byte, f.control_byte);
+    EXPECT_EQ(c.channel_id,   f.channel_id);
+    ASSERT_EQ(payload.size(), f.payload.size());
+    EXPECT_EQ(0, std::memcmp(f.payload.data(), payload.data(), payload.size()));
+  }
+}
+
+// Byte-exact cross-implementation pin: trezor-firmware's writer fixture for
+// an empty encrypted payload (empty_payload_with_checksum_expected: ctrl
+// 0x04, cid 0x1234, 64-byte packets) in
+// trezor-firmware@bc97a6b2b00068cb36a13da27ddaba8306314870,
+// core/tests/test_trezor.wire.thp.writer.py.  Jointly locks the header
+// layout, the length-includes-CRC rule, the CRC-over-header semantics, and
+// the zero padding to the chunk size.
+// (The fixtures for longer payloads in that file are built with hand-rolled
+// headers whose length field excludes the CRC, so they don't represent
+// protocol-correct frames and are deliberately not mirrored.)
+TEST(thp_framing, wire_bytes_match_trezor_firmware_empty_payload_fixture)
+{
+  static const uint8_t no_payload[1] = {0};
+  const auto wire = encode_frame(0x04, 0x1234, no_payload, 0, 64);
+  const auto expected = from_hex(
+      "0412340004edbd479c0000000000000000000000000000000000000000000000"
+      "0000000000000000000000000000000000000000000000000000000000000000");
+  ASSERT_EQ(expected.size(), wire.size());
+  EXPECT_EQ(expected, wire);
+}
+
+// Continuation layout for a payload that spans five chunks, asserted
+// byte-by-byte against a hand-built expectation rather than by re-running
+// the encoder.  This is the layout trezor-firmware's writer fixture for a
+// 256-byte payload exhibits at the pinned revision above: control byte
+// 0x80, the two-byte channel id, and a body split of 59 bytes in the
+// initiation chunk followed by 61 in each continuation.  Those split
+// offsets are the part of the format the assembler and the device must
+// agree on exactly; everything else about a continuation is header.
+TEST(thp_framing, multi_chunk_continuation_layout)
+{
+  std::vector<uint8_t> payload(256);
+  for (size_t i = 0; i < payload.size(); ++i) payload[i] = uint8_t(i);
+
+  const auto wire = encode_frame(0x04, 0x1234, payload.data(), payload.size());
+  // 256 payload + 4 CRC = 260 body bytes: 59 in the initiation chunk, 61 in
+  // each of three full continuations, and the remaining 18 in a fifth.
+  ASSERT_EQ(USB_CHUNK_SIZE * 5, wire.size());
+
+  // Initiation header: control, channel id, declared length (incl. CRC).
+  EXPECT_EQ(0x04,   wire[0]);
+  EXPECT_EQ(0x1234, read_be16(wire.data() + 1));
+  EXPECT_EQ(260,    read_be16(wire.data() + 3));
+
+  for (size_t n = 1; n <= 3; ++n) {
+    SCOPED_TRACE(n);
+    std::vector<uint8_t> expected{0x80, 0x12, 0x34};
+    const size_t from = 59 + 61 * (n - 1);
+    expected.insert(expected.end(), payload.begin() + from,
+                    payload.begin() + from + 61);
+    const std::vector<uint8_t> got(wire.begin() + n * USB_CHUNK_SIZE,
+                                   wire.begin() + (n + 1) * USB_CHUNK_SIZE);
+    EXPECT_EQ(expected, got);
+  }
+}
+
+TEST(thp_framing, crc_mismatch_throws)
+{
+  const uint8_t payload[] = "abcdefghij";
+  auto wire = encode_frame(0x40, 0xFFFF, payload, sizeof(payload) - 1);
+
+  // Flip a payload byte (offset 5 = first payload byte after the
+  // initiation header).
+  wire[5] ^= 0x01;
+
+  FrameAssembler asm_;
+  EXPECT_THROW(asm_.feed_chunk(wire.data(), USB_CHUNK_SIZE),
+               hw::trezor::exc::CommunicationException);
+}
+
+// Regression: the data-packet sequence bit lives at 0x10, not 0x08.
+//
+// THP spec, "Transport packet structure", defines DATA packets as
+// `000XX100` under mask 0xE7. Bit 4 (0x10) is the seq bit; bit 3 (0x08)
+// is the optional piggyback-ACK bit; on an ACK packet the seq bit is at
+// 0x08 instead. An earlier bug had us OR'ing 0x08 into the control byte
+// to mark seq=1, which the device reads as a repeated seq=0 frame plus a
+// piggyback-ACK signal, wedging the alternating-bit protocol on every
+// multi-frame exchange. HandshakeCompletionRequest is the first frame to
+// need seq=1, and with the bug it went out as 0x0A instead of 0x12: real
+// Safe 7 firmware silently drops it and the wallet hangs forever on
+// "Creating wallet from device...".
+//
+// This pins the bit positions and the Frame accessors that read them;
+// thp_protocol_v2.write_read_control_byte_sequence_matches_spec pins the
+// bytes ProtocolV2 actually emits.
+TEST(thp_framing, data_and_ack_sequence_bits_have_distinct_positions)
+{
+  EXPECT_EQ(0x10, CTRL_DATA_SEQ_BIT);
+  EXPECT_EQ(0x08, CTRL_DATA_ACK_BIT);
+  EXPECT_EQ(0x08, CTRL_ACK_SEQ_BIT);
+  EXPECT_EQ(0xE7, CTRL_DATA_MASK);
+  EXPECT_EQ(0xF7, CTRL_ACK_MASK);
+  EXPECT_EQ(0x12, CTRL_HANDSHAKE_COMP_REQ | CTRL_DATA_SEQ_BIT);
+
+  struct Case { uint8_t control; bool ack; uint8_t base; uint8_t seq; uint8_t pb; };
+  static const Case cases[] = {
+    // Encrypted transport at seq=0 and seq=1, then with the piggyback-ACK
+    // bit also set (0x1C), which must not disturb the type match.
+    { CTRL_ENCRYPTED_TRANSPORT,                       false, CTRL_ENCRYPTED_TRANSPORT, 0, 0 },
+    { CTRL_ENCRYPTED_TRANSPORT | CTRL_DATA_SEQ_BIT,   false, CTRL_ENCRYPTED_TRANSPORT, 1, 0 },
+    { CTRL_ENCRYPTED_TRANSPORT | CTRL_DATA_SEQ_BIT |
+      CTRL_DATA_ACK_BIT,                              false, CTRL_ENCRYPTED_TRANSPORT, 1, 1 },
+    { CTRL_HANDSHAKE_COMP_REQ  | CTRL_DATA_SEQ_BIT,   false, CTRL_HANDSHAKE_COMP_REQ,  1, 0 },
+  };
+  for (const Case &c : cases) {
+    SCOPED_TRACE(int(c.control));
+    Frame f{};
+    f.control_byte = c.control;
+    EXPECT_EQ(c.ack, f.is_ack());
+    EXPECT_EQ(c.base, f.control_byte & CTRL_DATA_MASK);
+    EXPECT_EQ(c.seq, f.data_seq_bit());
+    EXPECT_EQ(c.pb,  f.data_ack_bit());
+  }
+
+  // On ACK packets the sequence bit sits at 0x08, so ACK_SEQ1 is 0x28.
+  Frame ack1{}; ack1.control_byte = CTRL_ACK_SEQ1;
+  EXPECT_TRUE(ack1.is_ack());
+  EXPECT_EQ(1, ack1.ack_seq_bit());
+  Frame ack0{}; ack0.control_byte = CTRL_ACK_SEQ0;
+  EXPECT_TRUE(ack0.is_ack());
+  EXPECT_EQ(0, ack0.ack_seq_bit());
+}
+
+// Variable-size final chunk acceptance.  The FrameAssembler must
+// tolerate a final chunk smaller than the negotiated transport
+// chunk_size: the THP wire format carries a declared length, so the
+// assembler completes a frame as soon as that length is covered rather
+// than requiring a full padded chunk.  This test locks in that
+// length-tolerant contract.
+TEST(thp_framing, variable_size_final_chunk_accepted)
+{
+  // Build a frame that spans 2 full chunks plus a partial final
+  // chunk.  244 - 5 = 239 bytes in chunk 0; 244 - 3 = 241 bytes per
+  // continuation.  Total payload = 239 + 241 + 50 = 530 bytes.
+  std::vector<uint8_t> payload(530);
+  for (size_t i = 0; i < payload.size(); ++i) payload[i] = uint8_t((i * 7) ^ 0x5A);
+
+  auto wire = encode_frame(0x04, 0xBEEF, payload.data(), payload.size(),
+                           /*chunk_size=*/244);
+  // encode_frame produces fully-padded chunks; verify our test setup.
+  ASSERT_EQ(0u, wire.size() % 244);
+  ASSERT_EQ(244u * 3, wire.size());
+
+  FrameAssembler asm_;
+  EXPECT_FALSE(asm_.feed_chunk(wire.data() + 0,   244));
+  EXPECT_FALSE(asm_.feed_chunk(wire.data() + 244, 244));
+  // Trim the final chunk to a SHORT length covering the declared
+  // payload + CRC32 (THP length field marks the legal end).  53 bytes
+  // = 3-byte continuation header + remaining payload (50) ... 50 +
+  // padding past the CRC isn't needed because the assembler should
+  // accept whatever covers the declared length.
+  const size_t kFinalShortLen = 244 - 100;
+  EXPECT_TRUE(asm_.feed_chunk(wire.data() + 488, kFinalShortLen));
+
+  Frame f = asm_.take();
+  EXPECT_EQ(0x04, f.control_byte);
+  EXPECT_EQ(0xBEEF, f.channel_id);
+  ASSERT_EQ(payload.size(), f.payload.size());
+  EXPECT_EQ(0, std::memcmp(f.payload.data(), payload.data(), payload.size()));
+}
+
+// Runt-chunk regression guard.  Although the FrameAssembler accepts a
+// short final chunk (see above), it MUST still reject a continuation
+// chunk too small to even hold the 3-byte continuation header.  This is
+// the "THP: chunk too small" guard in framing.cpp.  This test admits a
+// normal initiation chunk, then feeds a 1-byte continuation chunk
+// (control byte only, no room for the 3-byte continuation header) and
+// asserts the assembler throws a CommunicationException rather than
+// over-reading.
+TEST(thp_framing, runt_continuation_chunk_rejected)
+{
+  std::vector<uint8_t> payload(500, 0x77);
+  auto wire = encode_frame(0x04, 0x1234, payload.data(), payload.size(), 244);
+  ASSERT_GE(wire.size(), 244u * 2);
+
+  FrameAssembler asm_;
+  // First (initiation) chunk admitted normally.
+  EXPECT_FALSE(asm_.feed_chunk(wire.data(), 244));
+
+  // A 1-byte continuation should throw: too small to even hold the
+  // continuation header (3 bytes).  framing.cpp throws
+  // CommunicationException with "THP: chunk too small".
+  std::vector<uint8_t> tiny{0x80};  // continuation control byte only
+  EXPECT_THROW(asm_.feed_chunk(tiny.data(), tiny.size()),
+               hw::trezor::exc::CommunicationException);
+}
+
+// Runt-initiation guard.  The initiation header is 5 bytes (ctrl + 2-byte
+// cid + 2-byte length).  A 4-byte chunk passes the generic 3-byte "too
+// small" guard but would let read_be16(chunk+3) read one byte out of
+// bounds, so the initiation path must reject it explicitly.  A 5-byte
+// chunk (exactly the header, no payload yet) is the boundary case: it is
+// VALID: read_be16(chunk+3) stays in bounds and the declared-length
+// logic awaits the continuation, so it must NOT be rejected by the
+// too-small guard.  This pins the off-by-one boundary (< not <=).
+TEST(thp_framing, runt_initiation_chunk_rejected)
+{
+  // 4-byte initiation chunk: ctrl=0x04 (initiation), cid=0x1234, then a
+  // single length byte, one short of the 2-byte length field.
+  std::vector<uint8_t> four{0x04, 0x12, 0x34, 0x00};
+  FrameAssembler asm_four;
+  EXPECT_THROW(asm_four.feed_chunk(four.data(), four.size()),
+               hw::trezor::exc::CommunicationException);
+
+  // 5-byte initiation chunk: full header, declared_len=0x000A (>0, so the
+  // payload+CRC arrive in a later chunk).  The assembler must accept it
+  // and return false (frame incomplete), NOT throw "initiation chunk too
+  // small".
+  std::vector<uint8_t> five{0x04, 0x12, 0x34, 0x00, 0x0A};
+  FrameAssembler asm_five;
+  EXPECT_FALSE(asm_five.feed_chunk(five.data(), five.size()));
+}
+
+// ---------------------------------------------------------------------------
+// SHA-256 (NIST FIPS 180-4 example).
+// ---------------------------------------------------------------------------
+TEST(thp_crypto, sha256_abc)
+{
+  NoiseHash h{};
+  noise_crypto::sha256(reinterpret_cast<const uint8_t *>("abc"), 3, h);
+  auto exp = from_hex("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  ASSERT_EQ(32u, exp.size());
+  EXPECT_EQ(0, std::memcmp(h.data(), exp.data(), exp.size()));
+}
+
+// ---------------------------------------------------------------------------
+// HMAC-SHA-256 (RFC 4231 test vectors 1 and 4).
+// ---------------------------------------------------------------------------
+TEST(thp_crypto, hmac_sha256_rfc4231_case1)
+{
+  auto key  = from_hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+  auto data = from_hex("4869205468657265"); // "Hi There"
+  auto exp  = from_hex("b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7");
+  NoiseHash mac{};
+  noise_crypto::hmac_sha256(key.data(), key.size(), data.data(), data.size(), mac);
+  EXPECT_EQ(0, std::memcmp(mac.data(), exp.data(), exp.size()));
+}
+
+TEST(thp_crypto, hmac_sha256_rfc4231_case4)
+{
+  auto key  = from_hex("0102030405060708090a0b0c0d0e0f10111213141516171819");
+  auto data = from_hex("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+                       "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd");
+  auto exp  = from_hex("82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b");
+  NoiseHash mac{};
+  noise_crypto::hmac_sha256(key.data(), key.size(), data.data(), data.size(), mac);
+  EXPECT_EQ(0, std::memcmp(mac.data(), exp.data(), exp.size()));
+}
+
+// ---------------------------------------------------------------------------
+// X25519: RFC 7748 sec. 5.2 raw-scalar test vectors.
+// ---------------------------------------------------------------------------
+TEST(thp_crypto, x25519_rfc7748_section_5_2_iter1)
+{
+  auto priv_v = from_hex("a546e36bf0527c9d3b16154b82465edd62144c0ac1fc5a18506a2244ba449ac4");
+  auto peer_v = from_hex("e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c");
+  auto exp_v  = from_hex("c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552");
+  NoisePrivKey priv{}; std::memcpy(priv.data(), priv_v.data(), 32);
+  NoisePubKey  peer{}; std::memcpy(peer.data(), peer_v.data(), 32);
+  NoisePubKey  out{};
+  noise_crypto::x25519(priv, peer, out);
+  EXPECT_EQ(0, std::memcmp(out.data(), exp_v.data(), exp_v.size()));
+}
+
+TEST(thp_crypto, x25519_rfc7748_section_5_2_iter2)
+{
+  auto priv_v = from_hex("4b66e9d4d1b4673c5ad22691957d6af5c11b6421e0ea01d42ca4169e7918ba0d");
+  auto peer_v = from_hex("e5210f12786811d3f4b7959d0538ae2c31dbe7106fc03c3efc4cd549c715a493");
+  auto exp_v  = from_hex("95cbde9476e8907d7aade45cb4b873f88b595a68799fa152e6f8f7647aac7957");
+  NoisePrivKey priv{}; std::memcpy(priv.data(), priv_v.data(), 32);
+  NoisePubKey  peer{}; std::memcpy(peer.data(), peer_v.data(), 32);
+  NoisePubKey  out{};
+  noise_crypto::x25519(priv, peer, out);
+  EXPECT_EQ(0, std::memcmp(out.data(), exp_v.data(), exp_v.size()));
+}
+
+TEST(thp_crypto, x25519_dh_symmetry)
+{
+  // Generate two random keypairs; verify the standard DH identity.
+  NoisePubKey  a_pub{}, b_pub{};
+  NoisePrivKey a_priv{}, b_priv{};
+  noise_crypto::x25519_keypair(a_pub, a_priv);
+  noise_crypto::x25519_keypair(b_pub, b_priv);
+  NoisePubKey k1{}, k2{};
+  noise_crypto::x25519(a_priv, b_pub, k1);
+  noise_crypto::x25519(b_priv, a_pub, k2);
+  EXPECT_EQ(0, std::memcmp(k1.data(), k2.data(), 32));
+}
+
+// ---------------------------------------------------------------------------
+// AES-256-GCM (NIST CAVS gcmEncryptExtIV256.rsp count 0 and 2).
+// ---------------------------------------------------------------------------
+TEST(thp_crypto, aes256gcm_empty_message_zero_iv)
+{
+  NoiseKey         key{}; std::memset(key.data(), 0, key.size());
+  noise_crypto::NoiseIv  iv{};
+  std::vector<uint8_t> ct;
+  ASSERT_TRUE(noise_crypto::aes256gcm_encrypt(key, iv, nullptr, 0, nullptr, 0, ct));
+  ASSERT_EQ(NOISE_TAGLEN, ct.size());
+  auto exp = from_hex("530f8afbc74536b9a963b4f1c4cb738b");
+  EXPECT_EQ(0, std::memcmp(ct.data(), exp.data(), exp.size()));
+
+  std::vector<uint8_t> pt;
+  ASSERT_TRUE(noise_crypto::aes256gcm_decrypt(key, iv, nullptr, 0,
+                                        ct.data(), ct.size(), pt));
+  EXPECT_TRUE(pt.empty());
+}
+
+TEST(thp_crypto, aes256gcm_16_bytes_zero_iv)
+{
+  NoiseKey         key{}; std::memset(key.data(), 0, key.size());
+  noise_crypto::NoiseIv  iv{};
+  std::vector<uint8_t> pt(16, 0);
+  std::vector<uint8_t> ct;
+  ASSERT_TRUE(noise_crypto::aes256gcm_encrypt(key, iv, nullptr, 0,
+                                        pt.data(), pt.size(), ct));
+  auto exp_ct  = from_hex("cea7403d4d606b6e074ec5d3baf39d18");
+  auto exp_tag = from_hex("d0d1c8a799996bf0265b98b5d48ab919");
+  ASSERT_EQ(32u, ct.size());
+  EXPECT_EQ(0, std::memcmp(ct.data(),       exp_ct.data(),  16));
+  EXPECT_EQ(0, std::memcmp(ct.data() + 16,  exp_tag.data(), 16));
+
+  std::vector<uint8_t> rt;
+  ASSERT_TRUE(noise_crypto::aes256gcm_decrypt(key, iv, nullptr, 0,
+                                        ct.data(), ct.size(), rt));
+  EXPECT_EQ(rt, pt);
+}
+
+TEST(thp_crypto, aes256gcm_tamper_detected)
+{
+  NoiseKey         key{}; std::memset(key.data(), 0, key.size());
+  noise_crypto::NoiseIv  iv{};
+  std::vector<uint8_t> pt(16, 0);
+  std::vector<uint8_t> ct;
+  ASSERT_TRUE(noise_crypto::aes256gcm_encrypt(key, iv, nullptr, 0,
+                                        pt.data(), pt.size(), ct));
+  ct[0] ^= 0x01;
+  std::vector<uint8_t> rt;
+  EXPECT_FALSE(noise_crypto::aes256gcm_decrypt(key, iv, nullptr, 0,
+                                         ct.data(), ct.size(), rt));
+}
+
+// Mirrors trezor-firmware's THP encryption vectors
+// (core/tests/test_trezor.wire.thp.crypto.py, vectors_enc).  Unlike the
+// zero-IV NIST-style tests above, these pin the key + THP-nonce-derived IV
+// + AAD path JOINTLY against the values the device computes.
+TEST(thp_crypto, aes256gcm_trezor_firmware_thp_nonce_vectors)
+{
+  const auto key_bytes = from_hex(
+      "0001020304050607000102030405060700010203040506070001020304050607");
+  NoiseKey key{};
+  std::memcpy(key.data(), key_bytes.data(), key.size());
+
+  struct Vector {
+    uint64_t    nonce;
+    const char *aad_hex;
+    const char *pt_hex;
+    const char *ct_hex;
+    const char *tag_hex;
+  };
+  const Vector vectors[] = {
+    { 0,   "5564",       "00010203040506070809",
+      "e2c9dd152fbee5821ea7", "10625812de81b14a46b9f1e5100a6d0c" },
+    { 1,   "5564",       "00010203040506070809",
+      "79811619ddb07c2b99f8", "71c6b872cdc499a7e9a3c7441f053214" },
+    { 369, "5564",       "000102030405060708090a0b0c0d0e0f",
+      "03bd030390f2dfe815a61c2b157a064f",
+      "c1200f8a7ae9a6d32cef0fff878d55c2" },
+    // Same key/nonce/plaintext as above but a longer AAD: the ciphertext
+    // is unchanged and only the tag moves.
+    { 369, "5564738291", "000102030405060708090a0b0c0d0e0f",
+      "03bd030390f2dfe815a61c2b157a064f",
+      "693ac160cd93a20f7fc255f049d808d0" },
+  };
+
+  for (const Vector &v : vectors) {
+    const auto aad = from_hex(v.aad_hex);
+    const auto pt  = from_hex(v.pt_hex);
+    const auto exp_ct  = from_hex(v.ct_hex);
+    const auto exp_tag = from_hex(v.tag_hex);
+
+    noise_crypto::NoiseIv iv{};
+    noise_crypto::iv_for_nonce(v.nonce, iv);
+
+    std::vector<uint8_t> ct;
+    ASSERT_TRUE(noise_crypto::aes256gcm_encrypt(key, iv, aad.data(), aad.size(),
+                                          pt.data(), pt.size(), ct));
+    ASSERT_EQ(pt.size() + NOISE_TAGLEN, ct.size());
+    EXPECT_EQ(0, std::memcmp(ct.data(), exp_ct.data(), exp_ct.size()))
+        << "ciphertext mismatch for nonce " << v.nonce;
+    EXPECT_EQ(0, std::memcmp(ct.data() + pt.size(),
+                             exp_tag.data(), exp_tag.size()))
+        << "tag mismatch for nonce " << v.nonce;
+
+    std::vector<uint8_t> rt;
+    ASSERT_TRUE(noise_crypto::aes256gcm_decrypt(key, iv, aad.data(), aad.size(),
+                                          ct.data(), ct.size(), rt));
+    EXPECT_EQ(pt, rt);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// IV builder: nonce 0 yields 0^96, nonce 1 yields 0^95||1, larger counter
+// values are encoded big-endian in the trailing 8 bytes.
+// ---------------------------------------------------------------------------
+TEST(thp_crypto, iv_for_nonce_layout)
+{
+  noise_crypto::NoiseIv iv{};
+  noise_crypto::iv_for_nonce(0, iv);
+  for (int i = 0; i < 12; ++i) EXPECT_EQ(0, iv[i]);
+
+  noise_crypto::iv_for_nonce(1, iv);
+  for (int i = 0; i < 11; ++i) EXPECT_EQ(0, iv[i]);
+  EXPECT_EQ(1, iv[11]);
+
+  noise_crypto::iv_for_nonce(0x0102030405060708ULL, iv);
+  EXPECT_EQ(0x01, iv[4]);  EXPECT_EQ(0x02, iv[5]);
+  EXPECT_EQ(0x03, iv[6]);  EXPECT_EQ(0x04, iv[7]);
+  EXPECT_EQ(0x05, iv[8]);  EXPECT_EQ(0x06, iv[9]);
+  EXPECT_EQ(0x07, iv[10]); EXPECT_EQ(0x08, iv[11]);
+}
+
+// Mirrors trezor-firmware's IV-from-nonce vectors
+// (core/tests/test_trezor.wire.thp.crypto.py, vectors_iv), including the
+// all-ones boundary the device treats as the last usable nonce.
+TEST(thp_crypto, iv_for_nonce_trezor_firmware_vectors)
+{
+  struct Vector { uint64_t nonce; const char *iv_hex; };
+  const Vector vectors[] = {
+    { 0,                     "000000000000000000000000" },
+    { 1,                     "000000000000000000000001" },
+    { 7,                     "000000000000000000000007" },
+    { 1025,                  "000000000000000000000401" },
+    { 4294967295ULL,         "0000000000000000ffffffff" },
+    { 0xFFFFFFFFFFFFFFFFULL, "00000000ffffffffffffffff" },
+  };
+  for (const Vector &v : vectors) {
+    noise_crypto::NoiseIv iv{};
+    noise_crypto::iv_for_nonce(v.nonce, iv);
+    const auto exp = from_hex(v.iv_hex);
+    EXPECT_EQ(0, std::memcmp(iv.data(), exp.data(), iv.size()))
+        << "IV mismatch for nonce " << v.nonce;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// THP HKDF self-consistency (regression check derived from the spec text).
+// ---------------------------------------------------------------------------
+TEST(thp_crypto, thp_hkdf_self_consistency)
+{
+  NoiseHash ck{};  std::memset(ck.data(),  'k', ck.size());
+  NoiseHash ikm{}; std::memset(ikm.data(), 'v', ikm.size());
+
+  NoiseHash temp{}, o1{}, o2{};
+  noise_crypto::hmac_sha256(ck.data(), ck.size(), ikm.data(), ikm.size(), temp);
+  const uint8_t one = 0x01;
+  noise_crypto::hmac_sha256(temp.data(), temp.size(), &one, 1, o1);
+  std::array<uint8_t, NOISE_HASHLEN + 1> o1p2{};
+  std::memcpy(o1p2.data(), o1.data(), 32);
+  o1p2[32] = 0x02;
+  noise_crypto::hmac_sha256(temp.data(), temp.size(),
+                      o1p2.data(), o1p2.size(), o2);
+
+  NoiseKey out1{}, out2{};
+  noise_crypto::thp_hkdf(ck.data(), ck.size(), ikm.data(), ikm.size(), out1, out2);
+  EXPECT_EQ(0, std::memcmp(out1.data(), o1.data(), 32));
+  EXPECT_EQ(0, std::memcmp(out2.data(), o2.data(), 32));
+}
+
+// Mirrors trezor-firmware's THP HKDF fixed vectors
+// (core/tests/test_trezor.wire.thp.crypto.py, vectors_hkdf).  Unlike the
+// self-consistency check above, which would miss a bug present on both
+// sides, these pin the output against values computed by an independent
+// implementation.  The first chaining key is the Noise protocol name the
+// handshake hashes are seeded with; the second vector chains off the
+// first vector's ck output, as the handshake itself does.
+TEST(thp_crypto, thp_hkdf_trezor_firmware_vectors)
+{
+  // "Noise_XX_25519_AESGCM_SHA256" padded with NULs to 32 bytes.
+  const uint8_t protocol_name[32] = {
+    'N','o','i','s','e','_','X','X','_','2','5','5','1','9','_',
+    'A','E','S','G','C','M','_','S','H','A','2','5','6',0,0,0,0,
+  };
+
+  const uint8_t ikm1[] = { 0x01, 0x02 };
+  NoiseKey ck1{}, k1{};
+  noise_crypto::thp_hkdf(protocol_name, sizeof(protocol_name),
+                   ikm1, sizeof(ikm1), ck1, k1);
+  const auto exp_ck1 = from_hex(
+      "c784373a217d6be057cddc6068e6748f255fc8beb6f99b7b90cbc64aad947514");
+  const auto exp_k1 = from_hex(
+      "12695451e29bf08ffe5e4e6ab734b0c3d7cdd99b16cd409f57bd4eaa874944ba");
+  EXPECT_EQ(0, std::memcmp(ck1.data(), exp_ck1.data(), ck1.size()));
+  EXPECT_EQ(0, std::memcmp(k1.data(),  exp_k1.data(),  k1.size()));
+
+  const auto ikm2 = from_hex("314159265212345678" "8904aa");
+  NoiseKey ck2{}, k2{};
+  noise_crypto::thp_hkdf(ck1.data(), ck1.size(),
+                   ikm2.data(), ikm2.size(), ck2, k2);
+  const auto exp_ck2 = from_hex(
+      "f88c1e08d5c3bae8f6e4a3d3324c8cbc60a805603e399e69c4bf4eacb27c2f48");
+  const auto exp_k2 = from_hex(
+      "5f0216bdb7110ee05372286974da8c9c8b96e2efa15b4af430755f462bd79a76");
+  EXPECT_EQ(0, std::memcmp(ck2.data(), exp_ck2.data(), ck2.size()));
+  EXPECT_EQ(0, std::memcmp(k2.data(),  exp_k2.data(),  k2.size()));
+}
+
+// ---------------------------------------------------------------------------
+// trezor_mask_static is deterministic for fixed inputs and changes whenever
+// the ephemeral public key changes (so paired-device lookups discriminate).
+// ---------------------------------------------------------------------------
+TEST(thp_crypto, trezor_mask_static_deterministic_and_eph_bound)
+{
+  NoisePubKey  static_pub{};
+  NoisePrivKey static_priv{};
+  noise_crypto::x25519_keypair(static_pub, static_priv);
+
+  NoisePubKey  eph_pub{};
+  NoisePrivKey eph_priv{};
+  noise_crypto::x25519_keypair(eph_pub, eph_priv);
+
+  NoisePubKey m1{}, m2{};
+  noise_crypto::trezor_mask_static(static_pub, eph_pub, m1);
+  noise_crypto::trezor_mask_static(static_pub, eph_pub, m2);
+  EXPECT_EQ(0, std::memcmp(m1.data(), m2.data(), 32));
+
+  NoisePubKey  eph_pub2{};
+  NoisePrivKey eph_priv2{};
+  noise_crypto::x25519_keypair(eph_pub2, eph_priv2);
+  NoisePubKey m_alt{};
+  noise_crypto::trezor_mask_static(static_pub, eph_pub2, m_alt);
+  EXPECT_NE(0, std::memcmp(m1.data(), m_alt.data(), 32));
+}
+
+// ---------------------------------------------------------------------------
+// Self-handshake: simulate the Trezor side of the handshake exactly per the
+// state machine in specification.md, run a complete handshake against the
+// real host implementation, and verify the two sides agree on the final
+// transport keys and handshake hash.
+//
+// This is a SELF test (both sides are this code), so it would not catch a
+// bug that is mirrored on both sides.  Its value is in pinning the
+// algorithm: any deviation in IV layout, AAD, mix_hash ordering, masked
+// key construction, or HKDF call shape between the two sides causes the
+// AES-GCM tag to mismatch and the test to fail loudly.
+// ---------------------------------------------------------------------------
+namespace {
+
+struct TrezorSide {
+  NoisePubKey  static_pub{};
+  NoisePrivKey static_priv{};
+  NoisePubKey  ephemeral_pub{};
+  NoisePrivKey ephemeral_priv{};
+  std::vector<uint8_t> device_properties;
+  // The state byte reported in HandshakeCompletionResponse.
+  uint8_t      state = STATE_UNPAIRED;
+
+  NoiseHash h{};
+  NoiseKey  ck{};
+  NoiseKey  k{};
+
+  HandshakeKeys keys{};
+  std::vector<uint8_t> handshake_init_response;
+  std::vector<uint8_t> handshake_completion_response;
+  std::vector<uint8_t> decrypted_completion_payload;
+  uint8_t              host_static_pub_received[NOISE_DHLEN] = {0};
+
+  void mix_hash(const uint8_t *data, size_t len) {
+    std::vector<uint8_t> buf;
+    buf.reserve(NOISE_HASHLEN + len);
+    buf.insert(buf.end(), h.begin(), h.end());
+    if (len) buf.insert(buf.end(), data, data + len);
+    noise_crypto::sha256(buf.data(), buf.size(), h);
+  }
+
+  void handle_init_request(const std::vector<uint8_t> &req) {
+    // req = host_eph_pub (32) || try_to_unlock (1)
+    ASSERT_EQ(NOISE_DHLEN + 1u, req.size());
+
+    noise_crypto::x25519_keypair(ephemeral_pub, ephemeral_priv);
+
+    // h = SHA-256(protocol_name || device_properties)
+    static const uint8_t protocol_name[] = {
+      'N','o','i','s','e','_','X','X','_','2','5','5','1','9',
+      '_','A','E','S','G','C','M','_','S','H','A','2','5','6',
+      0,0,0,0
+    };
+    std::vector<uint8_t> hash_in;
+    hash_in.insert(hash_in.end(), protocol_name, protocol_name + sizeof(protocol_name));
+    hash_in.insert(hash_in.end(), device_properties.begin(), device_properties.end());
+    noise_crypto::sha256(hash_in.data(), hash_in.size(), h);
+
+    // h = SHA-256(h || host_eph_pub)
+    mix_hash(req.data(), NOISE_DHLEN);
+    // h = SHA-256(h || try_to_unlock)
+    mix_hash(req.data() + NOISE_DHLEN, 1);
+    // h = SHA-256(h || trezor_eph_pub)
+    mix_hash(ephemeral_pub.data(), ephemeral_pub.size());
+
+    // (ck, k) = HKDF(protocol_name, X25519(trezor_eph_priv, host_eph_pub))
+    NoisePubKey host_eph_pub{};
+    std::memcpy(host_eph_pub.data(), req.data(), NOISE_DHLEN);
+    NoisePubKey ee{};
+    noise_crypto::x25519(ephemeral_priv, host_eph_pub, ee);
+    noise_crypto::thp_hkdf(protocol_name, sizeof(protocol_name),
+                     ee.data(), ee.size(), ck, k);
+
+    // mask = SHA-256(static_pub || trezor_eph_pub)
+    NoisePubKey masked{};
+    noise_crypto::trezor_mask_static(static_pub, ephemeral_pub, masked);
+
+    // enc_static = AES-GCM-Encrypt(k, IV=0^96, ad=h, masked)
+    noise_crypto::NoiseIv iv{};
+    noise_crypto::iv_for_nonce(0, iv);
+    std::vector<uint8_t> enc_static;
+    ASSERT_TRUE(noise_crypto::aes256gcm_encrypt(k, iv, h.data(), h.size(),
+                                          masked.data(), masked.size(),
+                                          enc_static));
+    // h = SHA-256(h || enc_static)
+    mix_hash(enc_static.data(), enc_static.size());
+
+    // (ck, k) = HKDF(ck, X25519(mask, X25519(static_priv, host_eph_pub)))
+    NoisePubKey se{};
+    noise_crypto::x25519(static_priv, host_eph_pub, se);
+    // The trezor side computes X25519(mask_scalar, ...). Equivalently, the
+    // host computes X25519(host_eph_priv, masked). They produce the same DH
+    // shared secret. Spec phrasing: ck, k = HKDF(ck, X25519(mask, se)).
+    std::array<uint8_t, NOISE_DHLEN * 2> concat{};
+    std::memcpy(concat.data(),               static_pub.data(),    NOISE_DHLEN);
+    std::memcpy(concat.data() + NOISE_DHLEN, ephemeral_pub.data(), NOISE_DHLEN);
+    NoiseHash mask_h{};
+    noise_crypto::sha256(concat.data(), concat.size(), mask_h);
+    NoisePrivKey mask_scalar{};
+    std::memcpy(mask_scalar.data(), mask_h.data(), NOISE_DHLEN);
+    NoisePubKey ssm{};
+    noise_crypto::x25519(mask_scalar, se, ssm);
+    noise_crypto::thp_hkdf(ck.data(), ck.size(), ssm.data(), ssm.size(), ck, k);
+
+    // tag = AES-GCM(k, IV=0^96, ad=h, plaintext=empty)
+    noise_crypto::iv_for_nonce(0, iv);
+    std::vector<uint8_t> tag;
+    ASSERT_TRUE(noise_crypto::aes256gcm_encrypt(k, iv, h.data(), h.size(),
+                                          nullptr, 0, tag));
+    // h = SHA-256(h || tag)
+    mix_hash(tag.data(), tag.size());
+
+    handshake_init_response.clear();
+    handshake_init_response.insert(handshake_init_response.end(),
+                                   ephemeral_pub.begin(), ephemeral_pub.end());
+    handshake_init_response.insert(handshake_init_response.end(),
+                                   enc_static.begin(), enc_static.end());
+    handshake_init_response.insert(handshake_init_response.end(),
+                                   tag.begin(), tag.end());
+  }
+
+  void handle_completion_request(const std::vector<uint8_t> &req) {
+    // req = enc_host_static (48) || enc_payload (var)
+    ASSERT_GE(req.size(), 48u);
+    const uint8_t *enc_host_static = req.data();
+    const uint8_t *enc_payload     = req.data() + 48;
+    const size_t   enc_payload_len = req.size() - 48;
+
+    // host_static_pub = AES-GCM-Decrypt(k, IV=0^95||1, ad=h, enc_host_static)
+    noise_crypto::NoiseIv iv{};
+    noise_crypto::iv_for_nonce(1, iv);
+    std::vector<uint8_t> host_static_pub;
+    ASSERT_TRUE(noise_crypto::aes256gcm_decrypt(k, iv, h.data(), h.size(),
+                                          enc_host_static, 48, host_static_pub));
+    ASSERT_EQ(NOISE_DHLEN, host_static_pub.size());
+    std::memcpy(host_static_pub_received, host_static_pub.data(), NOISE_DHLEN);
+    // h = SHA-256(h || enc_host_static)
+    mix_hash(enc_host_static, 48);
+
+    // (ck, k) = HKDF(ck, X25519(trezor_eph_priv, host_static_pub))
+    NoisePubKey hsp{}; std::memcpy(hsp.data(), host_static_pub.data(), NOISE_DHLEN);
+    NoisePubKey ss{};
+    noise_crypto::x25519(ephemeral_priv, hsp, ss);
+    noise_crypto::thp_hkdf(ck.data(), ck.size(), ss.data(), ss.size(), ck, k);
+
+    // payload = AES-GCM-Decrypt(k, IV=0^96, ad=h, enc_payload)
+    noise_crypto::iv_for_nonce(0, iv);
+    std::vector<uint8_t> payload;
+    ASSERT_TRUE(noise_crypto::aes256gcm_decrypt(k, iv, h.data(), h.size(),
+                                          enc_payload, enc_payload_len, payload));
+    decrypted_completion_payload = payload;
+    // h = SHA-256(h || enc_payload)
+    mix_hash(enc_payload, enc_payload_len);
+
+    // (key_request, key_response) = HKDF(ck, empty)
+    NoiseKey key_request{}, key_response{};
+    noise_crypto::thp_hkdf(ck.data(), ck.size(), nullptr, 0, key_request, key_response);
+
+    // encrypted_state = AES-GCM-Encrypt(key_response, IV=0^96, ad=empty,
+    //                                   plaintext=trezor_state byte)
+    const uint8_t state_byte = state;
+    noise_crypto::iv_for_nonce(0, iv);
+    std::vector<uint8_t> encrypted_state;
+    ASSERT_TRUE(noise_crypto::aes256gcm_encrypt(key_response, iv,
+                                          nullptr, 0,
+                                          &state_byte, 1,
+                                          encrypted_state));
+    handshake_completion_response = encrypted_state;
+
+    keys.key_request    = key_request;
+    keys.key_response   = key_response;
+    keys.handshake_hash = h;
+  }
+};
+
+} // namespace
+
+TEST(thp_handshake, full_handshake_self_test)
+{
+  TrezorSide trezor;
+  // Generate the persistent Trezor static keypair.
+  noise_crypto::x25519_keypair(trezor.static_pub, trezor.static_priv);
+  // Some non-empty device properties (real device sends a serialised
+  // ThpDeviceProperties protobuf; for the purposes of this test the
+  // bytes just need to match what the host hashes into h).
+  trezor.device_properties = {0x0a, 0x04, 'T','2','B','1'};
+
+  // Host side: fresh static keypair, no known devices.
+  HostStaticKey host_static;
+  noise_crypto::x25519_keypair(host_static.pub, host_static.priv);
+
+  NoiseXxInitiator host;
+  host.set_device_properties(trezor.device_properties.data(),
+                             trezor.device_properties.size());
+  host.set_host_static_key(host_static);
+
+  // Step 1: host -> trezor: HandshakeInitiationRequest
+  auto init_req = host.build_init_request(/*try_to_unlock=*/false);
+  trezor.handle_init_request(init_req);
+
+  // Step 2: trezor -> host: HandshakeInitiationResponse
+  host.consume_init_response(trezor.handshake_init_response.data(),
+                             trezor.handshake_init_response.size());
+  EXPECT_FALSE(host.is_known_device());
+
+  // Step 3: host -> trezor: HandshakeCompletionRequest
+  auto comp_req = host.build_completion_request();
+  trezor.handle_completion_request(comp_req);
+
+  // The unpaired flow sends an empty ThpHandshakeCompletionReqNoisePayload,
+  // which serialises to zero protobuf bytes. The Trezor must therefore see
+  // a zero-length decrypted payload.
+  EXPECT_TRUE(trezor.decrypted_completion_payload.empty());
+
+  // The Trezor must see exactly the host's static public key.
+  EXPECT_EQ(0, std::memcmp(trezor.host_static_pub_received,
+                           host_static.pub.data(), NOISE_DHLEN));
+
+  // Step 4: trezor -> host: HandshakeCompletionResponse
+  host.consume_completion_response(trezor.handshake_completion_response.data(),
+                                   trezor.handshake_completion_response.size());
+  ASSERT_TRUE(host.is_complete());
+  EXPECT_EQ(0x00 /*STATE_UNPAIRED*/, host.trezor_state());
+
+  // Both sides must have arrived at the same transport keys + handshake hash.
+  const HandshakeKeys &hk = host.keys();
+  EXPECT_EQ(0, std::memcmp(hk.key_request.data(),    trezor.keys.key_request.data(),    NOISE_KEYLEN));
+  EXPECT_EQ(0, std::memcmp(hk.key_response.data(),   trezor.keys.key_response.data(),   NOISE_KEYLEN));
+  EXPECT_EQ(0, std::memcmp(hk.handshake_hash.data(), trezor.keys.handshake_hash.data(), NOISE_HASHLEN));
+
+  // The masked-static-pubkey decoded by the host must match what the
+  // Trezor would have computed for itself (round-trip identity check).
+  NoisePubKey expected_masked{};
+  noise_crypto::trezor_mask_static(trezor.static_pub, trezor.ephemeral_pub, expected_masked);
+  EXPECT_EQ(0, std::memcmp(host.trezor_masked_static_pubkey().data(),
+                           expected_masked.data(), NOISE_DHLEN));
+}
+
+// ---------------------------------------------------------------------------
+// Paired-device recognition: a session N+1 with a fresh ephemeral must
+// still match the unmasked-static stored from session N. Earlier we stored
+// the masked form, which rotates per session and so could never re-match:
+// the user was forced to re-pair every connect.
+// ---------------------------------------------------------------------------
+TEST(thp_handshake, paired_device_recognised_across_sessions)
+{
+  // Session 1: simulate a Trezor we've previously paired with.  Capture
+  // its (unmasked) static pubkey and the host_static keypair we used.
+  TrezorSide trezor;
+  noise_crypto::x25519_keypair(trezor.static_pub, trezor.static_priv);
+  trezor.device_properties = {0x0a, 0x04, 'T','S','7','x'};
+
+  HostStaticKey host_static;
+  noise_crypto::x25519_keypair(host_static.pub, host_static.priv);
+
+  // Session 2: brand new initiator.  We feed it a KnownDevice whose
+  // trezor_static_pubkey is the unmasked one from the (simulated)
+  // ThpCredentialResponse.  The Trezor side will generate a fresh
+  // ephemeral, so the *masked* form on the wire is different from what
+  // session 1 saw, but the lookup must still succeed because we store
+  // the unmasked pubkey and recompute the mask per session.
+  KnownDevice kd;
+  kd.trezor_static_pubkey   = trezor.static_pub;
+  kd.host_static            = host_static;
+  kd.pairing_credential     = {0xDE, 0xAD, 0xBE, 0xEF};
+
+  NoiseXxInitiator host;
+  host.set_device_properties(trezor.device_properties.data(),
+                             trezor.device_properties.size());
+  host.set_host_static_key(host_static);
+  host.set_known_devices({kd});
+
+  auto init_req = host.build_init_request(/*try_to_unlock=*/false);
+  trezor.handle_init_request(init_req);
+  host.consume_init_response(trezor.handshake_init_response.data(),
+                             trezor.handshake_init_response.size());
+
+  // The whole point of B2: the recompute-on-lookup must succeed even
+  // though the masked form on the wire is novel.
+  EXPECT_TRUE(host.is_known_device());
+}
+
+// ---------------------------------------------------------------------------
+// Same lookup MUST NOT match a non-paired device: an attacker cannot
+// trick the host into thinking a fresh device is "known" by guessing.
+// ---------------------------------------------------------------------------
+TEST(thp_handshake, paired_lookup_rejects_unrelated_device)
+{
+  TrezorSide trezor;
+  noise_crypto::x25519_keypair(trezor.static_pub, trezor.static_priv);
+  trezor.device_properties = {0x0a, 0x04, 'T','S','7','x'};
+
+  // Known-device list contains some OTHER device's static pubkey.
+  HostStaticKey host_static;
+  noise_crypto::x25519_keypair(host_static.pub, host_static.priv);
+  HostStaticKey other_host;
+  noise_crypto::x25519_keypair(other_host.pub, other_host.priv);
+  NoisePubKey other_static{}; NoisePrivKey other_priv{};
+  noise_crypto::x25519_keypair(other_static, other_priv);
+
+  KnownDevice kd;
+  kd.trezor_static_pubkey   = other_static;          // not `trezor.static_pub`
+  kd.host_static            = other_host;
+  kd.pairing_credential     = {0x01, 0x02, 0x03};
+
+  NoiseXxInitiator host;
+  host.set_device_properties(trezor.device_properties.data(),
+                             trezor.device_properties.size());
+  host.set_host_static_key(host_static);
+  host.set_known_devices({kd});
+
+  auto init_req = host.build_init_request(/*try_to_unlock=*/false);
+  trezor.handle_init_request(init_req);
+  host.consume_init_response(trezor.handshake_init_response.data(),
+                             trezor.handshake_init_response.size());
+
+  EXPECT_FALSE(host.is_known_device());
+}
+
+// ---------------------------------------------------------------------------
+// TransportCipher: round-trip seal / open with non-zero counters.
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Elligator2 (RFC 9380 sec. G.2.1) for Curve25519.
+//
+// Provenance of the two expected vectors below: they are the byte-for-byte
+// output of the reference Elligator2 map in trezor-firmware's
+// python/src/trezorlib/thp/curve25519.py (pinned commit
+// 236cb059dd9e3ac92694ee589ab4037761517d61) applied to the little-endian
+// 32-byte field elements 1 and 2.  Reproduce with:
+//
+//     from trezorlib.thp import curve25519
+//     curve25519.elligator2((1).to_bytes(32, "little")).hex()  # 9cdb5255...
+//     curve25519.elligator2((2).to_bytes(32, "little")).hex()  # b349328e...
+//
+// elligator2() internally runs decode_coordinate(), which clears the input's
+// high bit (`array[-1] &= 0x7F`, RFC 7748 sec. 5) before the map, so these two
+// vectors also pin our decode_coordinate behaviour; the dedicated high-bit
+// test below exercises that mask in isolation.
+// ---------------------------------------------------------------------------
+TEST(thp_elligator2, deterministic_known_inputs)
+{
+  // Input 0x01..0
+  uint8_t r1[32] = {0}; r1[0] = 1;
+  uint8_t out1[32];
+  elligator2_curve25519(r1, out1);
+  auto exp1 = from_hex("9cdb525555555555555555555555555555555555555555555555555555555555");
+  EXPECT_EQ(0, std::memcmp(out1, exp1.data(), 32));
+
+  // Input 0x02..0
+  uint8_t r2[32] = {0}; r2[0] = 2;
+  uint8_t out2[32];
+  elligator2_curve25519(r2, out2);
+  auto exp2 = from_hex("b349328ee3388ee3388ee3388ee3388ee3388ee3388ee3388ee3388ee3388e63");
+  EXPECT_EQ(0, std::memcmp(out2, exp2.data(), 32));
+
+  // Determinism: same input -> same output
+  uint8_t out1b[32];
+  elligator2_curve25519(r1, out1b);
+  EXPECT_EQ(0, std::memcmp(out1, out1b, 32));
+
+  // Distinct inputs -> distinct outputs
+  EXPECT_NE(0, std::memcmp(out1, out2, 32));
+}
+
+// Regression: per RFC 7748 sec. 5 / RFC 9380 sec. G.2.1, decode_coordinate must
+// clear the high bit of the input before reducing mod p. The Python
+// reference (trezorlib/thp/curve25519.py) does `array[-1] &= 0x7F`. If we
+// skip that mask, ~50% of pairings (whenever SHA-512's truncated high
+// bit is set) produce a different field element than the device, and
+// CPace tags mismatch even with the correct user code.
+TEST(thp_elligator2, decode_coordinate_masks_high_bit)
+{
+  uint8_t with_high_bit[32]    = {0}; with_high_bit[31]    = 0x81;
+  uint8_t without_high_bit[32] = {0}; without_high_bit[31] = 0x01;
+  uint8_t out_a[32], out_b[32];
+  elligator2_curve25519(with_high_bit,    out_a);
+  elligator2_curve25519(without_high_bit, out_b);
+  EXPECT_EQ(0, std::memcmp(out_a, out_b, 32))
+      << "elligator2 must mask the high bit of the input (RFC 7748 sec. 5)";
+
+  // Sanity: the mask actually changes nothing when the high bit was
+  // already clear: the same bytes produce the same output.
+  uint8_t out_c[32];
+  elligator2_curve25519(without_high_bit, out_c);
+  EXPECT_EQ(0, std::memcmp(out_b, out_c, 32));
+}
+
+// The CPace generator is the one construction that fails silently and
+// totally: a wrong domain-separation prefix, length byte, pad length or
+// hash input still produces a well-formed 32-byte generator, and pairing
+// then fails against every real device with no diagnostic pointing at the
+// cause.  Deterministic-and-input-bound is true of any hash-based
+// derivation, so the three expected values are what make this test able to
+// detect a wrong construction.
+//
+// They were computed from the IRTF CPACE-X25519-SHA512 symmetric-setting
+// definition the THP spec cites (specification.md, Notes, "Code Entry
+// pairing sequence"):
+//
+//   pregenerator = SHA-512(0x08 "CPace255" 0x06 || code ||
+//                          0x6f || 0x00 * 111 || 0x20 ||
+//                          handshake_hash || 0x00)[:32]
+//   generator    = ELLIGATOR2(pregenerator)
+//
+// by an independent implementation, itself first validated against the two
+// trezorlib-derived elligator2 vectors pinned above.
+TEST(thp_elligator2, cpace_generator_matches_spec_vectors)
+{
+  NoiseHash h{}; for (size_t i = 0; i < h.size(); ++i) h[i] = uint8_t(i);
+  uint8_t g1[32], g2[32], g3[32];
+  cpace_derive_generator("123456", h, g1);
+  cpace_derive_generator("123456", h, g2);
+  EXPECT_EQ(0, std::memcmp(g1, g2, 32)) << "deterministic";
+
+  cpace_derive_generator("654321", h, g3);
+  EXPECT_NE(0, std::memcmp(g1, g3, 32)) << "different code -> different generator";
+
+  NoiseHash h2{}; for (size_t i = 0; i < h2.size(); ++i) h2[i] = uint8_t(i + 1);
+  uint8_t g4[32];
+  cpace_derive_generator("123456", h2, g4);
+  EXPECT_NE(0, std::memcmp(g1, g4, 32)) << "different handshake hash -> different generator";
+
+  const auto exp_g1 = from_hex(
+      "4e1da1dfe958d2243b655fd45da026889142bcc3aa96c7eb58f10242cd8af52a");
+  const auto exp_g3 = from_hex(
+      "7db4d7908f3b1d7c1c721f1195ed6d61af4d4c99f2d6a6e4d86dd41dbfc7a056");
+  const auto exp_g4 = from_hex(
+      "190f471b762da11231b3099f82686e43afd146f64cd43c1a4b72da9d13ae353b");
+  EXPECT_EQ(0, std::memcmp(g1, exp_g1.data(), 32)) << "code 123456, h = 00..1f";
+  EXPECT_EQ(0, std::memcmp(g3, exp_g3.data(), 32)) << "code 654321, h = 00..1f";
+  EXPECT_EQ(0, std::memcmp(g4, exp_g4.data(), 32)) << "code 123456, h = 01..20";
+}
+
+// The prefix's trailing 0x06 is CPace's prepend_len(PRS) and the 111-byte
+// pad is 128 - (9 + (1 + 6) + 1): both are fixed for a six-digit code, so
+// any other length silently derives a different domain.  Firmware asserts
+// the same length; we throw rather than derive something unusable.
+TEST(thp_elligator2, cpace_generator_rejects_codes_that_are_not_six_digits)
+{
+  NoiseHash h{};
+  uint8_t g[32];
+  EXPECT_THROW(cpace_derive_generator("12345",   h, g),
+               hw::trezor::exc::ProtocolException);
+  EXPECT_THROW(cpace_derive_generator("1234567", h, g),
+               hw::trezor::exc::ProtocolException);
+  EXPECT_NO_THROW(cpace_derive_generator("123456", h, g));
+}
+
+// ---------------------------------------------------------------------------
+// CodeEntry pairing: drive the FSM as the host with a simulated Trezor.
+// The simulated Trezor exists only here; it follows specification.md's
+// state machine TP* literally.  As with the handshake self-test, this
+// pins the algorithm and would catch any deviation between the two
+// sides, but a bug present on both sides cannot be detected here.
+// ---------------------------------------------------------------------------
+namespace {
+
+struct SimulatedTrezor {
+  NoiseHash handshake_hash{};
+  uint8_t   secret[16] = {0};
+  uint8_t   commitment[32] = {0};
+  uint8_t   challenge[16] = {0};
+  uint32_t  code_int = 0;
+  std::string code_str;
+  uint8_t   cpace_priv[32] = {0};
+  uint8_t   cpace_pub[32]  = {0};
+  uint8_t   shared[32]     = {0};
+
+  void set_handshake_hash(const NoiseHash &h) { handshake_hash = h; }
+
+  // Trezor builds the commitment from secret = SHA-256(secret).
+  std::vector<uint8_t> step_select_method() {
+    // Pick a deterministic secret for testability.
+    for (int i = 0; i < 16; ++i) secret[i] = uint8_t(0xa0 + i);
+    NoiseHash c{};
+    noise_crypto::sha256(secret, 16, c);
+    std::memcpy(commitment, c.data(), sizeof(commitment));
+    return std::vector<uint8_t>(commitment, commitment + 32);
+  }
+
+  // After commitment + challenge, derive the code, then compute the
+  // CPace ephemeral keys for the device side.
+  std::vector<uint8_t> step_after_challenge(const uint8_t *host_challenge, size_t len) {
+    if (len != 16) throw std::runtime_error("bad challenge size");
+    std::memcpy(challenge, host_challenge, 16);
+    // code = SHA-256(0x02 || h || secret || challenge) % 1_000_000 (BE)
+    std::vector<uint8_t> in;
+    in.push_back(0x02);
+    in.insert(in.end(), handshake_hash.begin(), handshake_hash.end());
+    in.insert(in.end(), secret, secret + 16);
+    in.insert(in.end(), challenge, challenge + 16);
+    NoiseHash code_hash;
+    noise_crypto::sha256(in.data(), in.size(), code_hash);
+    // Big-endian reduce mod 1e6
+    uint64_t accum = 0;
+    for (uint8_t b : code_hash) accum = (accum * 256 + b) % 1000000ULL;
+    code_int = uint32_t(accum);
+    char buf[8];
+    std::snprintf(buf, sizeof(buf), "%06u", code_int);
+    code_str = buf;
+    // Derive cpace key pair
+    uint8_t generator[32];
+    cpace_derive_generator(code_str, handshake_hash, generator);
+    for (int i = 0; i < 32; ++i) cpace_priv[i] = uint8_t(i + 1);
+    NoisePrivKey priv{}; std::memcpy(priv.data(), cpace_priv, 32);
+    NoisePubKey gen{};   std::memcpy(gen.data(),  generator,  32);
+    NoisePubKey pub{};
+    noise_crypto::x25519(priv, gen, pub);
+    std::memcpy(cpace_pub, pub.data(), 32);
+    return std::vector<uint8_t>(cpace_pub, cpace_pub + 32);
+  }
+
+  // After the host sends back its CPace public key + tag, verify and
+  // (on success) hand back the secret.
+  std::vector<uint8_t> step_consume_host_tag(const uint8_t *host_pub, const uint8_t *tag) {
+    NoisePrivKey priv{}; std::memcpy(priv.data(), cpace_priv, 32);
+    NoisePubKey  hp{};   std::memcpy(hp.data(),   host_pub,  32);
+    NoisePubKey  s{};
+    noise_crypto::x25519(priv, hp, s);
+    std::memcpy(shared, s.data(), 32);
+    NoiseHash expected_tag;
+    noise_crypto::sha256(shared, 32, expected_tag);
+    if (std::memcmp(expected_tag.data(), tag, 32) != 0) {
+      throw std::runtime_error("simulated Trezor: tag mismatch");
+    }
+    return std::vector<uint8_t>(secret, secret + 16);
+  }
+};
+
+} // namespace
+
+TEST(thp_pairing, code_entry_full_self_test)
+{
+  // Pretend a handshake just completed.
+  NoiseHash h{};
+  for (size_t i = 0; i < h.size(); ++i) h[i] = uint8_t(0x10 + i);
+
+  SimulatedTrezor trezor;
+  trezor.set_handshake_hash(h);
+
+  CodeEntryPairing host(h);
+
+  // Trezor sends commitment.
+  auto cmt_raw = trezor.step_select_method();
+
+  // Host consumes commitment and draws the challenge the caller places in
+  // ThpCodeEntryChallenge; the device reads those 16 bytes.
+  host.consume_commitment_build_challenge(cmt_raw.data(), cmt_raw.size());
+
+  // Trezor computes the code + cpace pubkey.
+  auto cpace_t_pub_raw = trezor.step_after_challenge(host.challenge().data(),
+                                                     host.challenge().size());
+
+  // Host consumes Trezor's CPace public key.
+  host.consume_cpace_trezor(cpace_t_pub_raw.data(), cpace_t_pub_raw.size());
+
+  // The user sees Trezor's display, types the same code into the host.
+  // We give the host the exact code the simulator computed.
+  const CpaceHostTag host_tag = host.build_host_tag(trezor.code_str);
+
+  // Trezor verifies the tag and (on success) sends the secret.
+  auto secret_raw = trezor.step_consume_host_tag(
+      host_tag.cpace_host_public_key.data(), host_tag.tag.data());
+
+  // Host verifies commitment and code-secret-challenge equation.
+  EXPECT_TRUE(host.consume_secret(secret_raw.data(), secret_raw.size()));
+  EXPECT_TRUE(host.is_paired());
+}
+
+// Wrong-code fail-closed.
+//
+// Security outcome under test: when the user types the WRONG pairing
+// code, the host derives a CPace generator that differs from the
+// device's, so the host's CPace public key and SHA-256(shared_secret)
+// tag DO NOT match what the device computed.  The device-side CPace tag
+// check (step_consume_host_tag) MUST reject, failing closed, instead of
+// handing back the secret.  is_paired() must remain false.
+//
+// History: an earlier version of this test computed `host.build_host_tag
+// (wrong_code)` and then only asserted `EXPECT_FALSE(host.is_paired())`.
+// That was a TAUTOLOGY: is_paired() can only become true after a
+// successful consume_secret(), which the test never called, so the
+// assertion was trivially true regardless of whether the wrong code was
+// actually rejected by the CPace tag check.  It exercised no security
+// path.
+//
+// This rewrite drives the real comparison: it feeds the wrong-code
+// host_tag into the simulated device's tag verifier and asserts it
+// THROWS (tag mismatch -> abort), AND, as a cross-check that the
+// rejection is genuinely code-dependent and not a fluke of the harness,
+// confirms the CORRECT code on the same FSM state verifies cleanly,
+// pairs, and yields a secret.
+TEST(thp_pairing, code_entry_wrong_code_fails_closed)
+{
+  NoiseHash h{};
+  for (size_t i = 0; i < h.size(); ++i) h[i] = uint8_t(i);
+
+  // ---- Wrong-code path: device tag check must fail closed. ----
+  {
+    SimulatedTrezor trezor;
+    trezor.set_handshake_hash(h);
+    CodeEntryPairing host(h);
+
+    auto cmt = trezor.step_select_method();
+    host.consume_commitment_build_challenge(cmt.data(), cmt.size());
+    auto cpace_t_pub = trezor.step_after_challenge(host.challenge().data(),
+                                                   host.challenge().size());
+    host.consume_cpace_trezor(cpace_t_pub.data(), cpace_t_pub.size());
+
+    // User mistypes the code: flip the leading digit so the host's CPace
+    // generator (and hence shared secret and tag) diverges from the
+    // device's.
+    std::string wrong_code = trezor.code_str;
+    if (wrong_code[0] == '9') wrong_code[0] = '0'; else wrong_code[0]++;
+    ASSERT_NE(wrong_code, trezor.code_str);
+
+    const CpaceHostTag host_tag = host.build_host_tag(wrong_code);
+
+    // The security-relevant assertion: the device's CPace tag check
+    // detects the mismatch and aborts (throws); it does NOT release the
+    // secret.  This is the genuine fail-closed outcome, not a precondition.
+    EXPECT_THROW(trezor.step_consume_host_tag(host_tag.cpace_host_public_key.data(),
+                                              host_tag.tag.data()),
+                 std::exception);
+
+    // The host was never told it paired (no consume_secret reached).
+    EXPECT_FALSE(host.is_paired());
+  }
+
+  // ---- Correct-code cross-check: same flow, right code -> pairs. ----
+  // Proves the rejection above was caused by the wrong code, not by a
+  // broken harness that rejects everything.
+  {
+    SimulatedTrezor trezor;
+    trezor.set_handshake_hash(h);
+    CodeEntryPairing host(h);
+
+    auto cmt = trezor.step_select_method();
+    host.consume_commitment_build_challenge(cmt.data(), cmt.size());
+    auto cpace_t_pub = trezor.step_after_challenge(host.challenge().data(),
+                                                   host.challenge().size());
+    host.consume_cpace_trezor(cpace_t_pub.data(), cpace_t_pub.size());
+
+    const CpaceHostTag host_tag = host.build_host_tag(trezor.code_str);
+
+    std::vector<uint8_t> secret_raw;
+    ASSERT_NO_THROW(secret_raw = trezor.step_consume_host_tag(
+        host_tag.cpace_host_public_key.data(), host_tag.tag.data()));
+    EXPECT_TRUE(host.consume_secret(secret_raw.data(), secret_raw.size()));
+    EXPECT_TRUE(host.is_paired());
+  }
+}
+
+// The host half of the authentication: consume_secret is where the host
+// decides the device it just did CPace with is the one the user is looking
+// at.  Both of its rejection branches are exercised here; without them a
+// device that never knew the code, or one that returns a secret matching a
+// commitment it made up after seeing the challenge, would pair silently.
+TEST(thp_pairing, consume_secret_rejects_bad_commitment_and_wrong_code)
+{
+  NoiseHash h{};
+  for (size_t i = 0; i < h.size(); ++i) h[i] = uint8_t(0x40 + i);
+
+  // Branch (a): commitment != SHA-256(secret).  Correct code entered, but
+  // the secret handed back is not the one the commitment covered.
+  {
+    SimulatedTrezor trezor;
+    trezor.set_handshake_hash(h);
+    CodeEntryPairing host(h);
+
+    auto cmt = trezor.step_select_method();
+    host.consume_commitment_build_challenge(cmt.data(), cmt.size());
+    auto cpace_t_pub = trezor.step_after_challenge(host.challenge().data(),
+                                                   host.challenge().size());
+    host.consume_cpace_trezor(cpace_t_pub.data(), cpace_t_pub.size());
+    host.build_host_tag(trezor.code_str);
+
+    std::vector<uint8_t> tampered(trezor.secret, trezor.secret + 16);
+    tampered[0] ^= 0x01;
+    EXPECT_FALSE(host.consume_secret(tampered.data(), tampered.size()));
+    EXPECT_FALSE(host.is_paired());
+  }
+
+  // Branch (b): the secret is genuine, so the commitment check passes, but
+  // the code the user entered is not the one it derives.  A device that
+  // displayed a different code than the user typed must not pair.
+  {
+    SimulatedTrezor trezor;
+    trezor.set_handshake_hash(h);
+    CodeEntryPairing host(h);
+
+    auto cmt = trezor.step_select_method();
+    host.consume_commitment_build_challenge(cmt.data(), cmt.size());
+    auto cpace_t_pub = trezor.step_after_challenge(host.challenge().data(),
+                                                   host.challenge().size());
+    host.consume_cpace_trezor(cpace_t_pub.data(), cpace_t_pub.size());
+
+    std::string wrong_code = trezor.code_str;
+    if (wrong_code[5] == '9') wrong_code[5] = '0'; else wrong_code[5]++;
+    host.build_host_tag(wrong_code);
+
+    EXPECT_FALSE(host.consume_secret(trezor.secret, 16));
+    EXPECT_FALSE(host.is_paired());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Code zero-padding: the spec requires the entered code to be hashed as
+// exactly 6 ASCII digits, zero-padded on the left. The user types
+// "942" but the Trezor displayed "000942" and hashed those 6 bytes:
+// without padding the host computes a different CPace generator and the
+// device rejects the host_tag. This test runs the full happy path with
+// a code that genuinely needs padding (we brute-force a handshake_hash
+// that yields a leading-zero code, then have the user type the
+// leading-zero-stripped form).  This would silently fail before B3.
+// ---------------------------------------------------------------------------
+TEST(thp_pairing, code_entry_zero_padded_code_works)
+{
+  // Find a handshake_hash that produces a code with at least one
+  // leading zero (i.e. code_int < 100000). The simulator's code is
+  // derived from a SHA-256 over (0x02 || h || secret || challenge), so
+  // varying h is enough; every ~10 attempts will yield a leading zero.
+  NoiseHash h{};
+  SimulatedTrezor trezor;
+  std::vector<uint8_t> cmt_raw, cpace_t_pub_raw;
+  std::unique_ptr<CodeEntryPairing> host;
+
+  for (uint32_t seed = 0; seed < 256; ++seed) {
+    h = NoiseHash{};
+    for (size_t i = 0; i < h.size(); ++i) h[i] = uint8_t((seed * 7 + i) & 0xff);
+    trezor = SimulatedTrezor{};
+    trezor.set_handshake_hash(h);
+    host.reset(new CodeEntryPairing(h));
+    cmt_raw = trezor.step_select_method();
+    host->consume_commitment_build_challenge(cmt_raw.data(), cmt_raw.size());
+    cpace_t_pub_raw = trezor.step_after_challenge(host->challenge().data(),
+                                                  host->challenge().size());
+    if (trezor.code_int < 100000) break;
+  }
+  ASSERT_TRUE(host != nullptr);
+  ASSERT_LT(trezor.code_int, 100000u) << "failed to find a leading-zero code";
+
+  host->consume_cpace_trezor(cpace_t_pub_raw.data(), cpace_t_pub_raw.size());
+
+  // User types the code WITHOUT the leading zero(s). Host must pad to
+  // 6 digits internally before hashing.
+  std::string unpadded = std::to_string(trezor.code_int);
+  ASSERT_LT(unpadded.size(), 6u);
+
+  const CpaceHostTag host_tag = host->build_host_tag(unpadded);
+
+  // The Trezor (which hashed the 6-digit padded form) accepts the tag.
+  auto secret_raw = trezor.step_consume_host_tag(
+      host_tag.cpace_host_public_key.data(), host_tag.tag.data());
+  EXPECT_TRUE(host->consume_secret(secret_raw.data(), secret_raw.size()));
+  EXPECT_TRUE(host->is_paired());
+}
+
+// Reject obviously-malformed codes early instead of letting them flow
+// into the CPace derivation.
+//
+// The FSM is primed with a REAL device CPace public key.  An earlier
+// version primed it with an all-zero key, which crypto_scalarmult rejects
+// on its own, so every case threw whether or not build_host_tag validated
+// anything: it could not tell "rejected a bad code" from "choked on a
+// degenerate key".  The positive control at the end is what makes the
+// three rejections mean something.
+TEST(thp_pairing, code_entry_rejects_malformed_codes)
+{
+  NoiseHash h{};
+  for (size_t i = 0; i < h.size(); ++i) h[i] = uint8_t(0x90 + i);
+
+  SimulatedTrezor trezor;
+  trezor.set_handshake_hash(h);
+  CodeEntryPairing host(h);
+
+  auto cmt = trezor.step_select_method();
+  host.consume_commitment_build_challenge(cmt.data(), cmt.size());
+  auto cpace_t_pub = trezor.step_after_challenge(host.challenge().data(),
+                                                 host.challenge().size());
+  host.consume_cpace_trezor(cpace_t_pub.data(), cpace_t_pub.size());
+
+  // 7-digit code: too long.
+  EXPECT_THROW(host.build_host_tag("1234567"),
+               hw::trezor::exc::ProtocolException);
+  // Non-digits: reject.
+  EXPECT_THROW(host.build_host_tag("12a456"),
+               hw::trezor::exc::ProtocolException);
+  // Empty: reject.
+  EXPECT_THROW(host.build_host_tag(""),
+               hw::trezor::exc::ProtocolException);
+
+  // Positive control: a well-formed code on the same FSM state is accepted,
+  // so the three rejections above are decisions about the code and not a
+  // side effect of the state the FSM happens to be in.
+  EXPECT_NO_THROW(host.build_host_tag(trezor.code_str));
+}
+
+TEST(thp_transport_cipher, seal_open_round_trip)
+{
+  NoiseKey key{};
+  for (size_t i = 0; i < key.size(); ++i) key[i] = uint8_t(i);
+
+  TransportCipher tx(key, /*initial_nonce=*/0);
+  TransportCipher rx(key, /*initial_nonce=*/0);
+
+  for (int i = 0; i < 4; ++i) {
+    std::vector<uint8_t> pt(64, uint8_t(i + 1));
+    std::vector<uint8_t> ct;
+    tx.seal(nullptr, 0, pt.data(), pt.size(), ct);
+    EXPECT_EQ(pt.size() + NOISE_TAGLEN, ct.size());
+
+    std::vector<uint8_t> back;
+    ASSERT_TRUE(rx.open(nullptr, 0, ct.data(), ct.size(), back));
+    EXPECT_EQ(pt, back);
+  }
+  EXPECT_EQ(4u, tx.nonce());
+  EXPECT_EQ(4u, rx.nonce());
+}
+
+// ---------------------------------------------------------------------------
+// TransportCipher fail-closed nonce-exhaustion guard.
+//
+// The 96-bit AES-GCM IV is derived from a 64-bit counter; reusing a nonce
+// under the same key is catastrophic for AES-GCM.  When the counter has
+// reached UINT64_MAX the cipher MUST refuse rather than wrap:
+//   - seal() throws hw::trezor::exc::SecurityException.
+//   - open() returns false.
+// In both cases the counter must NOT advance (no wrap to 0), so a repeated
+// call behaves identically.  This is defence-in-depth, unreachable in
+// practice at 2^64-1 frames, but a wrap would silently reuse nonce 0.
+// ---------------------------------------------------------------------------
+TEST(thp_transport_cipher, nonce_exhaustion_seal_throws_and_does_not_wrap)
+{
+  NoiseKey key{};
+  for (size_t i = 0; i < key.size(); ++i) key[i] = uint8_t(0x11 * (i + 1));
+
+  TransportCipher tx(key, /*initial_nonce=*/UINT64_MAX);
+  ASSERT_EQ(UINT64_MAX, tx.nonce());
+
+  std::vector<uint8_t> pt(8, 0xAB);
+  std::vector<uint8_t> out;
+
+  // First seal at the exhausted counter must fail closed.
+  EXPECT_THROW(tx.seal(nullptr, 0, pt.data(), pt.size(), out),
+               hw::trezor::exc::SecurityException);
+  // Counter must not have advanced (no wrap to 0).
+  EXPECT_EQ(UINT64_MAX, tx.nonce());
+
+  // A second call still refuses identically: the guard is stable, not a
+  // one-shot.
+  EXPECT_THROW(tx.seal(nullptr, 0, pt.data(), pt.size(), out),
+               hw::trezor::exc::SecurityException);
+  EXPECT_EQ(UINT64_MAX, tx.nonce());
+}
+
+// The ciphertext here is GENUINELY VALID at nonce UINT64_MAX: it is
+// produced by encrypting under the same key with the IV the exhausted
+// counter would use.  That is what makes the test able to fail.  An
+// earlier version fed 24 bytes of 0xCD, which the AES-GCM tag check
+// rejects on its own, so both assertions held with the guard deleted and
+// the test asserted nothing about the guard at all.
+TEST(thp_transport_cipher, nonce_exhaustion_open_returns_false_and_does_not_wrap)
+{
+  NoiseKey key{};
+  for (size_t i = 0; i < key.size(); ++i) key[i] = uint8_t(0x11 * (i + 1));
+
+  const std::vector<uint8_t> pt(8, 0xAB);
+  noise_crypto::NoiseIv iv{};
+  noise_crypto::iv_for_nonce(UINT64_MAX, iv);
+  std::vector<uint8_t> ct;
+  ASSERT_TRUE(noise_crypto::aes256gcm_encrypt(key, iv, nullptr, 0,
+                                              pt.data(), pt.size(), ct));
+  ASSERT_EQ(pt.size() + NOISE_TAGLEN, ct.size());
+
+  TransportCipher rx(key, /*initial_nonce=*/UINT64_MAX);
+  ASSERT_EQ(UINT64_MAX, rx.nonce());
+
+  // Without the guard this ciphertext decrypts and open() returns true.
+  // With it, open() refuses (its failure convention is false, not a
+  // throw) and the counter does not advance.
+  std::vector<uint8_t> out;
+  EXPECT_FALSE(rx.open(nullptr, 0, ct.data(), ct.size(), out));
+  EXPECT_EQ(UINT64_MAX, rx.nonce());
+
+  // Repeated call behaves identically: no wrap to 0.
+  EXPECT_FALSE(rx.open(nullptr, 0, ct.data(), ct.size(), out));
+  EXPECT_EQ(UINT64_MAX, rx.nonce());
+}
+
+// Sticky failure: one AEAD failure permanently disables the cipherstate,
+// as the Noise spec and Trezor's own host require.  A peer that fails
+// authentication once does not get to keep streaming frames, so a channel
+// must not silently resume after one corrupt frame.
+TEST(thp_transport_cipher, open_failure_is_sticky)
+{
+  NoiseKey key{};
+  for (size_t i = 0; i < key.size(); ++i) key[i] = uint8_t(0x07 * (i + 1));
+
+  TransportCipher tx(key, /*initial_nonce=*/0);
+  TransportCipher rx(key, /*initial_nonce=*/0);
+
+  const std::vector<uint8_t> pt(16, 0x5A);
+  std::vector<uint8_t> ct;
+  tx.seal(nullptr, 0, pt.data(), pt.size(), ct);
+
+  // Corrupt the frame in flight: open() rejects it and latches.
+  std::vector<uint8_t> tampered = ct;
+  tampered[0] ^= 0x01;
+  std::vector<uint8_t> out;
+  EXPECT_FALSE(rx.open(nullptr, 0, tampered.data(), tampered.size(), out));
+
+  // The untampered frame at the same counter would otherwise open cleanly;
+  // after the latch it does not, and the counter has not advanced.
+  EXPECT_FALSE(rx.open(nullptr, 0, ct.data(), ct.size(), out));
+  EXPECT_EQ(0u, rx.nonce());
+}
+
+// ---------------------------------------------------------------------------
+// ThpStore round-trip.  Persist a host static keypair plus two KnownDevice
+// records (with non-trivial pairing-credential bytes) to a temp file, read
+// it back into a fresh store, and assert every field
+// survives byte-for-byte.  Uses a unique temp path (never the user's real
+// ~/.trezor/thp_store.bin) and removes it afterward.
+// ---------------------------------------------------------------------------
+namespace {
+
+// Small RAII helper: a unique temp path that is removed on scope exit.
+struct ScopedTempPath {
+  boost::filesystem::path p;
+  ScopedTempPath()
+    : p(boost::filesystem::temp_directory_path() /
+        boost::filesystem::unique_path("monero_thp_store_%%%%-%%%%.bin")) {}
+  ~ScopedTempPath() {
+    boost::system::error_code ec;
+    boost::filesystem::remove(p, ec);  // best-effort cleanup
+  }
+  std::string str() const { return p.string(); }
+};
+
+} // namespace
+
+TEST(thp_store, round_trip_preserves_all_fields)
+{
+  ScopedTempPath tmp;
+
+  // Host static keypair with distinctive, non-trivial bytes.
+  HostStaticKey host;
+  for (size_t i = 0; i < host.pub.size(); ++i)  host.pub[i]  = uint8_t(0x10 + i);
+  for (size_t i = 0; i < host.priv.size(); ++i) host.priv[i] = uint8_t(0xA0 + i);
+
+  // Device 1: distinct static pubkey, per-device host keypair and a
+  // non-trivial pairing credential.
+  KnownDevice kd1;
+  for (size_t i = 0; i < kd1.trezor_static_pubkey.size(); ++i)
+    kd1.trezor_static_pubkey[i] = uint8_t(0x01 + i);
+  for (size_t i = 0; i < kd1.host_static.pub.size(); ++i)
+    kd1.host_static.pub[i] = uint8_t(0x21 + i);
+  for (size_t i = 0; i < kd1.host_static.priv.size(); ++i)
+    kd1.host_static.priv[i] = uint8_t(0x41 + i);
+  kd1.pairing_credential = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x7F, 0x80, 0xFF};
+
+  // Device 2: different values throughout, including a longer credential
+  // blob, to exercise variable-length records.
+  KnownDevice kd2;
+  for (size_t i = 0; i < kd2.trezor_static_pubkey.size(); ++i)
+    kd2.trezor_static_pubkey[i] = uint8_t(0xF0 - i);
+  for (size_t i = 0; i < kd2.host_static.pub.size(); ++i)
+    kd2.host_static.pub[i] = uint8_t(0x5A ^ i);
+  for (size_t i = 0; i < kd2.host_static.priv.size(); ++i)
+    kd2.host_static.priv[i] = uint8_t(0xC3 ^ i);
+  kd2.pairing_credential.assign(64, 0);
+  for (size_t i = 0; i < kd2.pairing_credential.size(); ++i)
+    kd2.pairing_credential[i] = uint8_t((i * 37 + 11) & 0xFF);
+
+  // Write via a real ThpStore.  load_or_init on a non-existent path yields
+  // an empty store; we then set the host key and upsert the devices, save.
+  {
+    ThpStore store;
+    store.load_or_init(tmp.str());
+    store.set_host_static(host);
+    store.upsert_known_device(kd1);
+    store.upsert_known_device(kd2);
+    store.save(tmp.str());
+  }
+  ASSERT_TRUE(boost::filesystem::exists(tmp.p));
+
+  // Read back into a fresh store.
+  ThpStore loaded;
+  loaded.load_or_init(tmp.str());
+
+  // Host static key survives byte-for-byte.
+  EXPECT_EQ(0, std::memcmp(loaded.host_static().pub.data(),
+                           host.pub.data(), host.pub.size()));
+  EXPECT_EQ(0, std::memcmp(loaded.host_static().priv.data(),
+                           host.priv.data(), host.priv.size()));
+
+  // Both device records survive, in insertion order.
+  ASSERT_EQ(2u, loaded.known_devices().size());
+  const KnownDevice &g1 = loaded.known_devices()[0];
+  const KnownDevice &g2 = loaded.known_devices()[1];
+
+  EXPECT_EQ(0, std::memcmp(g1.trezor_static_pubkey.data(),
+                           kd1.trezor_static_pubkey.data(),
+                           kd1.trezor_static_pubkey.size()));
+  EXPECT_EQ(0, std::memcmp(g1.host_static.pub.data(),
+                           kd1.host_static.pub.data(),
+                           kd1.host_static.pub.size()));
+  EXPECT_EQ(0, std::memcmp(g1.host_static.priv.data(),
+                           kd1.host_static.priv.data(),
+                           kd1.host_static.priv.size()));
+  EXPECT_EQ(kd1.pairing_credential, g1.pairing_credential);
+
+  EXPECT_EQ(0, std::memcmp(g2.trezor_static_pubkey.data(),
+                           kd2.trezor_static_pubkey.data(),
+                           kd2.trezor_static_pubkey.size()));
+  EXPECT_EQ(0, std::memcmp(g2.host_static.pub.data(),
+                           kd2.host_static.pub.data(),
+                           kd2.host_static.pub.size()));
+  EXPECT_EQ(0, std::memcmp(g2.host_static.priv.data(),
+                           kd2.host_static.priv.data(),
+                           kd2.host_static.priv.size()));
+  EXPECT_EQ(kd2.pairing_credential, g2.pairing_credential);
+}
+
+// ---------------------------------------------------------------------------
+// ThpStore malformed-input handling.
+//
+// Contract (store.cpp): the deserialiser throws hw::trezor::exc::
+// EncodingException on bad magic / truncated / overflowing input, and the
+// public load_or_init() catches that, logs a warning, and re-initialises to
+// an EMPTY store (so a corrupt file forces a clean re-pair rather than
+// bricking wallet-open or crashing).  Every case below must therefore:
+//   - NOT crash / NOT UB, and
+//   - leave the store in a clean empty state (no host static, no devices).
+// We exercise the failure surface through the public API.
+//
+// Helper: write raw bytes to a path, then load and assert the store ended
+// up empty (graceful rejection).
+namespace {
+
+void write_raw_file(const std::string &path, const std::vector<uint8_t> &bytes)
+{
+  std::ofstream f(path, std::ios::binary | std::ios::trunc);
+  ASSERT_TRUE(f.good());
+  if (!bytes.empty())
+    f.write(reinterpret_cast<const char *>(bytes.data()),
+            static_cast<std::streamsize>(bytes.size()));
+  f.flush();
+  ASSERT_TRUE(f.good());
+}
+
+void expect_empty_store_after_load(const std::string &path)
+{
+  ThpStore store;
+  // Must not throw / crash on malformed input: it discards and re-inits.
+  ASSERT_NO_THROW(store.load_or_init(path));
+  // No partial-corrupt state: no devices, and the host static key is the
+  // default all-zero value (i.e. it was reset, not partially populated).
+  EXPECT_TRUE(store.known_devices().empty());
+  HostStaticKey zero{};
+  EXPECT_EQ(0, std::memcmp(store.host_static().pub.data(),
+                           zero.pub.data(), zero.pub.size()));
+  EXPECT_EQ(0, std::memcmp(store.host_static().priv.data(),
+                           zero.priv.data(), zero.priv.size()));
+}
+
+// The valid 8-byte magic header that prefixes every well-formed store file.
+const std::vector<uint8_t> kStoreMagic =
+    {'M','T','H','P','S','T','R','2'};
+
+} // namespace
+
+// (a) Truncated file: valid magic + a record header whose declared length
+//     runs past the end of the buffer.  Must be rejected gracefully.
+TEST(thp_store, malformed_truncated_record_body_rejected)
+{
+  ScopedTempPath tmp;
+  std::vector<uint8_t> bytes = kStoreMagic;
+  bytes.push_back(0x01);  // TAG_HOST_STATIC_PUB
+  bytes.push_back(0x20);  // varint length = 32
+  // ...but only supply 4 of the promised 32 bytes -> body cut off.
+  bytes.insert(bytes.end(), {0xAA, 0xBB, 0xCC, 0xDD});
+  write_raw_file(tmp.str(), bytes);
+
+  expect_empty_store_after_load(tmp.str());
+}
+
+// (b) Bogus/oversized length varint that would over-read far past the
+//     buffer.  The deserialiser must bound-check and reject, not over-read.
+TEST(thp_store, malformed_oversized_length_varint_rejected)
+{
+  ScopedTempPath tmp;
+  std::vector<uint8_t> bytes = kStoreMagic;
+  bytes.push_back(0x01);  // TAG_HOST_STATIC_PUB
+  // Multi-byte varint encoding an enormous length (~0xFFFFFFF) that vastly
+  // exceeds the remaining buffer -> off + len > buf.size().
+  bytes.insert(bytes.end(), {0xFF, 0xFF, 0xFF, 0x7F});
+  bytes.insert(bytes.end(), {0x00, 0x01, 0x02});  // a few real bytes
+  write_raw_file(tmp.str(), bytes);
+
+  expect_empty_store_after_load(tmp.str());
+}
+
+// (c) Wrong / absent magic byte: a non-empty file that does not begin with
+//     the MTHPSTR2 magic.  Rejected gracefully.
+TEST(thp_store, malformed_wrong_magic_rejected)
+{
+  ScopedTempPath tmp;
+  // Eight bytes that are the wrong magic, plus some trailing bytes.
+  std::vector<uint8_t> bytes =
+      {'M','T','H','P','S','T','R','1',  // legacy/wrong magic
+       0x01, 0x20, 0x00, 0x00};
+  write_raw_file(tmp.str(), bytes);
+
+  expect_empty_store_after_load(tmp.str());
+}
+
+// (d) Empty file: present on disk but zero bytes -> shorter than the magic
+//     header, so it fails the magic check and is rejected gracefully.
+TEST(thp_store, malformed_empty_file_rejected)
+{
+  ScopedTempPath tmp;
+  write_raw_file(tmp.str(), std::vector<uint8_t>{});
+  ASSERT_TRUE(boost::filesystem::exists(tmp.p));
+
+  expect_empty_store_after_load(tmp.str());
+}
+
+// A 10-byte varint encoding 2^64-1.  read_varint accepts it (the shift cap
+// is 63 and the final byte contributes bit 63), so the *value* check in the
+// deserialiser is the only line of defence.
+const std::vector<uint8_t> kVarintU64Max =
+    {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01};
+
+// (e) Length varint near 2^64: `off + len` wraps modulo 2^64 to a small
+//     value, so a naive `off + len > buf.size()` truncation check passes
+//     and the KNOWN_DEVICE inner loop reads attacker-chosen lengths past
+//     the end of the buffer (heap over-read).  The bound must be computed
+//     subtraction-side (`len > buf.size() - off`) to be wrap-safe.
+TEST(thp_store, malformed_varint_wraparound_known_device_rejected)
+{
+  ScopedTempPath tmp;
+  std::vector<uint8_t> bytes = kStoreMagic;
+  bytes.push_back(0x03);  // TAG_KNOWN_DEVICE
+  bytes.insert(bytes.end(), kVarintU64Max.begin(), kVarintU64Max.end());
+  bytes.insert(bytes.end(), {0x01, 0x20, 0xAA});  // a few inner-record bytes
+  write_raw_file(tmp.str(), bytes);
+
+  expect_empty_store_after_load(tmp.str());
+}
+
+// (f) Same wraparound under an unknown (skipped) tag: the skip path
+//     `off += len` would wrap `off` backwards and re-parse the same bytes
+//     forever, a hang the load_or_init catch cannot recover from.
+TEST(thp_store, malformed_varint_wraparound_unknown_tag_rejected)
+{
+  ScopedTempPath tmp;
+  std::vector<uint8_t> bytes = kStoreMagic;
+  bytes.push_back(0x7E);  // unknown tag -> forward-compat skip path
+  bytes.insert(bytes.end(), kVarintU64Max.begin(), kVarintU64Max.end());
+  write_raw_file(tmp.str(), bytes);
+
+  expect_empty_store_after_load(tmp.str());
+}
+
+// The three guards below live inside a KNOWN_DEVICE record, where the
+// spill/wrap arithmetic is subtlest and where a random buffer reaches them
+// only by luck.  Each case is built so that exactly one guard is the reason
+// the record is rejected.
+//
+// (g) An inner varint whose continuation bytes run past the end of the
+//     whole buffer.  read_varint bounds against the buffer, so this is the
+//     "truncated inner varint" branch.
+TEST(thp_store, malformed_inner_varint_truncated_rejected)
+{
+  ScopedTempPath tmp;
+  std::vector<uint8_t> bytes = kStoreMagic;
+  bytes.push_back(0x03);  // TAG_KNOWN_DEVICE
+  bytes.push_back(0x02);  // outer length = 2, which is all that remains
+  bytes.push_back(0x02);  // KD_TAG_PAIRING_CREDENTIAL
+  bytes.push_back(0x80);  // varint continues, but the buffer ends here
+  write_raw_file(tmp.str(), bytes);
+
+  expect_empty_store_after_load(tmp.str());
+}
+
+// (h) An inner varint that is complete, but only because it reads bytes
+//     belonging to whatever follows the KNOWN_DEVICE record.  read_varint
+//     cannot see the inner boundary, so the deserialiser checks it
+//     afterwards ("inner varint past record").  Without that check a
+//     hostile store steers the inner cursor using bytes outside its own
+//     record.
+TEST(thp_store, malformed_inner_varint_spilling_past_record_rejected)
+{
+  ScopedTempPath tmp;
+  std::vector<uint8_t> bytes = kStoreMagic;
+  bytes.push_back(0x03);  // TAG_KNOWN_DEVICE
+  bytes.push_back(0x02);  // outer length = 2
+  bytes.push_back(0x02);  // KD_TAG_PAIRING_CREDENTIAL
+  bytes.push_back(0x80);  // last byte of the record, varint incomplete
+  bytes.push_back(0x01);  // outside the record: completes the varint
+  write_raw_file(tmp.str(), bytes);
+
+  expect_empty_store_after_load(tmp.str());
+}
+
+// (i) A well-formed inner varint declaring more bytes than the record has
+//     left.  The bound has to be computed subtraction-side
+//     (ilen > len - inner_off); the addition form wraps and admits a heap
+//     over-read.
+TEST(thp_store, malformed_inner_record_overflow_rejected)
+{
+  ScopedTempPath tmp;
+  std::vector<uint8_t> bytes = kStoreMagic;
+  bytes.push_back(0x03);              // TAG_KNOWN_DEVICE
+  bytes.push_back(0x05);              // outer length = 5
+  bytes.push_back(0x02);              // KD_TAG_PAIRING_CREDENTIAL
+  bytes.push_back(0x20);              // inner length = 32, but 3 bytes left
+  bytes.insert(bytes.end(), {0xAA, 0xBB, 0xCC});
+  write_raw_file(tmp.str(), bytes);
+
+  expect_empty_store_after_load(tmp.str());
+}
+
+// (j) Structure-aware fuzz battery.  The hand-written cases above pin the
+//     known structural edges (truncation, oversized & wrap-around varints,
+//     bad/legacy magic, the three inner-record guards).  This sprays a
+//     deterministic spread of random tag/length/body permutations at the
+//     public load path to cover the space between them.
+//
+//     Contract under test: load_or_init() must NEVER throw, hang, crash, or
+//     leave UB behind, for ANY input.  We do NOT assert the store ends empty
+//     (a random buffer can coincidentally encode a valid record, which the
+//     parser is allowed to load), only that loading and then touching the
+//     loaded state is always safe.  Fixed PRNG seed => any failure is
+//     bit-for-bit reproducible from the reported iteration.
+TEST(thp_store, malformed_fuzz_battery_rejected)
+{
+  // splitmix64: tiny, deterministic, well-distributed, enough to spray the
+  // parser without pulling in <random> machinery.
+  uint64_t state = 0x0123456789abcdefULL;
+  auto next = [&state]() -> uint64_t {
+    uint64_t z = (state += 0x9e3779b97f4a7c15ULL);
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    z = (z ^ (z >> 27)) * 0x94d049bb133111ebULL;
+    return z ^ (z >> 31);
+  };
+  auto byte = [&next]() -> uint8_t { return uint8_t(next() & 0xFF); };
+
+  ScopedTempPath tmp;
+  for (int iter = 0; iter < 512; ++iter) {
+    std::vector<uint8_t> bytes;
+    const int    mode = int(next() % 4);
+    const size_t len  = size_t(next() % 64);
+
+    switch (mode) {
+      case 0:  // pure random bytes (usually fails the magic check)
+        for (size_t i = 0; i < len; ++i) bytes.push_back(byte());
+        break;
+      case 1:  // valid magic + random tail
+        bytes = kStoreMagic;
+        for (size_t i = 0; i < len; ++i) bytes.push_back(byte());
+        break;
+      case 2: {  // magic + a few random (tag, multi-byte varint, body) records
+        bytes = kStoreMagic;
+        const int records = int(next() % 4);
+        for (int r = 0; r < records; ++r) {
+          bytes.push_back(byte());                    // random tag
+          const int vlen = 1 + int(next() % 6);       // 1..6 varint bytes
+          for (int v = 0; v < vlen; ++v)              // continuation bit on all but last
+            bytes.push_back(uint8_t((byte() & 0x7F) | (v + 1 < vlen ? 0x80 : 0x00)));
+          const size_t body = size_t(next() % 40);
+          for (size_t b = 0; b < body; ++b) bytes.push_back(byte());
+        }
+        break;
+      }
+      default: {  // a plausible record truncated at a random offset
+        bytes = kStoreMagic;
+        bytes.push_back(uint8_t(next() % 6));          // a low tag value
+        bytes.push_back(0x20);                          // claims a 32-byte body
+        const size_t supplied = size_t(next() % 33);    // 0..32 actually provided
+        for (size_t b = 0; b < supplied; ++b) bytes.push_back(byte());
+        break;
+      }
+    }
+
+    write_raw_file(tmp.str(), bytes);
+
+    ThpStore store;
+    ASSERT_NO_THROW(store.load_or_init(tmp.str()))
+        << "load_or_init threw on iter=" << iter << " mode=" << mode
+        << " (" << bytes.size() << " bytes)";
+    // Touch whatever loaded: a parser bug that produced an oversized or
+    // malformed device entry would surface as UB / a throw here.
+    ASSERT_NO_THROW({
+      for (const auto &kd : store.known_devices()) {
+        (void)kd.trezor_static_pubkey.size();
+        (void)kd.pairing_credential.size();
+      }
+      (void)store.host_static().pub[0];
+    }) << "touching loaded state threw on iter=" << iter << " mode=" << mode;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ThpStore concurrent-writer semantics.  The store is per-user and shared
+// by every wallet process (CLI and GUI may run at once), so save() folds in
+// devices that another process persisted after we loaded instead of
+// overwriting the whole file with our snapshot.
+// ---------------------------------------------------------------------------
+namespace {
+
+KnownDevice make_known_device(uint8_t seed)
+{
+  KnownDevice kd;
+  for (size_t i = 0; i < kd.trezor_static_pubkey.size(); ++i)
+    kd.trezor_static_pubkey[i] = uint8_t(seed + i);
+  for (size_t i = 0; i < kd.host_static.pub.size(); ++i)
+    kd.host_static.pub[i] = uint8_t(seed ^ (0x30 + i));
+  for (size_t i = 0; i < kd.host_static.priv.size(); ++i)
+    kd.host_static.priv[i] = uint8_t(seed ^ (0x60 + i));
+  kd.pairing_credential = {seed, uint8_t(seed + 1), uint8_t(seed + 2)};
+  return kd;
+}
+
+bool store_has_device(const ThpStore &store, const KnownDevice &kd)
+{
+  for (const auto &got : store.known_devices()) {
+    if (std::memcmp(got.trezor_static_pubkey.data(),
+                    kd.trezor_static_pubkey.data(),
+                    kd.trezor_static_pubkey.size()) == 0)
+      return true;
+  }
+  return false;
+}
+
+} // namespace
+
+// Two stores load the same (initially missing) file, each pairs a different
+// device, and both save.  The second save must preserve the first writer's
+// device instead of clobbering it; losing it would silently force a
+// re-pair the next time that device is used.
+TEST(thp_store, save_merges_devices_from_concurrent_writer)
+{
+  ScopedTempPath tmp;
+  HostStaticKey host;
+  for (size_t i = 0; i < host.pub.size(); ++i)  host.pub[i]  = uint8_t(0x10 + i);
+  for (size_t i = 0; i < host.priv.size(); ++i) host.priv[i] = uint8_t(0xA0 + i);
+
+  const KnownDevice device_x = make_known_device(0x01);
+  const KnownDevice device_y = make_known_device(0x80);
+
+  ThpStore a, b;
+  a.load_or_init(tmp.str());  // both load while the file is absent
+  b.load_or_init(tmp.str());
+  a.set_host_static(host);
+  b.set_host_static(host);
+  a.upsert_known_device(device_x);
+  b.upsert_known_device(device_y);
+
+  a.save(tmp.str());
+  b.save(tmp.str());  // unaware of device_x; must fold it in, not drop it
+
+  ThpStore loaded;
+  loaded.load_or_init(tmp.str());
+  ASSERT_EQ(2u, loaded.known_devices().size());
+  EXPECT_TRUE(store_has_device(loaded, device_x));
+  EXPECT_TRUE(store_has_device(loaded, device_y));
+}
+
+// When both the disk file and the saving store know the SAME device, the
+// in-memory entry wins: we may have just re-paired it, so our credential is
+// the fresher one.
+TEST(thp_store, save_conflicting_device_in_memory_entry_wins)
+{
+  ScopedTempPath tmp;
+  HostStaticKey host;
+  for (size_t i = 0; i < host.pub.size(); ++i)  host.pub[i]  = uint8_t(0x10 + i);
+  for (size_t i = 0; i < host.priv.size(); ++i) host.priv[i] = uint8_t(0xA0 + i);
+
+  KnownDevice stale = make_known_device(0x01);
+  KnownDevice fresh = stale;
+  fresh.pairing_credential = {0xCA, 0xFE, 0xBA, 0xBE};
+
+  {
+    ThpStore first;
+    first.load_or_init(tmp.str());
+    first.set_host_static(host);
+    first.upsert_known_device(stale);
+    first.save(tmp.str());
+  }
+  {
+    ThpStore second;
+    second.load_or_init(tmp.str());  // sees the stale credential
+    second.upsert_known_device(fresh);
+    second.save(tmp.str());
+  }
+
+  ThpStore loaded;
+  loaded.load_or_init(tmp.str());
+  ASSERT_EQ(1u, loaded.known_devices().size());
+  EXPECT_EQ(fresh.pairing_credential,
+            loaded.known_devices()[0].pairing_credential);
+}
+
+// ---------------------------------------------------------------------------
+// Scripted transport, and the protocol layers driven through it.
+//
+// A trezor-core protocol-v1 device (Model T / Safe 3 / Safe 5) answers the
+// THP broadcast probe with a codec_v1-framed Failure report ('?','#','#',
+// msg_type, ...).  The allocation reader must recognise that as a legacy
+// device rather than abort the connection, because the alternative breaks
+// every v1 device on every connect.
+// ---------------------------------------------------------------------------
+namespace {
+
+// Minimal scripted Transport: write_chunk records what the host emitted;
+// the timed read_chunk serves the scripted frames in order, then times out.
+// Scripts are generators so a response can be built from what the host has
+// written by then (the allocation nonce and every handshake body are
+// generated per call and cannot be baked into a fixture).
+//
+// A generator returns one whole encoded frame, which encode_frame has
+// already padded to a whole number of chunks.  read_chunk hands out one
+// chunk per call and parks the remainder, exactly as the 64-byte USB
+// carrier delivers it: a HandshakeInitiationResponse carries 96 payload
+// bytes and so spans two chunks, and serving only its first chunk would
+// silently drop the second and pull the *following* generator in
+// mid-frame, one response short for the rest of the script.
+struct ScriptedTransport : public hw::trezor::Transport {
+  std::vector<std::function<std::vector<uint8_t>()>> reads;
+  size_t next_read = 0;
+  std::vector<uint8_t> pending_read;   // frame handed out chunk by chunk
+  size_t pending_read_off = 0;
+  std::vector<uint8_t> last_written;
+  std::vector<std::vector<uint8_t>> written_chunks;
+  size_t next_unread_chunk = 0;
+
+  void write(const google::protobuf::Message &) override {}
+  void read(std::shared_ptr<google::protobuf::Message> &,
+            hw::trezor::messages::MessageType *) override {}
+
+  void write_chunk(const void *buff, size_t size) override {
+    const uint8_t *p = static_cast<const uint8_t *>(buff);
+    last_written.assign(p, p + size);
+    written_chunks.push_back(last_written);
+  }
+  size_t read_chunk(void *buff, size_t size, unsigned int /*timeout_ms*/) override {
+    if (pending_read_off >= pending_read.size()) {
+      if (next_read >= reads.size())
+        throw hw::trezor::exc::TimeoutException();
+      pending_read = reads[next_read++]();
+      pending_read_off = 0;
+    }
+    const size_t n = std::min(size, pending_read.size() - pending_read_off);
+    std::memcpy(buff, pending_read.data() + pending_read_off, n);
+    pending_read_off += n;
+    return n;
+  }
+
+  // Reassemble the next frame the host wrote, in write order.  A script
+  // that consumes exactly the frames it expects therefore also pins the
+  // order in which the host writes them.
+  Frame take_written_frame() {
+    FrameAssembler asm_;
+    while (next_unread_chunk < written_chunks.size()) {
+      const auto &c = written_chunks[next_unread_chunk++];
+      if (asm_.feed_chunk(c.data(), c.size())) return asm_.take();
+    }
+    throw std::runtime_error("ScriptedTransport: no complete frame written");
+  }
+
+  // Control byte of every initiation chunk written so far, in order.
+  std::vector<uint8_t> written_control_bytes() const {
+    std::vector<uint8_t> out;
+    for (const auto &c : written_chunks) {
+      if (!c.empty() && (c[0] & CTRL_CONTINUATION_BIT) == 0)
+        out.push_back(c[0]);
+    }
+    return out;
+  }
+};
+
+// A 64-byte codec_v1 report as a trezor-core v1 device sends it: magic
+// '?','#','#', then big-endian msg_type 3 (Failure) and length.
+std::vector<uint8_t> v1_codec_failure_report()
+{
+  std::vector<uint8_t> chunk(64, 0);
+  chunk[0] = '?'; chunk[1] = '#'; chunk[2] = '#';
+  chunk[4] = 0x03;  // msg_type = Failure
+  chunk[8] = 0x02;  // payload length
+  return chunk;
+}
+
+// A chunk that parses as a THP initiation packet but fails the CRC check.
+std::vector<uint8_t> corrupt_thp_frame()
+{
+  const uint8_t payload[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+  auto wire = encode_frame(CTRL_CHANNEL_ALLOC_RESPONSE, CID_BROADCAST,
+                           payload, sizeof(payload));
+  wire[5] ^= 0x01;  // corrupt the first payload byte
+  return wire;
+}
+
+// Queue the ChannelAllocationResponse a THP device sends for the broadcast
+// probe: the host's own 8-byte nonce echoed back, the granted CID, and the
+// device properties the handshake later mixes in as its Noise prologue.
+void script_allocation(ScriptedTransport &transport, uint16_t cid,
+                       const std::vector<uint8_t> &device_properties)
+{
+  ScriptedTransport *t = &transport;
+  const std::vector<uint8_t> props = device_properties;
+  transport.reads.push_back([t, cid, props] {
+    const Frame req = t->take_written_frame();
+    std::vector<uint8_t> payload(req.payload.begin(), req.payload.begin() + 8);
+    payload.push_back(uint8_t(cid >> 8));
+    payload.push_back(uint8_t(cid & 0xFF));
+    payload.insert(payload.end(), props.begin(), props.end());
+    return encode_frame(CTRL_CHANNEL_ALLOC_RESPONSE, CID_BROADCAST,
+                        payload.data(), payload.size());
+  });
+}
+
+// Queue the four reads a THP device produces for one full Noise XX
+// handshake on `cid`: ACK of the initiation request, the initiation
+// response, ACK of the completion request, and the completion response.
+// `dev` plays the device side and must outlive the transport.
+void script_handshake(ScriptedTransport &transport, TrezorSide &device,
+                      uint16_t cid)
+{
+  ScriptedTransport *t = &transport;
+  TrezorSide        *d = &device;
+
+  transport.reads.push_back([t, d, cid] {
+    const Frame req = t->take_written_frame();
+    d->handle_init_request(req.payload);
+    return encode_frame(CTRL_ACK_SEQ0, cid, nullptr, 0);
+  });
+  transport.reads.push_back([d, cid] {
+    return encode_frame(CTRL_HANDSHAKE_INIT_RESP, cid,
+                        d->handshake_init_response.data(),
+                        d->handshake_init_response.size());
+  });
+  transport.reads.push_back([t, d, cid] {
+    (void)t->take_written_frame();               // host ACK of the response
+    const Frame comp = t->take_written_frame();  // HandshakeCompletionRequest
+    d->handle_completion_request(comp.payload);
+    return encode_frame(CTRL_ACK_SEQ1, cid, nullptr, 0);
+  });
+  transport.reads.push_back([d, cid] {
+    // Device sequence bit is 1 on the completion response (wire 0x13).
+    return encode_frame(CTRL_HANDSHAKE_COMP_RESP | CTRL_DATA_SEQ_BIT, cid,
+                        d->handshake_completion_response.data(),
+                        d->handshake_completion_response.size());
+  });
+}
+
+} // namespace
+
+// The codec_v1 magic is proof of a legacy device, so it short-circuits the
+// probe instead of costing the caller the full allocation budget.  A valid
+// allocation response is queued directly behind the v1 report: only a
+// short-circuit stops the reader consuming it and reporting `allocated`,
+// so this distinguishes "recognised the v1 magic" from "gave up".
+TEST(thp_channel, codec_v1_reply_short_circuits_allocation)
+{
+  ScriptedTransport t;
+  t.reads.push_back([] { return v1_codec_failure_report(); });
+  script_allocation(t, 0x1234, {});
+
+  AllocatedChannel ch;
+  EXPECT_EQ(AllocationResult::codec_v1_reply,
+            allocate_channel(t, ch, /*timeout_ms=*/50));
+  EXPECT_EQ(1u, t.next_read) << "the reader must stop at the codec_v1 magic";
+  EXPECT_EQ(0, ch.channel_id) << "no allocation may be reported";
+}
+
+// Legacy firmware that ignores the unknown packet outright.
+TEST(thp_channel, silent_device_reports_no_response)
+{
+  ScriptedTransport t;  // no scripted reads: every read times out
+
+  AllocatedChannel ch;
+  EXPECT_EQ(AllocationResult::no_response,
+            allocate_channel(t, ch, /*timeout_ms=*/50));
+  EXPECT_EQ(0, ch.channel_id);
+}
+
+TEST(thp_channel, allocation_resyncs_after_unparseable_chunk)
+{
+  ScriptedTransport t;
+  // First read: a THP-shaped chunk with a broken CRC, which the assembler
+  // rejects.  The probe must discard it, reset the assembler and keep
+  // waiting; the second read is a well-formed allocation response echoing
+  // the nonce from the request and granting channel 0x1234.
+  t.reads.push_back([] { return corrupt_thp_frame(); });
+  script_allocation(t, 0x1234, {0x0a, 0x04, 'T', 'S', '7', 'x'});
+
+  AllocatedChannel got;
+  ASSERT_EQ(AllocationResult::allocated,
+            allocate_channel(t, got, /*timeout_ms=*/50));
+  EXPECT_EQ(0x1234, got.channel_id);
+  ASSERT_EQ(8u, got.nonce.size());
+  EXPECT_EQ(0, std::memcmp(got.nonce.data(), t.written_chunks[0].data() + 5, 8));
+  EXPECT_EQ(std::vector<uint8_t>({0x0a, 0x04, 'T', 'S', '7', 'x'}),
+            got.device_properties_pb);
+}
+
+// ---------------------------------------------------------------------------
+// ProtocolV2, driven end to end against the simulated device.
+//
+// The framing tests above prove control bytes can be encoded; this proves
+// ProtocolV2 emits the right ones in the right order.  The expected
+// sequence is the whole alternating-bit protocol written out: the
+// handshake's four host frames, then two request/response exchanges whose
+// sequence bits must toggle on both directions independently.  Anything
+// that wedges the sequencing (the 0x08-vs-0x10 bug this file already
+// carries a constant-level guard for, an ACK that is not sent, a counter
+// that does not toggle) changes this list.
+//
+// It also pins the two things that are invisible from the framing layer:
+// the 3-byte encrypted-transport plaintext header, and the cipherstate
+// nonces (send starts at 0, receive at 1, because the completion response
+// already consumed response nonce 0).  Both are asserted by the device
+// side actually decrypting what the host sent and the host actually
+// decrypting what the device sealed.
+// ---------------------------------------------------------------------------
+TEST(thp_protocol_v2, write_read_control_byte_sequence_matches_spec)
+{
+  constexpr uint16_t kCid = 0x1234;
+
+  TrezorSide dev;
+  noise_crypto::x25519_keypair(dev.static_pub, dev.static_priv);
+  dev.device_properties = {0x0a, 0x04, 'T', 'S', '7', 'x'};
+
+  ScriptedTransport t;
+  script_handshake(t, dev, kCid);
+
+  // The device's cipherstates mirror the host's; they can only be built
+  // once the handshake has produced the keys, so the first application
+  // read constructs them.
+  std::unique_ptr<TransportCipher> dev_recv, dev_send;
+  std::vector<std::vector<uint8_t>> device_saw;
+  uint16_t success_wire = 0;
+
+  // A device response carrying an empty common.Success on session 0.
+  auto seal_success = [&](uint8_t control) {
+    hw::trezor::messages::common::Success ok;
+    success_wire = static_cast<uint16_t>(
+        hw::trezor::MessageMapper::get_message_wire_number(ok));
+    std::vector<uint8_t> plain(3);
+    plain[0] = 0x00;
+    write_be16(plain.data() + 1, success_wire);
+    std::vector<uint8_t> sealed;
+    dev_send->seal(nullptr, 0, plain.data(), plain.size(), sealed);
+    return encode_frame(control, kCid, sealed.data(), sealed.size());
+  };
+
+  // Exchange 1: host request (seq 0) -> ACK, then device response (seq 0).
+  t.reads.push_back([&] {
+    (void)t.take_written_frame();  // host ACK of the completion response
+    const Frame req = t.take_written_frame();
+    EXPECT_EQ(CTRL_ENCRYPTED_TRANSPORT, req.control_byte);
+    dev_recv.reset(new TransportCipher(dev.keys.key_request,  /*nonce=*/0));
+    dev_send.reset(new TransportCipher(dev.keys.key_response, /*nonce=*/1));
+    std::vector<uint8_t> plain;
+    EXPECT_TRUE(dev_recv->open(nullptr, 0, req.payload.data(),
+                               req.payload.size(), plain));
+    device_saw.push_back(plain);
+    return encode_frame(CTRL_ACK_SEQ0, kCid, nullptr, 0);
+  });
+  t.reads.push_back([&] { return seal_success(CTRL_ENCRYPTED_TRANSPORT); });
+
+  // Exchange 2: the sequence bit must have toggled on both directions.
+  t.reads.push_back([&] {
+    (void)t.take_written_frame();  // host ACK of the first response
+    const Frame req = t.take_written_frame();
+    EXPECT_EQ(CTRL_ENCRYPTED_TRANSPORT | CTRL_DATA_SEQ_BIT, req.control_byte);
+    std::vector<uint8_t> plain;
+    EXPECT_TRUE(dev_recv->open(nullptr, 0, req.payload.data(),
+                               req.payload.size(), plain));
+    device_saw.push_back(plain);
+    return encode_frame(CTRL_ACK_SEQ1, kCid, nullptr, 0);
+  });
+  t.reads.push_back([&] {
+    return seal_success(CTRL_ENCRYPTED_TRANSPORT | CTRL_DATA_SEQ_BIT);
+  });
+
+  AllocatedChannel alloc;
+  alloc.channel_id = kCid;
+  alloc.nonce.assign(8, 0);
+  alloc.device_properties_pb = dev.device_properties;
+
+  ProtocolV2 v2;
+  v2.adopt_allocation(alloc);
+  ASSERT_NO_THROW(v2.session_begin(t));
+  EXPECT_EQ(kCid, v2.channel_id());
+
+  for (int i = 0; i < 2; ++i) {
+    SCOPED_TRACE(i);
+    hw::trezor::messages::management::Initialize req;
+    ASSERT_NO_THROW(v2.write(t, req));
+
+    std::shared_ptr<google::protobuf::Message> resp;
+    hw::trezor::messages::MessageType mt{};
+    ASSERT_NO_THROW(v2.read(t, resp, &mt));
+    ASSERT_TRUE(resp != nullptr);
+    EXPECT_EQ(success_wire, static_cast<uint16_t>(mt));
+  }
+
+  // The control bytes the host put on the wire, in order:
+  //   0x00 HandshakeInitiationRequest      (data, seq 0)
+  //   0x20 ACK seq 0                       (of the initiation response)
+  //   0x12 HandshakeCompletionRequest      (data, seq 1 at bit 0x10)
+  //   0x28 ACK seq 1                       (of the completion response)
+  //   0x04 encrypted transport, seq 0      (first request)
+  //   0x20 ACK seq 0                       (of the first response)
+  //   0x14 encrypted transport, seq 1      (second request)
+  //   0x28 ACK seq 1                       (of the second response)
+  const std::vector<uint8_t> expected = {
+    CTRL_HANDSHAKE_INIT_REQ,
+    CTRL_ACK_SEQ0,
+    CTRL_HANDSHAKE_COMP_REQ | CTRL_DATA_SEQ_BIT,
+    CTRL_ACK_SEQ1,
+    CTRL_ENCRYPTED_TRANSPORT,
+    CTRL_ACK_SEQ0,
+    CTRL_ENCRYPTED_TRANSPORT | CTRL_DATA_SEQ_BIT,
+    CTRL_ACK_SEQ1,
+  };
+  EXPECT_EQ(expected, t.written_control_bytes());
+
+  // Both requests decrypted on the device side, which is only possible if
+  // the host's send counter started at 0 and advanced by exactly one per
+  // frame.  Their plaintext is the 3-byte header and nothing else: a
+  // management::Initialize is translated to an empty GetFeatures, because
+  // THP devices reject Initialize as Failure_UnexpectedMessage.
+  ASSERT_EQ(2u, device_saw.size());
+  for (const auto &plain : device_saw) {
+    ASSERT_EQ(3u, plain.size());
+    EXPECT_EQ(0x00, plain[0]) << "session id byte";
+    EXPECT_EQ(static_cast<uint16_t>(hw::trezor::messages::MessageType_GetFeatures),
+              read_be16(plain.data() + 1));
+  }
+
+  // Every scripted device response was consumed exactly once: the host
+  // neither skipped an exchange nor read one response short (the latter
+  // would leave a later script entry running against a frame the host has
+  // not written yet).
+  EXPECT_EQ(t.reads.size(), t.next_read);
+}
+
+// ---------------------------------------------------------------------------
+// ProtocolAutoDetect: the v1-vs-v2 decision, and the two states in which
+// bring-up must fail closed rather than continue on an unauthenticated
+// channel.
+// ---------------------------------------------------------------------------
+TEST(thp_auto_detect, silent_device_selects_protocol_v1)
+{
+  ScriptedTransport t;  // legacy firmware ignores the allocation request
+
+  ProtocolAutoDetect ad;
+  ad.configure(ProtocolConfig{});
+  ASSERT_NO_THROW(ad.session_begin(t));
+  EXPECT_STREQ("v1", ad.selected_protocol());
+}
+
+TEST(thp_auto_detect, codec_v1_reply_selects_protocol_v1)
+{
+  ScriptedTransport t;
+  t.reads.push_back([] { return v1_codec_failure_report(); });
+
+  ProtocolAutoDetect ad;
+  ad.configure(ProtocolConfig{});
+  ASSERT_NO_THROW(ad.session_begin(t));
+  EXPECT_STREQ("v1", ad.selected_protocol());
+}
+
+// The control bytes a fail-closed bring-up puts on the wire and no more:
+// the broadcast allocation request, the four handshake frames, and then
+// nothing.  Both refusal tests below assert this, because it is what
+// separates "reached the state check and refused" from "died earlier" and
+// from "refused only after talking on the channel it would not vouch for".
+std::vector<uint8_t> refused_handshake_control_bytes()
+{
+  return {
+    CTRL_CHANNEL_ALLOC_REQUEST,
+    CTRL_HANDSHAKE_INIT_REQ,
+    CTRL_ACK_SEQ0,
+    CTRL_HANDSHAKE_COMP_REQ | CTRL_DATA_SEQ_BIT,
+    CTRL_ACK_SEQ1,
+  };
+}
+
+// TOFU anti-spoof: a device that claims an existing pairing must be one we
+// hold a credential for.  With no store configured there are no known
+// devices, so STATE_PAIRED is unsupported by anything on this host and the
+// bring-up must refuse instead of continuing on a channel whose peer it
+// cannot place.
+TEST(thp_auto_detect, paired_device_not_in_known_devices_is_refused)
+{
+  constexpr uint16_t kCid = 0x2222;
+
+  TrezorSide dev;
+  noise_crypto::x25519_keypair(dev.static_pub, dev.static_priv);
+  dev.device_properties = {0x0a, 0x04, 'T', 'S', '7', 'x'};
+  dev.state = STATE_PAIRED;
+
+  ScriptedTransport t;
+  script_allocation(t, kCid, dev.device_properties);
+  script_handshake(t, dev, kCid);
+
+  ProtocolAutoDetect ad;
+  ad.configure(ProtocolConfig{});
+  try {
+    ad.session_begin(t);
+    ADD_FAILURE() << "STATE_PAIRED with an empty known-devices list must be refused";
+  } catch (const hw::trezor::exc::SecurityException &e) {
+    // The v2 stack raises SecurityException from one other place (a failed
+    // AES-GCM open in ProtocolV2::read), so match the refusal itself
+    // rather than just its type.
+    EXPECT_NE(std::string::npos, std::string(e.what()).find("not in our known-devices"))
+        << "refused for the wrong reason: " << e.what();
+  } catch (const std::exception &e) {
+    ADD_FAILURE() << "expected a SecurityException, got: " << e.what();
+  }
+
+  // The whole handshake ran (all five scripted responses consumed) and the
+  // refusal came out of the post-handshake state check, before a single
+  // encrypted-transport frame was written.
+  EXPECT_EQ(t.reads.size(), t.next_read);
+  EXPECT_EQ(refused_handshake_control_bytes(), t.written_control_bytes());
+  EXPECT_STREQ("unknown", ad.selected_protocol())
+      << "a refused device must not be recorded as selected";
+}
+
+// STATE_UNPAIRED needs the CodeEntry pairing FSM, which needs the user.
+// Without a prompt there is no way to authenticate the channel, so the
+// bring-up must refuse rather than proceed unpaired.
+TEST(thp_auto_detect, unpaired_device_without_pairing_prompt_is_refused)
+{
+  constexpr uint16_t kCid = 0x3333;
+
+  TrezorSide dev;
+  noise_crypto::x25519_keypair(dev.static_pub, dev.static_priv);
+  dev.device_properties = {0x0a, 0x04, 'T', 'S', '7', 'x'};
+  dev.state = STATE_UNPAIRED;
+
+  ScriptedTransport t;
+  script_allocation(t, kCid, dev.device_properties);
+  script_handshake(t, dev, kCid);
+
+  ProtocolConfig cfg;
+  cfg.pairing_prompt = nullptr;  // no UI wired up
+
+  ProtocolAutoDetect ad;
+  ad.configure(cfg);
+  try {
+    ad.session_begin(t);
+    ADD_FAILURE() << "STATE_UNPAIRED with no pairing prompt must be refused";
+  } catch (const hw::trezor::exc::SecurityException &e) {
+    EXPECT_NE(std::string::npos, std::string(e.what()).find("no pairing prompt is configured"))
+        << "refused for the wrong reason: " << e.what();
+  } catch (const std::exception &e) {
+    ADD_FAILURE() << "expected a SecurityException, got: " << e.what();
+  }
+
+  // As above: the refusal must land after a complete handshake and before
+  // ThpPairingRequest, which is the first thing the pairing FSM would put
+  // on the wire if the guard were removed.
+  EXPECT_EQ(t.reads.size(), t.next_read);
+  EXPECT_EQ(refused_handshake_control_bytes(), t.written_control_bytes());
+  EXPECT_STREQ("unknown", ad.selected_protocol());
+}
+
+} // namespace
+
+#endif // DEVICE_TREZOR_READY

--- a/tests/unit_tests/trezor_exceptions.cpp
+++ b/tests/unit_tests/trezor_exceptions.cpp
@@ -1,0 +1,193 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Unit tests for the categorization of hw::trezor::exc exceptions.  The
+// wallet API carries the result to its frontends as
+// Monero::Wallet::TrezorError, which decides whether a failed device
+// open offers a retry, re-prompts for a pairing code, or reports a hard
+// error, so both the mapping and the integer values are a contract.
+
+#include "gtest/gtest.h"
+
+#include <stdexcept>
+
+#include "device_trezor/trezor/exceptions.hpp"
+
+namespace exc = hw::trezor::exc;
+using exc::error_kind;
+
+// ---------------------------------------------------------------------
+// Communication failures: the device is off, unplugged, held by another
+// process, or stopped answering.  All retryable.
+// ---------------------------------------------------------------------
+
+TEST(TrezorExceptions, not_connected_is_unreachable) {
+  EXPECT_EQ(exc::classify(exc::NotConnectedException()), error_kind::unreachable);
+}
+
+TEST(TrezorExceptions, acquire_failure_is_unreachable) {
+  EXPECT_EQ(exc::classify(exc::DeviceAcquireException()), error_kind::unreachable);
+}
+
+TEST(TrezorExceptions, unresponsive_device_is_unreachable) {
+  EXPECT_EQ(exc::classify(exc::DeviceNotResponsiveException()), error_kind::unreachable);
+  EXPECT_EQ(exc::classify(exc::TimeoutException()), error_kind::unreachable);
+}
+
+TEST(TrezorExceptions, expired_session_is_unreachable) {
+  EXPECT_EQ(exc::classify(exc::SessionException()), error_kind::unreachable);
+}
+
+TEST(TrezorExceptions, bare_communication_failure_is_unreachable) {
+  EXPECT_EQ(exc::classify(exc::CommunicationException()), error_kind::unreachable);
+}
+
+// ---------------------------------------------------------------------
+// User cancellation.  CancelledException derives from FailureException,
+// which derives from ProtocolException, so the classification has to
+// match it before either base.
+// ---------------------------------------------------------------------
+
+TEST(TrezorExceptions, on_device_cancel_is_cancelled) {
+  EXPECT_EQ(exc::classify(exc::proto::CancelledException()), error_kind::cancelled);
+}
+
+TEST(TrezorExceptions, cancel_carrying_a_failure_code_is_cancelled) {
+  // The shape thrown by throw_failure_exception for Failure_ActionCancelled.
+  const boost::optional<uint32_t> code(4);
+  const boost::optional<std::string> message(std::string("Cancelled"));
+  EXPECT_EQ(exc::classify(exc::proto::CancelledException(code, message)),
+            error_kind::cancelled);
+}
+
+// ---------------------------------------------------------------------
+// Pairing.  A rejected code is restated as PairingFailedException by
+// device_trezor_base, which is the only layer that knows a CodeEntry
+// exchange was in flight.
+// ---------------------------------------------------------------------
+
+TEST(TrezorExceptions, rejected_pairing_code_is_pairing_rejected) {
+  EXPECT_EQ(exc::classify(exc::proto::PairingFailedException()), error_kind::pairing_rejected);
+}
+
+TEST(TrezorExceptions, pairing_rejection_wins_over_its_failure_base) {
+  const exc::proto::FailureException &as_failure = exc::proto::PairingFailedException();
+  EXPECT_EQ(exc::classify(as_failure), error_kind::pairing_rejected);
+}
+
+// ---------------------------------------------------------------------
+// Firmware without Monero support.  Thrown by require_initialized() once
+// the Features message is in, which on a first pairing is after the user
+// has already typed a code, so it needs its own non-retryable category.
+// ---------------------------------------------------------------------
+
+TEST(TrezorExceptions, missing_monero_capability_is_firmware_unsupported) {
+  EXPECT_EQ(exc::classify(exc::FirmwareNotSupportedException()),
+            error_kind::firmware_unsupported);
+}
+
+// ---------------------------------------------------------------------
+// Protocol faults: framing, encoding, and the authentication checks of
+// the transport.  A retry does not help, so the frontend reports them.
+// ---------------------------------------------------------------------
+
+TEST(TrezorExceptions, protocol_fault_is_protocol) {
+  EXPECT_EQ(exc::classify(exc::ProtocolException("THP frame length exceeds 16-bit field")),
+            error_kind::protocol);
+}
+
+TEST(TrezorExceptions, encoding_fault_is_protocol) {
+  EXPECT_EQ(exc::classify(exc::EncodingException()), error_kind::protocol);
+}
+
+TEST(TrezorExceptions, protocol_security_assertion_is_protocol) {
+  EXPECT_EQ(exc::classify(exc::proto::SecurityException()), error_kind::protocol);
+}
+
+TEST(TrezorExceptions, transport_security_failure_is_protocol) {
+  // SecurityException sits outside the TrezorException hierarchy.
+  EXPECT_EQ(exc::classify(exc::SecurityException()), error_kind::protocol);
+  EXPECT_EQ(exc::classify(exc::Poly1305TagInvalid()), error_kind::protocol);
+}
+
+TEST(TrezorExceptions, unexpected_message_is_protocol) {
+  // Raised by the client when a response does not match the request,
+  // even though it derives from FailureException.
+  EXPECT_EQ(exc::classify(exc::proto::UnexpectedMessageException()), error_kind::protocol);
+}
+
+// ---------------------------------------------------------------------
+// Everything the device itself refused for a reason of its own.
+// ---------------------------------------------------------------------
+
+TEST(TrezorExceptions, device_reported_failure_is_other) {
+  EXPECT_EQ(exc::classify(exc::proto::FailureException()), error_kind::other);
+  EXPECT_EQ(exc::classify(exc::proto::InvalidPinException()), error_kind::other);
+  EXPECT_EQ(exc::classify(exc::proto::NotInitializedException()), error_kind::other);
+  EXPECT_EQ(exc::classify(exc::proto::FirmwareErrorException()), error_kind::other);
+}
+
+TEST(TrezorExceptions, bare_device_exception_is_other) {
+  EXPECT_EQ(exc::classify(exc::TrezorException("Device is in the bootloader mode")),
+            error_kind::other);
+}
+
+// ---------------------------------------------------------------------
+// Anything that is not a device failure at all, such as the wallet
+// error raised when a password does not match.
+// ---------------------------------------------------------------------
+
+TEST(TrezorExceptions, unrelated_exception_is_none) {
+  EXPECT_EQ(exc::classify(std::runtime_error("invalid password")), error_kind::none);
+}
+
+// ---------------------------------------------------------------------
+// Log level and integer surface.
+// ---------------------------------------------------------------------
+
+TEST(TrezorExceptions, expected_failures_are_the_ones_the_user_answers) {
+  EXPECT_TRUE(exc::is_expected_failure(error_kind::unreachable));
+  EXPECT_TRUE(exc::is_expected_failure(error_kind::cancelled));
+  EXPECT_TRUE(exc::is_expected_failure(error_kind::pairing_rejected));
+  EXPECT_TRUE(exc::is_expected_failure(error_kind::firmware_unsupported));
+  EXPECT_FALSE(exc::is_expected_failure(error_kind::protocol));
+  EXPECT_FALSE(exc::is_expected_failure(error_kind::other));
+  EXPECT_FALSE(exc::is_expected_failure(error_kind::none));
+}
+
+TEST(TrezorExceptions, enum_values_are_stable_across_the_api_boundary) {
+  // Monero::Wallet::TrezorError mirrors these, and the GUI compares the
+  // integers, so values may be appended but never reordered.
+  EXPECT_EQ(static_cast<int>(error_kind::none), 0);
+  EXPECT_EQ(static_cast<int>(error_kind::unreachable), 1);
+  EXPECT_EQ(static_cast<int>(error_kind::cancelled), 2);
+  EXPECT_EQ(static_cast<int>(error_kind::protocol), 3);
+  EXPECT_EQ(static_cast<int>(error_kind::other), 4);
+  EXPECT_EQ(static_cast<int>(error_kind::firmware_unsupported), 5);
+  EXPECT_EQ(static_cast<int>(error_kind::pairing_rejected), 6);
+}


### PR DESCRIPTION

## What this does

This adds support for the Trezor Host Protocol v2 (THP) to `src/device_trezor`, which is what
the **Trezor Safe 7** requires. Without it, Monero cannot talk to a Safe 7 at all.

Everything already supported keeps working unchanged. Devices that speak the existing v1 wire
protocol (Model T, Safe 3, Safe 5) continue to use it; nothing about their code path changes.

## Why this is needed, and why the failure is confusing today

The Safe 7 enumerates over USB with the **same VID/PID as the Model T** (`0x1209:0x53C1`) — every
`ModelClass.CORE` device shares it. So the device is detected, looks supported, and then fails
part way through, which is a worse first experience than not being detected at all.

**Detection has to be a protocol probe rather than a device-ID lookup, and the reason is not that
the descriptors are identical.** They are not: a Safe 7 reports `iManufacturer` "Trezor Company"
and `iProduct` "Trezor Safe 7" where a Model T reports "SatoshiLabs" and "TREZOR". The reason is
that **THP is a firmware build flag, not a model property** — `features.append('thp')` in
`core/SConscript.firmware`. Whether a given device in front of you speaks THP is a property of the
firmware it is running, so a table keyed on model would be wrong the first time Trezor ships THP
to another device or a build without it. Asking the device is the only answer that stays correct.

## How it works

THP replaces v1's plaintext framing with an encrypted, authenticated channel:

- **Framing** — chunked packets with a CRC32 over each frame.
- **Channel** — a `Noise_XX_25519_AESGCM_SHA256` handshake, giving mutual authentication and a
  forward-secure transport cipher.
- **Pairing** — CPace `CodeEntry`: the device shows a six-digit code, the host asks the user for
  it, and both sides derive the same key only if the code matches. The device issues a long-lived
  **pairing credential** on success.
- **Credential store** — the host static key and the issued credentials are persisted so that
  pairing happens once per device, not once per connection.

Protocol selection is a probe on connect: if the device answers with the v1 magic bytes it is a v1
device and the v1 path is used immediately; otherwise the THP handshake proceeds.

## Compatibility and behaviour changes for existing users

I want to be explicit about this rather than bury it, because some of it is visible to people who
are not buying a Safe 7:

- **Existing v1 devices:** no protocol change. The probe short-circuits the moment the device
  answers with the v1 magic bytes `'?' '#' '#'` — only a v1 device can produce those — so a
  legacy device is identified in about a millisecond rather than waiting out a THP timeout.
  **I have not timed that on hardware yet**, so read it as reasoning about the code path rather
  than a measurement. I will post a Model T connect time on this branch against one on upstream
  master as soon as I have it. An earlier revision of this branch did cost legacy devices several
  seconds per connect, which is exactly why I am not asserting the number.
- **The connect-candidate loop** is touched: `connect()` now walks the enumerated transports
  instead of taking the first match, because a Safe 7 needs the direct-USB carrier that
  enumeration lists after Bridge. Enumeration **order** is deliberately unchanged — Bridge still
  comes first, so Monero does not start taking the USB interface away from Trezor Suite for people
  who have never touched a Safe 7.
- **New on-disk state:** the credential store, holding the host static private key and one
  credential per paired device. Location, format and permissions are documented in
  `src/device_trezor/trezor/thp/README.md`. It is deliberately **per user and per network**: on
  Windows that means `CSIDL_APPDATA` rather than the `CSIDL_COMMON_APPDATA` that
  `tools::get_default_data_dir()` resolves to, since every local account on a machine shares the
  latter and host private keys should not be shared between them. A testnet wallet likewise gets
  its own store rather than reaching into mainnet's.

## A known limitation I have not fixed

**A first-time Safe 7 pairing can fail if a Trezor bridge is running, instead of falling back to
direct USB.** I would rather state this than have someone find it.

`trezord-go` cannot carry THP and never will: it re-frames rather than pipes (`wire/v1.go` builds
the `'?' '#' '#'` header itself and discards any packet without it), it contains no THP code, its
last release was 2023-04-19, and it has an open issue titled "Archive the repo". Trezor Suite has
moved to a separate bridge on a different port.

Because Bridge is tried first and a Safe 7 shares the Model T's VID/PID, a user with a bridge
running can have it acquire the device and then fail at `GetFeatures`, rather than Monero moving
on to WebUSB, which would have worked.

The clean fix is the one Trezor's own client uses: a THP-only device answers a v1 message with a
fixed `Failure` carrying `Failure_InvalidProtocol`, and
`packages/connect/src/device/workflow/handshake.ts` keys its fall-through on exactly that. **I did
not implement it here, for three reasons I would rather put in front of you than work around:**
the first v1 exchange happens well after `connect()` has returned, so it is not reachable from the
transport-selection loop without adding a new probe exchange per candidate; `FailureException`'s
code member is private with no accessor; and `Failure_InvalidProtocol` **does not exist in the
vendored proto** — `FailureType` stops at `Failure_InvalidSession = 14` and jumps to
`Failure_FirmwareError = 99`, so the pin predates it. Doing it properly means either a proto
resync, which pulls in unrelated semantic changes to the other Trezor protos and wants its own
hardware validation, or hardcoding `17`.

I would rather take direction on which of those you prefer than pick one unilaterally inside a PR
this size. In the meantime the workaround is to quit the bridge, or plug in with Suite closed for
the first pairing only.

## Why C++ from the specification rather than Trezor's Rust crate

I know this is the first question, so I want to answer it before anything else.

I read the record before starting. selsta on `monero-gui#4517` (2026-07-19): "*A rust
implementation might work depending on the amount of dependencies*". jeffro256 in Tech Meeting
#167: "*I would prefer less to spend a crap ton of time reinventing the wheel*". rbrunner7 in the
same meeting: "*Complicated == high potential for bugs*". Those are all reasonable, and I am not
going to pretend the discussion did not happen or that it went my way.

**The first thing to say is that there is no THP crate to depend on.** Checked again the day I
opened this: `trezor-thp` returns *"crate `trezor-thp` does not exist"* from the crates.io API. It
exists only as a path crate inside the `trezor-firmware` monorepo at `rust/trezor-thp`, first
committed 2025-11-26, with protocol fixes still landing at the end of July 2026. mmilata offered on
#10368 in June to "*publish it as a crate if it helps*", and that has not happened.

Trezor **do** publish `trezor-client` from the same `rust/` directory — 0.1.6, updated 2026-07-14 —
so I want to be explicit that I have not overlooked it. It is the **v1** client: its dependencies
are `protobuf`, `byteorder`, `rusb`, `hex`, `thiserror` and `tracing`, it does not depend on
`trezor-thp`, and it implements none of this. It cannot talk to a Safe 7 either.

So the Rust route is not "add a dependency and be done". It is: vendor an unpublished,
in-development subdirectory of a monorepo; write the C ABI that upstream does not currently
expose; and then write substantially the same integration layer you see here against it — against
an interface nobody has committed to keeping stable. `rust/trezor-thp/Cargo.toml` also declares
`edition = "2024"`, so adopting it sets a Rust MSRV of 1.85 for the whole tree.

**On the dependency count, since it came up: jpk68's "11, to be exact" is right about the crate
itself, and I will concede it — 3 direct (`log`, `heapless`, `trezor-noise-protocol`), 12
transitive.** But that is the crate with its crypto in `[dev-dependencies]`. A host that can
actually complete a handshake needs `trezor-noise-rust-crypto` and `getrandom` on top, which
resolves to **42 crates**, and then protobuf and a transport on top of that. That is the number
worth comparing against.

**And one thing I would genuinely like an answer to rather than assert:** `rust/trezor-thp` ships
**no licence file and no `license` field in its `Cargo.toml`**, while its sibling `trezor-client`
in the same directory sets `license = "CC0-1.0"` explicitly. `trezor-firmware`'s `LICENSE.md` says
"all other files — GPLv3", which would be the default reading, but I do not think a missing field
next to a deliberately-set one is something to guess at. If the licence is GPL-3.0, adopting it
into a BSD-3 project is a question that needs settling before any of the engineering matters. I may
be reading it wrong, and would rather be corrected than build on a bad assumption.

**On Rust in the tree — I am not going to argue the toolchain is a problem, because it is not.**
`.github/workflows/depends.yml` has installed rustup since `ef509e1c0` (2025-02-06) and every one
of the ten cross targets carries a `rust_host`. `src/fcmp_pp/fcmp_pp_rust/` is reserved and wired
in with `add_subdirectory`, `fcmp++.h` is a C-ABI FFI header, and the top-level
`CMakeLists.txt:72` carries a commented-out `RUSTC_WRAPPER` waiting on FCMP++. Guix gained Rust in
#9801 on 2026-07-31. **The direction of travel is not in doubt and the toolchain is ready.**

The only accurate remaining statement is narrower: nothing in the tree is *compiled* with Rust
yet — `fcmp_pp_rust/CMakeLists.txt` is a licence header with no commands, and there is no
`Cargo.toml` anywhere. That is a fact about timing, not an argument, and I am not going to lean on
it.

**So my case does not rest on Rust being impractical. It rests on three things:**

**One — it exists, it is tested, and it works today.** That is the whole of the first argument. A
Safe 7 currently does not work with Monero at all, and this is the only implementation anyone has
written. Nobody else has started.

**Two — it adds no dependencies.** Not "few": zero new third-party dependencies. It uses
libsodium and protobuf, both of which `src/device_trezor` already links, plus Boost and OpenSSL,
which the tree already depends on. The only build change is adding OpenSSL to `device_trezor`'s
private link line. There are no new platform imports either — the credential store goes through
the same `epee::file_io_utils` helpers and `tools::replace_file` the wallet already uses, on every
platform.

To be precise about what I have actually built rather than what I expect: I have compiled and run
the tests on **x86_64 Linux only**. `USE_DEVICE_TREZOR_MANDATORY: ON` is set at the top of both
`build.yml` and `depends.yml`, so a compile failure on any of the ten `depends` targets turns the
run red rather than silently dropping Trezor support — but that is CI's word to give, not mine,
and I would treat the first CI run as the real answer.

**Three — it is cheap to reverse.** See the section at the end. This is the argument I would
weigh most heavily if I were reviewing it.

**Reviewability, today.** This is reviewable with the toolchain you already have: no new
compiler to install to check a change, no FFI boundary between the audited code and the wallet, no
open question about who reviews the shim. That is a statement about *today*, not a claim that
Rust is unreviewable — when `fcmp_pp_rust` is populated and depends carries a toolchain, that
advantage narrows.

**Guix reproducibility.** A pure `src/` change does not touch the Guix inputs at all.

### Answering the "should anyone hand-write this?" objection directly

rbrunner7's point in meeting #167 was not about language. "*Complicated == high potential for
bugs*" cuts against a hand-written implementation in Rust exactly as much as in C++, and swapping
languages does not answer it. The only thing that answers it is evidence, so here is the evidence
rather than an argument:

- The primitives are pinned against **external** values rather than against themselves. I want to
  be exact about the provenance of each, because "tested against vectors" can mean very little:
  - **Noise_XX handshake, transport cipher, CRC32, elligator2** — vectors published by Trezor
    (commit-pinned in the test file) and by the relevant specifications. The CRC32 is
    bit-identical to the device's own.
  - **CPace generator** — the three vectors are **derived by me** from the IRTF CPACE-X25519-SHA512
    definition using an independent Python implementation, which I first validated against the two
    Trezor-published elligator2 vectors before using it to generate anything. They are not
    upstream-published values, because upstream does not publish any: the Python THP test suite
    that carried them was deleted when Trezor moved to their Rust implementation, and the Rust
    replacement ships no vector tables. I would welcome a cross-check against firmware.
- The multi-chunk framing layout is pinned against **hand-built expected bytes** derived from the
  specification — control byte, continuation header, and the 59/61 split — not against a second
  call to the encoder. It is not pinned against a captured firmware fixture; the upstream fixture
  file is deleted at HEAD, and I would upgrade this test if someone points me at a live copy.
- The fail-closed branches are tested for *failing*, not only for succeeding — including
  `consume_secret`'s two rejection paths, which are the whole host-side authentication mechanism.
- The protocol state machine and the v1-fallback decision have their own scripted round-trip tests
  asserting the exact control-byte sequence on the wire.

If any of that is thinner than it should be, say which part and I will add to it. I would rather
argue about coverage than about language.

### If you would rather have Rust

The case for the crate is real: it would be written by the people who wrote the protocol, and it
would track firmware changes without me in the loop.

Two things worth knowing before that trade looks free.

**First, what it costs today:** there is no published THP crate to adopt, so the Rust path starts
with vendoring an in-development monorepo subdirectory, settling the licence question above,
writing a C ABI that upstream does not currently expose, and accepting a tree-wide Rust MSRV of
1.85. That is months of work, not a swap. If the project decides to go that way I will help where
I can, but I would not want the decision to rest on an assumption that I can carry it alone —
see the last section.

**Second, and more usefully: this change is cheap to reverse.** The protocol implementation lives
entirely under `src/device_trezor/trezor/thp/`. It adds no dependency, touches no consensus code,
and nothing outside `device_trezor` calls into it. **If the Rust route arrives later, deleting
this is one commit and re-pointing the integration layer is a small one.** Taking it now does not
foreclose taking the crate when it exists — it just means Safe 7 owners are not waiting in the
meantime.

I wrote it in C++ because, weighing the above, I judged it the better fit for the codebase as it
stands today. If you disagree, I will follow the project's lead. What I would ask is that the
call be made rather than deferred, because the status quo is that a Safe 7 does not work at all.

## The one genuinely new cryptographic primitive

CPace requires a map-to-curve. I implement **elligator2** over Curve25519. This is the one new
primitive in the PR and it deserves the most review attention, so here is exactly why it is
hand-written rather than called.

**Why no library provides it.** CPace draft-10 section 7.2 mandates RFC 9380's
`map_to_curve_elligator2` with the `v` coordinate discarded, producing a **raw Montgomery `u` with
no cofactor clearing**. libsodium cannot supply that:
`crypto_core_ed25519_from_uniform` clears the cofactor and outputs Edwards, so it yields `u(8P)` —
interoperability-fatal against the device. `crypto_core_ristretto255_from_hash` is a different
encoding entirely. There is no X25519-specific map. The primitive that *would* work,
`ge25519_elligator2`, lives in libsodium's `private/ed25519_ref10.h` and is not public API.
**Trezor hand-roll it on both sides for the same reason** — `crypto/elligator2.c` (MIT, following
RFC 9380) and `trezorlib/thp/curve25519.py`.

**What the field arithmetic runs on, and why it changed.** The map is built on Monero's **in-tree
ref10 field arithmetic** (`src/crypto/crypto-ops.h`), the same primitives
`src/fcmp_pp/fcmp_pp_crypto.cpp` already uses from outside `src/crypto/`. Nothing under
`src/crypto/` is modified.

I originally wrote this over OpenSSL BIGNUM and that was a mistake, so I want to record what was
wrong with it rather than quietly ship the replacement. `BN_FLG_CONSTTIME` only routes
`BN_mod_exp` and `BN_mod_inverse` to constant-time variants; it does nothing for the surrounding
comparisons and assignments. My `is_square` branched on the Legendre result and the caller
branched again to select `x1` or `x2`, leaking one bit of the pairing code per run.

That bit is worse than it sounds, which is why I did not leave it documented as an accepted
trade-off. The leaked predicate is `is_square(gx1(code, h))`, and **`h` is public** — it comes off
the handshake transcript. So the bit is checkable *offline*: an attacker recomputes it for all
10^6 candidate codes and halves the space, and k observed pairing attempts leave 10^6/2^k. That
defeats CPace's central guarantee of exactly one **online** guess per run, against a secret with
only about 20 bits in it to begin with.

The map is now branch-free: a fixed addition chain for the Legendre symbol, `fe_cmov` with an
arithmetic mask for the `x1`/`x2` selection, a fixed-limb input decode, and `fe_invert` as RFC
9380's `inv0` — which also restored section 6.7.1 step 2, a CMOV the OpenSSL version had replaced
with a throw. This matches what Trezor do on both sides (`crypto/elligator2.c`,
`trezorlib/thp/curve25519.py`) and what RFC 9380 section 4 requires.

`<openssl/bn.h>` is gone from this file entirely as a result.

**Why the Noise cipher uses OpenSSL EVP rather than libsodium.** libsodium's
`crypto_aead_aes256gcm_*` requires Intel AES-NI or the ARM crypto extensions, and its own
documentation says there are *"no plans to support non hardware-accelerated implementations"* —
there is no software fallback in any version. More concretely,
`contrib/depends/packages/sodium.mk` pins **1.0.18**, whose `crypto_aead/aes256gcm/` directory
contains only `aesni/` and no `armcrypto/`. So on riscv64, aarch64-linux, arm64-darwin,
armv7-android and aarch64-android, `crypto_aead_aes256gcm_is_available()` returns 0
unconditionally and every entry point fails with `ENOSYS`; on the five x86 targets it is a runtime
CPUID check that can still fail. OpenSSL EVP works on all of them.

Every step is checked against published test vectors — see below.

## Vendored protobuf definitions

`messages-thp.proto` is vendored through the **existing** `fetch_protob.sh`, from the **existing**
upstream — `trezor-common`. No second script and no second upstream: everything arrives through
git, which is what #9491 asked for.

There is one wrinkle worth stating plainly: `messages-thp.proto` **does not exist at the pinned
`trezor-common` revision**, and bumping that pin is not a free move — the five existing protos
change substantially between the current pin and master, including a semantic `optional` ->
`required` on `MoneroAddress.address` and a new `chunkify` field in `messages-monero.proto`. None
of that is THP's business and all of it would want its own hardware validation.

So the script keeps **one upstream and two pins in a single clone**, reading the THP proto out of
the object database:

```sh
git -C trezor-common show "${THP_REF}:protob/messages-thp.proto" > protob/messages-thp.proto
```

Both pins are therefore git-hash-verified, which also removes the integrity asymmetry of fetching
one file over `curl` (and with it the missing `--fail`, rather than patching it).

The vendored copy differs from upstream by exactly two edits, both mechanical, both applied by the
script and both documented in `protob/README.md`:

1. `import "options.proto";` becomes `import "messages.proto";`. This tree does not vendor
   `options.proto`, and every custom option the file actually uses — `wire_in`, `wire_out`,
   `bitcoin_only`, `include_in_bitcoin_only` — is already declared in `messages.proto` at the pin.
   Vendoring `options.proto` as well is not an alternative: it re-declares the same extension
   numbers and protoc rejects the duplicates.
2. Six lines of `option (wire_enum) = true;` / `option (internal_only) = true;` are deleted. Both
   extensions exist only in `options.proto`, so protoc cannot resolve them here. They are metadata
   for trezor-firmware's own code generator and change neither the wire format nor the generated
   C++.

`protob/README.md` carries a one-liner that reproduces the vendored file from upstream, so the diff
you are reading is checkable against Trezor's object database without taking my word for any of it.

**I ran the whole script end to end on a clean tree to be sure.** It exits 0, and `git status`
afterwards shows **one** modified file:

```
 M src/device_trezor/trezor/protob/messages-management.proto
```

That is not this PR's doing. The script fetches upstream verbatim, and the committed copy carries a
one-word comment typo fix made in this tree by `2c327aa32` ("fix spelling in comments and docs") —
so re-running the vendoring script reverts it. `messages-thp.proto` and everything else reproduce
byte-for-byte. I have left the pre-existing wart alone rather than widen this PR to fix monero's
tooling, but it is recorded in `protob/README.md` now so the next person to run the script is not
alarmed by it.

One cosmetic note, in case a linter flags it: the vendored proto contains two non-ASCII characters,
both `≤` inside upstream's own comments on `host_name` and `app_name`. They are upstream's and I
have deliberately not "fixed" them, because doing so would break exactly the byte-for-byte
reproducibility above.

**Licence and provenance** are recorded in `protob/README.md`. `protob/COPYING` is byte-identical
to `trezor-common`'s root `COPYING` at both pins, and is **LGPL-3.0** (`LGPL-3.0-only`; upstream
ships no per-file headers and makes no "or any later version" election). `trezor-common` is a
read-only export of `trezor-firmware`'s `common/` directory, governed by `common/COPYING` — the
same LGPL-3.0 text — and **not** by `trezor-firmware`'s repository-root `COPYING`, which is GPL-3.0
and covers the firmware itself. I checked all four of those files rather than assuming.

sha256sums, so this can be verified without cloning anything:

```
02182d39653d362e14e40b4d8e4a29e68959b25015f2b311e64c3854124d1831  messages-common.proto
d703cc79e03155646a930b837917a4f40e24413453d1f45924ed3c23212a1d33  messages-debug.proto
bbe64b801786fe970da6836dd889f37d9a29ec7394ce3341a2a188afbb0bc466  messages-management.proto
20235c36b1a0fec625821ad8cc60908ca964a376a4cbe7a901fe9fcc668a9805  messages-monero.proto
b8574e3a591074920a1f97a2d85f851fe6e679158a943f3a6e4bf9b43ff29faa  messages.proto
633e1a967f6e83e66cb2d647265750339dac8fe9545738947343c7200cae1d12  messages-thp.proto
da7eabb7bafdf7d3ae5e9f223aa5bdc1eece45ac569dc21b3b037520b4464768  COPYING
```

## Testing

**Automated.** `tests/unit_tests/device_trezor_thp.cpp` and `tests/unit_tests/trezor_exceptions.cpp`
add **82 tests across 12 suites**, all of which run with no hardware attached and finish in about
130 ms. They cover framing across chunk boundaries, CRC32, the HKDF cascade and IV layout, the
Noise_XX handshake against an in-process device simulator, the transport cipher including nonce
exhaustion, CPace and elligator2, the credential store against malformed and hostile input, and the
error classifier — with the fail-closed branches tested for failing, not only for succeeding.

Built and run on x86_64 Linux, Release, `USE_DEVICE_TREZOR_MANDATORY=ON`, GCC 16:

```
[==========] 82 tests from 12 test suites ran. (134 ms total)
[  PASSED  ] 82 tests.
```

**Sanitizers.** Rebuilt with the project's own `-DSANITIZE=ON`, which is exactly
`-fsanitize=address,undefined`, and ran the same 82 tests with leak detection and
`detect_stack_use_after_return` on:

```
[==========] 82 tests from 12 test suites ran. (625 ms total)
[  PASSED  ] 82 tests.
```

**AddressSanitizer and LeakSanitizer report nothing at all.** UBSan emits 41 diagnostics, and I
want to be exact about them rather than claim a clean sheet: every one is `left shift of negative
value` inside `src/crypto/crypto-ops.c`, and **not one is in any file this PR adds**. That is
pre-existing in monero's ref10 arithmetic — running the untouched `crypto*` and `ringct*` suites
from the same binary produces 255 of the same diagnostics. It shows up here only because the
elligator2 map reuses ref10 instead of rolling its own field arithmetic, which I would rather have
than the alternative.

**Hardware: not tested yet, and I would rather say so than let the automated results imply it.**
That is the main reason this is a draft. I will post, as a comment on this PR: the exact device and
firmware version, first pairing, reconnect with a stored credential (which should *not* re-prompt),
a wrong code, cancelling at each step, a signed transaction that broadcasts, and a legacy
Model T / Safe 3 / Safe 5 still connecting and signing with its connect timing.

Everything claimed above this line is what the code and the automated tests support. Nothing above
it rests on a device.

## Reviewing this without a Safe 7

Most of the change can be reviewed and exercised without the hardware, since the tests are
self-contained:

```sh
cmake -DBUILD_TESTS=ON -DUSE_DEVICE_TREZOR=ON ..
make -j unit_tests
./tests/unit_tests/unit_tests --gtest_filter='thp_*:Trezor*'
```

For building the GUI against this branch, use `MANUAL_SUBMODULES=1` and **do not** use
`make devmode` — with `DEV_MODE=ON` CMake force-checks-out `origin/master` in the submodule and
will destroy your checkout.

## Commit structure

One commit. The layers are separated by file rather than by commit — `thp/framing`, `thp/noise`,
`thp/pairing`, `thp/store`, `thp/protocol_v2`, `thp/auto_detect` — and each has its own section in
`tests/unit_tests/device_trezor_thp.cpp`, so the diff can still be read a layer at a time.

Two changes in it are **not** THP and I want them visible rather than buried, because they affect
existing users:

- `UdpTransport::open()` raises its open counter **before** `session_begin` rather than after. A
  throw from `session_begin` currently leaves the counter at zero, `pre_close()` returns false, and
  the socket is never released. That is a pre-existing bug; I only noticed it because the THP
  handshake gave `session_begin` a reason to throw.
- The Bridge `/enumerate` probe gets a two-second timeout of its own, instead of inheriting the
  180-second default. Without a bridge installed and with something quietly dropping packets to
  `localhost:21325`, a wallet open currently stalls for three minutes. Real Bridge operations keep
  the long timeout.

If you would rather have either of those as its own PR, say so and I will pull it out.

## Companion GUI change

The GUI side is `monero-project/monero-gui#4674`, opened as a draft. It deliberately does **not**
bump the `monero` submodule: monero-gui pins the `release-v0.18` line, and no commit since 2020 has
moved that pointer for anything other than release prep. The three `DEV_MODE=ON` GUI CI jobs build
against monero master regardless of the pin, so they go green on their own once this merges.
Nothing needs to happen to that submodule for this PR.

## Open questions I would like maintainers to answer

1. **C++ or the Rust crate.** See above. I will follow the project's decision either way.
2. **The elligator2 implementation** is the piece I would most like a second pair of eyes on.
3. **Credential store location.** It currently derives from the wallet's data directory. If there
   is a preferred convention for per-user secret state that I have missed, say so and I will move
   it.

## How I would like to work on this

Safe 7 support has been outstanding for a while and, as far as I can tell, nobody had started. I
wrote this so that most of the work would already be done whenever the project got to it. I am not
asking for anything in return and I have no stake in it beyond wanting the device to work.

So, plainly:

**Take it and change it.** If you want large-scale changes — a different structure, the Rust route,
a different home for the credential store, different naming — you do not need me in the loop to
make them. Fork the branch, rewrite whatever you like, land it under whatever authorship makes
sense. I would much rather Safe 7 support existed than that this particular diff did.

**I will work with you on feedback.** I will answer review comments here, keep the branch rebased,
and make the changes I am able to make. What I cannot do is an indefinite series of large reworks
that each need hardware I do not have: I have one Safe 7 and one Linux machine. No macOS or Windows
build host, no bitcoin-only firmware, no THP-capable emulator, no legacy device beyond what is
listed in the testing section. Anything gated on those is genuinely better done by someone who has
them than by me guessing.

**I will not be at meetings.** Everything I have to say is in this PR and I will answer anything
asked here. If a decision gets made in a meeting, point me at it and I will act on it.

And if the project decides it does not want this at all, that is a fine outcome too — the branch
stays public and anyone in the community is welcome to take it.
