### PR TITLE
epee: replace some fragile code

### DIFF
--- a/contrib/epee/include/misc_language.h
+++ b/contrib/epee/include/misc_language.h
@@ -58,14 +58,13 @@ namespace misc_utils
       return v[0];
 
     size_t n = (v.size()) / 2;
-    std::sort(v.begin(), v.end());
-    //nth_element(v.begin(), v.begin()+n-1, v.end());
+    std::nth_element(v.begin(), v.begin()+n, v.end());
     if(v.size()%2)
     {//1, 3, 5...
       return v[n];
     }else 
     {//2, 4, 6...
-      return get_mid<type_vec_type>(v[n-1],v[n]);
+      return get_mid<type_vec_type>(*std::max_element(v.begin(), v.begin()+n), v[n]);
     }
 
   }

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -87,7 +87,8 @@ namespace net_utils
     static std::mutex hosts_mutex;
     std::lock_guard<std::mutex> guard(hosts_mutex);
     static std::map<std::string, unsigned int> hosts;
-    unsigned int &val = hosts[m_host];
+    auto it = hosts.emplace(m_host, 0).first;
+    unsigned int &val = it->second;
     if (delta > 0)
       MTRACE("New connection from host " << m_host << ": " << val);
     else if (delta < 0)
@@ -95,7 +96,9 @@ namespace net_utils
     CHECK_AND_ASSERT_THROW_MES(delta >= 0 || val >= (unsigned)-delta, "Count would go negative");
     CHECK_AND_ASSERT_THROW_MES(delta <= 0 || val <= std::numeric_limits<unsigned int>::max() - (unsigned)delta, "Count would wrap");
     val += delta;
-    return val;
+    const unsigned int ret = val;
+    if (ret == 0) hosts.erase(it);
+    return ret;
   }
 
   template<typename T>

--- a/contrib/epee/src/network_throttle-detail.cpp
+++ b/contrib/epee/src/network_throttle-detail.cpp
@@ -345,7 +345,7 @@ size_t network_throttle::get_recommended_size_of_planned_transport() const {
 
 double network_throttle::get_current_speed() const {
 	unsigned int bytes_transferred = 0;
-	if (m_history.size() == 0 || m_slot_size == 0)
+	if (m_history.size() <= 1 || m_slot_size == 0)
 		return 0;
 		
 	auto it = m_history.begin();


### PR DESCRIPTION
- Fixes potential unbounded memory growth, as the per-host connection count map didn't remove entries once a host's count returned to zero
- Fixes a faulty comparison which could have resulted in division by zero