### PR TITLE
rpc: make thread count configurable, use better default value

### DIFF
--- a/src/daemon/rpc.h
+++ b/src/daemon/rpc.h
@@ -51,6 +51,7 @@ public:
 private:
   cryptonote::core_rpc_server m_server;
   const std::string m_description;
+  const std::size_t m_threads_count;
 public:
   t_rpc(
       boost::program_options::variables_map const & vm
@@ -61,6 +62,7 @@ public:
     , const std::string & description
     )
     : m_server{core.get(), p2p.get()}, m_description{description}
+    , m_threads_count{command_line::get_arg(vm, cryptonote::core_rpc_server::arg_rpc_threads)}
   {
     MGINFO("Initializing " << m_description << " RPC server...");
 
@@ -73,8 +75,8 @@ public:
 
   void run()
   {
-    MGINFO("Starting " << m_description << " RPC server...");
-    if (!m_server.run(2, false))
+    MGINFO("Starting " << m_description << " RPC server with " << m_threads_count << " threads...");
+    if (!m_server.run(m_threads_count, false))
     {
       throw std::runtime_error("Failed to start " + m_description + " RPC server.");
     }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -99,6 +99,12 @@ namespace
   {
     store_128(difficulty, sdiff, swdiff, stop64);
   }
+
+  std::size_t default_rpc_threads_count()
+  {
+    const unsigned int hw_concurrency = boost::thread::hardware_concurrency();
+    return std::min<std::size_t>(hw_concurrency > 0 ? hw_concurrency : 4, 8);
+  }
 } //anonymous namespace
 
 namespace cryptonote
@@ -115,6 +121,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg_rpc_max_connections_per_private_ip);
     command_line::add_arg(desc, arg_rpc_max_connections);
     command_line::add_arg(desc, arg_rpc_response_soft_limit);
+    command_line::add_arg(desc, arg_rpc_threads);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   core_rpc_server::core_rpc_server(
@@ -3128,5 +3135,11 @@ namespace cryptonote
       "rpc-response-soft-limit"
     , "Max response bytes that can be queued, enforced at next response attempt"
     , DEFAULT_RPC_SOFT_LIMIT_SIZE
+  };
+
+  const command_line::arg_descriptor<std::size_t> core_rpc_server::arg_rpc_threads = {
+      "rpc-threads"
+    , "Number of threads to use for the RPC server"
+    , default_rpc_threads_count()
   };
 }  // namespace cryptonote

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -159,6 +159,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg_rpc_max_connections_per_private_ip);
     command_line::add_arg(desc, arg_rpc_max_connections);
     command_line::add_arg(desc, arg_rpc_response_soft_limit);
+    command_line::add_arg(desc, arg_rpc_threads);
   }
   //------------------------------------------------------------------------------------------------------------------------------
   core_rpc_server::core_rpc_server(
@@ -3151,5 +3152,11 @@ namespace cryptonote
       "rpc-response-soft-limit"
     , "Max response bytes that can be queued, enforced at next response attempt"
     , DEFAULT_RPC_SOFT_LIMIT_SIZE
+  };
+
+  const command_line::arg_descriptor<std::size_t> core_rpc_server::arg_rpc_threads = {
+      "rpc-threads"
+    , "Number of threads to use for the RPC server"
+    , 2
   };
 }  // namespace cryptonote

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -67,6 +67,7 @@ namespace cryptonote
     static const command_line::arg_descriptor<std::size_t> arg_rpc_max_connections_per_private_ip;
     static const command_line::arg_descriptor<std::size_t> arg_rpc_max_connections;
     static const command_line::arg_descriptor<std::size_t> arg_rpc_response_soft_limit;
+    static const command_line::arg_descriptor<std::size_t> arg_rpc_threads;
 
     typedef epee::net_utils::connection_context_base connection_context;
 

--- a/utils/fish/monerod.fish
+++ b/utils/fish/monerod.fish
@@ -104,3 +104,4 @@ complete -c monerod -l rpc-max-connections-per-public-ip -d "Max RPC connections
 complete -c monerod -l rpc-max-connections-per-private-ip -d "Max RPC connections per private and localhost IP permitted. Default: 25"
 complete -c monerod -l rpc-max-connections -d "Max RPC connections permitted. Default: 100"
 complete -c monerod -l rpc-response-soft-limit -d "Max response bytes that can be queued, enforced at next response attempt. Default: 26214400"
+complete -c monerod -l rpc-threads -r -d "Number of threads to use for the RPC server"

--- a/utils/fish/monerod.fish
+++ b/utils/fish/monerod.fish
@@ -104,3 +104,4 @@ complete -c monerod -l rpc-max-connections-per-public-ip -d "Max RPC connections
 complete -c monerod -l rpc-max-connections-per-private-ip -d "Max RPC connections per private and localhost IP permitted. Default: 25"
 complete -c monerod -l rpc-max-connections -d "Max RPC connections permitted. Default: 100"
 complete -c monerod -l rpc-response-soft-limit -d "Max response bytes that can be queued, enforced at next response attempt. Default: 26214400"
+complete -c monerod -l rpc-threads -r -d "Number of threads to use for the RPC server. Default: 2"


### PR DESCRIPTION
Adds a new command-line option to the daemon (`--rpc-threads`), allowing the user to choose how many threads the RPC server should use. Its default value is the system's hardware concurrency, with upper and lower bounds of eight and four, respectively.

This should improve the scaling of RPC wallet sync by a small (but non-negligible) amount.