### PR TITLE
blockchain, tx_pool: release locks before db-only reads

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2321,6 +2321,9 @@ bool Blockchain::get_outs(const COMMAND_RPC_GET_OUTPUTS_BIN::request& req, COMMA
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
 
+  db_rtxn_guard rtxn_guard(m_db);
+  critical_region_var.unlock();
+
   res.outs.clear();
   res.outs.reserve(req.outputs.size());
 
@@ -2584,6 +2587,9 @@ bool Blockchain::get_transactions_blobs(const std::vector<crypto::hash>& txs_ids
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
 
+  db_rtxn_guard rtxn_guard(m_db);
+  critical_region_var.unlock();
+
   txs.reserve(txs_ids.size());
   for (const auto& tx_hash : txs_ids)
   {
@@ -2607,6 +2613,9 @@ bool Blockchain::get_transactions_blobs(const std::vector<crypto::hash>& txs_ids
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
+
+  db_rtxn_guard rtxn_guard(m_db);
+  critical_region_var.unlock();
 
   txs.reserve(txs_ids.size());
   for (const auto& tx_hash : txs_ids)
@@ -2632,6 +2641,9 @@ bool Blockchain::get_split_transactions_blobs(const t_ids_container& txs_ids, t_
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
+
+  db_rtxn_guard rtxn_guard(m_db);
+  critical_region_var.unlock();
 
   reserve_container(txs, txs_ids.size());
   for (const auto& tx_hash : txs_ids)
@@ -2666,6 +2678,9 @@ bool Blockchain::get_transactions(const t_ids_container& txs_ids, t_tx_container
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
+
+  db_rtxn_guard rtxn_guard(m_db);
+  critical_region_var.unlock();
 
   reserve_container(txs, txs_ids.size());
   for (const auto& tx_hash : txs_ids)
@@ -2798,6 +2813,8 @@ bool Blockchain::find_blockchain_supplement(const uint64_t req_start_block, cons
   }
 
   db_rtxn_guard rtxn_guard(m_db);
+  critical_region_var.unlock();
+
   top_hash = m_db->top_block_hash(&total_height);
   ++total_height;
   CHECK_AND_ASSERT_MES(total_height > start_height, false, "chain height expected to be higher than start block");

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -598,11 +598,10 @@ namespace cryptonote
   {
     PERF_TIMER(get_transaction_info);
     CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
 
     try
     {
-      LockedTXN lock(m_blockchain.get_db());
+      db_rtxn_guard lock(&m_blockchain.get_db());
       txpool_tx_meta_t meta;
       if (!m_blockchain.get_txpool_tx_meta(txid, meta))
       {
@@ -657,7 +656,7 @@ namespace cryptonote
   bool tx_memory_pool::get_transactions_info(const epee::span<const crypto::hash> txids, std::vector<std::pair<crypto::hash, tx_details>>& txs, bool include_sensitive, size_t max_tx_count) const
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    db_rtxn_guard lock(&m_blockchain.get_db());
 
     txs.clear();
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -426,6 +426,7 @@ namespace cryptonote
       ? std::min(req.max_block_count, (uint64_t)COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT)
       : COMMAND_RPC_GET_BLOCKS_FAST_MAX_BLOCK_COUNT;
 
+    db_rtxn_guard rtxn_guard(&m_core.get_blockchain_storage().get_db());
     std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::tuple<crypto::hash, crypto::hash, cryptonote::blobdata> > > > bs;
     if(!m_core.find_blockchain_supplement(req.start_height, req.block_ids, bs, res.current_height, res.top_block_hash, res.start_height, req.prune, !req.no_miner_tx, req.block_ids_exclusive, max_blocks, COMMAND_RPC_GET_BLOCKS_FAST_MAX_TX_COUNT))
     {
@@ -614,6 +615,7 @@ namespace cryptonote
     res.status = "Failed";
     res.blocks.clear();
     res.blocks.reserve(req.heights.size());
+    db_rtxn_guard rtxn_guard(&m_core.get_blockchain_storage().get_db());
     for (uint64_t height : req.heights)
     {
       block blk;


### PR DESCRIPTION
Attempts to shrink critical sections on hot read paths; LMDB's snapshot consistency should suffice without these additional locks. This will, in theory, provide some improvement in RPC scaling for wallet sync.

@Boog900 was again kind enough to provide the following graph, measuring wallet sync performance:

<img width="1152" height="864" alt="synthetic-monerod-master-vs-blockchain-lock2" src="https://github.com/user-attachments/assets/15c1ad78-d319-4075-98a2-eb51db962c4b" />