### PR TITLE
src, epee: decouple net client users from http_client header

### DIFF
--- a/contrib/epee/include/net/abstract_http_client.h
+++ b/contrib/epee/include/net/abstract_http_client.h
@@ -73,6 +73,9 @@ namespace http
     virtual bool invoke_get(const boost::string_ref uri, std::chrono::milliseconds timeout, const std::string& body = std::string(), const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
     virtual uint64_t get_bytes_sent() const = 0;
     virtual uint64_t get_bytes_received() const = 0;
+    virtual const std::string &get_host() const = 0;
+    virtual const std::string &get_port() const = 0;
+    virtual void wipe_response() = 0;
   };
 
   class http_client_factory

--- a/contrib/epee/include/net/abstract_http_client.h
+++ b/contrib/epee/include/net/abstract_http_client.h
@@ -74,6 +74,9 @@ namespace http
     virtual bool invoke_get(const boost::string_ref uri, std::chrono::milliseconds timeout, const std::string& body = std::string(), const http_response_info** ppresponse_info = NULL, const fields_list& additional_params = fields_list()) = 0;
     virtual uint64_t get_bytes_sent() const = 0;
     virtual uint64_t get_bytes_received() const = 0;
+    virtual const std::string &get_host() const = 0;
+    virtual const std::string &get_port() const = 0;
+    virtual void wipe_response() = 0;
   };
 
   class http_client_factory

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -115,8 +115,8 @@ namespace net_utils
 				, m_lock()
 			{}
 
-			const std::string &get_host() const { return m_host_buff; };
-			const std::string &get_port() const { return m_port; };
+			const std::string &get_host() const override { return m_host_buff; };
+			const std::string &get_port() const override { return m_port; };
 
 			using abstract_http_client::set_server;
 
@@ -271,7 +271,7 @@ namespace net_utils
 				return m_net_client.get_bytes_received();
 			}
 			//---------------------------------------------------------------------------
-			void wipe_response()
+			void wipe_response() override
 			{
 				m_response_info.wipe();
 			}

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -115,8 +115,8 @@ namespace net_utils
 				, m_lock()
 			{}
 
-			const std::string &get_host() const { return m_host_buff; };
-			const std::string &get_port() const { return m_port; };
+			const std::string &get_host() const override { return m_host_buff; };
+			const std::string &get_port() const override { return m_port; };
 
 			using abstract_http_client::set_server;
 
@@ -276,7 +276,7 @@ namespace net_utils
 				return m_net_client.get_bytes_received();
 			}
 			//---------------------------------------------------------------------------
-			void wipe_response()
+			void wipe_response() override
 			{
 				m_response_info.wipe();
 			}

--- a/src/common/http_connection.h
+++ b/src/common/http_connection.h
@@ -30,13 +30,13 @@
 
 #include <chrono>
 #include "string_tools.h"
-#include "net/http_client.h"
+#include "net/abstract_http_client.h"
 
 namespace tools {
 
 class t_http_connection {
 private:
-  epee::net_utils::http::http_simple_client * mp_http_client;
+  epee::net_utils::http::abstract_http_client * mp_http_client;
   bool m_ok;
 public:
   static constexpr std::chrono::seconds TIMEOUT()
@@ -44,7 +44,7 @@ public:
     return std::chrono::minutes(3) + std::chrono::seconds(30);
   }
 
-  t_http_connection(epee::net_utils::http::http_simple_client* p_http_client)
+  t_http_connection(epee::net_utils::http::abstract_http_client* p_http_client)
     : mp_http_client(p_http_client)
     , m_ok(false)
   {

--- a/src/common/rpc_client.h
+++ b/src/common/rpc_client.h
@@ -35,16 +35,16 @@
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "storages/http_abstract_invoke.h"
 #include "net/http_auth.h"
-#include "net/http_client.h"
 #include "net/net_ssl.h"
 #include "string_tools.h"
+#include "net/http.h"
 
 namespace tools
 {
   class t_rpc_client final
   {
   private:
-    epee::net_utils::http::http_simple_client m_http_client;
+    std::unique_ptr<epee::net_utils::http::abstract_http_client> m_http_client;
   public:
     t_rpc_client(
         uint32_t ip
@@ -52,9 +52,9 @@ namespace tools
       , boost::optional<epee::net_utils::http::login> user
       , epee::net_utils::ssl_options_t ssl_options
       )
-      : m_http_client{}
+      : m_http_client{net::http::client_factory().create()}
     {
-      m_http_client.set_server(
+      m_http_client->set_server(
         epee::string_tools::get_ip_string_from_int32(ip), std::to_string(port), std::move(user), std::move(ssl_options)
       );
     }
@@ -66,15 +66,15 @@ namespace tools
       , std::string const & method_name
       )
     {
-      t_http_connection connection(&m_http_client);
+      t_http_connection connection(m_http_client.get());
 
       bool ok = connection.is_open();
       if (!ok)
       {
-        fail_msg_writer() << "Couldn't connect to daemon: " << m_http_client.get_host() << ":" << m_http_client.get_port();
+        fail_msg_writer() << "Couldn't connect to daemon: " << m_http_client->get_host() << ":" << m_http_client->get_port();
         return false;
       }
-      ok = epee::net_utils::invoke_http_json_rpc("/json_rpc", method_name, req, res, m_http_client, t_http_connection::TIMEOUT());
+      ok = epee::net_utils::invoke_http_json_rpc("/json_rpc", method_name, req, res, *m_http_client, t_http_connection::TIMEOUT());
       if (!ok)
       {
         fail_msg_writer() << "basic_json_rpc_request: Daemon request failed";
@@ -94,15 +94,15 @@ namespace tools
       , std::string const & fail_msg
       )
     {
-      t_http_connection connection(&m_http_client);
+      t_http_connection connection(m_http_client.get());
 
       bool ok = connection.is_open();
       if (!ok)
       {
-        fail_msg_writer() << "Couldn't connect to daemon: " << m_http_client.get_host() << ":" << m_http_client.get_port();
+        fail_msg_writer() << "Couldn't connect to daemon: " << m_http_client->get_host() << ":" << m_http_client->get_port();
         return false;
       }
-      ok = epee::net_utils::invoke_http_json_rpc("/json_rpc", method_name, req, res, m_http_client, t_http_connection::TIMEOUT());
+      ok = epee::net_utils::invoke_http_json_rpc("/json_rpc", method_name, req, res, *m_http_client, t_http_connection::TIMEOUT());
       if (!ok || res.status != CORE_RPC_STATUS_OK) // TODO - handle CORE_RPC_STATUS_BUSY ?
       {
         fail_msg_writer() << fail_msg << " -- json_rpc_request: " << res.status;
@@ -122,15 +122,15 @@ namespace tools
       , std::string const & fail_msg
       )
     {
-      t_http_connection connection(&m_http_client);
+      t_http_connection connection(m_http_client.get());
 
       bool ok = connection.is_open();
       if (!ok)
       {
-        fail_msg_writer() << "Couldn't connect to daemon: " << m_http_client.get_host() << ":" << m_http_client.get_port();
+        fail_msg_writer() << "Couldn't connect to daemon: " << m_http_client->get_host() << ":" << m_http_client->get_port();
         return false;
       }
-      ok = epee::net_utils::invoke_http_json(relative_url, req, res, m_http_client, t_http_connection::TIMEOUT());
+      ok = epee::net_utils::invoke_http_json(relative_url, req, res, *m_http_client, t_http_connection::TIMEOUT());
       if (!ok || res.status != CORE_RPC_STATUS_OK) // TODO - handle CORE_RPC_STATUS_BUSY ?
       {
         fail_msg_writer() << fail_msg << "-- rpc_request: " << res.status;
@@ -144,7 +144,7 @@ namespace tools
 
     bool check_connection()
     {
-      t_http_connection connection(&m_http_client);
+      t_http_connection connection(m_http_client.get());
       return connection.is_open();
     }
   };

--- a/src/common/rpc_client.h
+++ b/src/common/rpc_client.h
@@ -35,16 +35,16 @@
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "storages/http_abstract_invoke.h"
 #include "net/http_auth.h"
-#include "net/http_client.h"
 #include "net/net_ssl.h"
 #include "string_tools.h"
+#include "net/http.h"
 
 namespace tools
 {
   class t_rpc_client final
   {
   private:
-    epee::net_utils::http::http_simple_client m_http_client;
+    std::unique_ptr<epee::net_utils::http::abstract_http_client> m_http_client;
   public:
     t_rpc_client(
         uint32_t ip
@@ -52,9 +52,9 @@ namespace tools
       , boost::optional<epee::net_utils::http::login> user
       , epee::net_utils::ssl_options_t ssl_options
       )
-      : m_http_client{}
+      : m_http_client{net::http::client_factory().create()}
     {
-      m_http_client.set_server(
+      m_http_client->set_server(
         epee::string_tools::get_ip_string_from_int32(ip), std::to_string(port), std::move(user), std::move(ssl_options)
       );
     }
@@ -67,15 +67,15 @@ namespace tools
       , std::string const & fail_msg
       )
     {
-      t_http_connection connection(&m_http_client);
+      t_http_connection connection(m_http_client.get());
 
       bool ok = connection.is_open();
       if (!ok)
       {
-        fail_msg_writer() << "Couldn't connect to daemon: " << m_http_client.get_host() << ":" << m_http_client.get_port();
+        fail_msg_writer() << "Couldn't connect to daemon: " << m_http_client->get_host() << ":" << m_http_client->get_port();
         return false;
       }
-      ok = epee::net_utils::invoke_http_json_rpc("/json_rpc", method_name, req, res, m_http_client, t_http_connection::TIMEOUT());
+      ok = epee::net_utils::invoke_http_json_rpc("/json_rpc", method_name, req, res, *m_http_client, t_http_connection::TIMEOUT());
       if (!ok || res.status != CORE_RPC_STATUS_OK) // TODO - handle CORE_RPC_STATUS_BUSY ?
       {
         fail_msg_writer() << fail_msg << " -- json_rpc_request: " << res.status;
@@ -95,15 +95,15 @@ namespace tools
       , std::string const & fail_msg
       )
     {
-      t_http_connection connection(&m_http_client);
+      t_http_connection connection(m_http_client.get());
 
       bool ok = connection.is_open();
       if (!ok)
       {
-        fail_msg_writer() << "Couldn't connect to daemon: " << m_http_client.get_host() << ":" << m_http_client.get_port();
+        fail_msg_writer() << "Couldn't connect to daemon: " << m_http_client->get_host() << ":" << m_http_client->get_port();
         return false;
       }
-      ok = epee::net_utils::invoke_http_json(relative_url, req, res, m_http_client, t_http_connection::TIMEOUT());
+      ok = epee::net_utils::invoke_http_json(relative_url, req, res, *m_http_client, t_http_connection::TIMEOUT());
       if (!ok || res.status != CORE_RPC_STATUS_OK) // TODO - handle CORE_RPC_STATUS_BUSY ?
       {
         fail_msg_writer() << fail_msg << "-- rpc_request: " << res.status;
@@ -117,7 +117,7 @@ namespace tools
 
     bool check_connection()
     {
-      t_http_connection connection(&m_http_client);
+      t_http_connection connection(m_http_client.get());
       return connection.is_open();
     }
   };

--- a/src/device_trezor/CMakeLists.txt
+++ b/src/device_trezor/CMakeLists.txt
@@ -92,6 +92,7 @@ if(DEVICE_TREZOR_READY)
             ringct_basic
             cryptonote_core
             common
+            net
             ${sodium_LIBRARIES}
             ${Boost_CHRONO_LIBRARY}
             ${Protobuf_LIBRARY}

--- a/src/device_trezor/CMakeLists.txt
+++ b/src/device_trezor/CMakeLists.txt
@@ -94,6 +94,7 @@ if(DEVICE_TREZOR_READY)
             ringct_basic
             cryptonote_core
             common
+            net
             ${sodium_LIBRARIES}
             ${Boost_CHRONO_LIBRARY}
             ${Protobuf_LIBRARY}

--- a/src/device_trezor/trezor/transport.cpp
+++ b/src/device_trezor/trezor/transport.cpp
@@ -31,6 +31,10 @@
 #include <libusb.h>
 #endif
 
+#include "net/http.h"
+#include "string_tools.h"
+#include "string_tools_lexical.h"
+
 #include <algorithm>
 #include <functional>
 #include <boost/endian/conversion.hpp>
@@ -38,6 +42,7 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 #include "common/apply_permutation.h"
 #include "transport.hpp"
 #include "messages/messages-common.pb.h"
@@ -344,6 +349,7 @@ namespace trezor{
   BridgeTransport::BridgeTransport(
         boost::optional<std::string> device_path,
         boost::optional<std::string> bridge_host):
+    m_http_client(net::http::client_factory().create()),
     m_device_path(device_path),
     m_bridge_host(bridge_host ? bridge_host.get() : DEFAULT_BRIDGE),
     m_response(boost::none),
@@ -361,7 +367,7 @@ namespace trezor{
         MDEBUG("Bridge host: " << m_bridge_host);
       }
 
-      m_http_client.set_server(m_bridge_host, boost::none, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
+      m_http_client->set_server(m_bridge_host, boost::none, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
     }
 
   std::string BridgeTransport::get_path() const {
@@ -377,7 +383,7 @@ namespace trezor{
     json bridge_res;
     std::string req;
 
-    bool req_status = invoke_bridge_http("/enumerate", req, bridge_res, m_http_client);
+    bool req_status = invoke_bridge_http("/enumerate", req, bridge_res, *m_http_client);
     if (!req_status){
       throw exc::CommunicationException("Bridge enumeration failed");
     }
@@ -421,7 +427,7 @@ namespace trezor{
     std::string uri = "/acquire/" + m_device_path.get() + "/null";
     std::string req;
     json bridge_res;
-    bool req_status = invoke_bridge_http(uri, req, bridge_res, m_http_client);
+    bool req_status = invoke_bridge_http(uri, req, bridge_res, *m_http_client);
     if (!req_status){
       throw exc::CommunicationException("Failed to acquire device");
     }
@@ -443,7 +449,7 @@ namespace trezor{
     std::string uri = "/release/" + m_session.get();
     std::string req;
     json bridge_res;
-    bool req_status = invoke_bridge_http(uri, req, bridge_res, m_http_client);
+    bool req_status = invoke_bridge_http(uri, req, bridge_res, *m_http_client);
     if (!req_status){
       throw exc::CommunicationException("Failed to release device");
     }
@@ -467,7 +473,7 @@ namespace trezor{
     epee::wipeable_string res_hex;
     epee::wipeable_string req_hex = epee::to_hex::wipeable_string(epee::span<const std::uint8_t>(req_buff_raw, buff_size));
 
-    bool req_status = invoke_bridge_http(uri, req_hex, res_hex, m_http_client);
+    bool req_status = invoke_bridge_http(uri, req_hex, res_hex, *m_http_client);
     if (!req_status){
       throw exc::CommunicationException("Call method failed");
     }

--- a/src/device_trezor/trezor/transport.hpp
+++ b/src/device_trezor/trezor/transport.hpp
@@ -38,8 +38,10 @@
 
 #include <typeinfo>
 #include <type_traits>
-#include "net/http_client.h"
 #include "scope_guard.h"
+#include "net/abstract_http_client.h"
+#include "misc_language.h"
+#include "misc_log_ex.h"
 
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
@@ -192,7 +194,7 @@ namespace trezor {
     std::ostream& dump(std::ostream& o) const override;
 
   private:
-    epee::net_utils::http::http_simple_client m_http_client;
+    const std::unique_ptr<epee::net_utils::http::abstract_http_client> m_http_client;
     std::string m_bridge_host;
     boost::optional<std::string> m_device_path;
     boost::optional<std::string> m_session;

--- a/src/device_trezor/trezor/transport.hpp
+++ b/src/device_trezor/trezor/transport.hpp
@@ -38,8 +38,10 @@
 
 #include <typeinfo>
 #include <type_traits>
-#include "net/http_client.h"
 #include "scope_guard.h"
+#include "net/abstract_http_client.h"
+#include "misc_language.h"
+#include "misc_log_ex.h"
 
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
@@ -53,6 +55,10 @@
 #include "messages/messages-common.pb.h"
 #include "messages/messages-management.pb.h"
 #include "messages/messages-monero.pb.h"
+
+#ifdef WITH_DEVICE_TREZOR_WEBUSB
+#include <libusb.h>
+#endif
 
 namespace hw {
 namespace trezor {
@@ -192,7 +198,7 @@ namespace trezor {
     std::ostream& dump(std::ostream& o) const override;
 
   private:
-    epee::net_utils::http::http_simple_client m_http_client;
+    const std::unique_ptr<epee::net_utils::http::abstract_http_client> m_http_client;
     std::string m_bridge_host;
     boost::optional<std::string> m_device_path;
     boost::optional<std::string> m_session;
@@ -251,8 +257,6 @@ namespace trezor {
   };
 
 #ifdef WITH_DEVICE_TREZOR_WEBUSB
-#include <libusb.h>
-
   class WebUsbTransport : public Transport {
   public:
 

--- a/src/net/http.cpp
+++ b/src/net/http.cpp
@@ -31,10 +31,18 @@
 #include "parse.h"
 #include "socks_connect.h"
 
+#include "net/http_client.h"
+
 namespace net
 {
 namespace http
 {
+
+class client : public epee::net_utils::http::http_simple_client
+{
+public:
+  bool set_proxy(const std::string &address) override;
+};
 
 bool client::set_proxy(const std::string &address)
 {

--- a/src/net/http.h
+++ b/src/net/http.h
@@ -28,18 +28,12 @@
 
 #pragma once
 
-#include "net/http_client.h"
+#include "net/abstract_http_client.h"
 
 namespace net
 {
 namespace http
 {
-
-class client : public epee::net_utils::http::http_simple_client
-{
-public:
-  bool set_proxy(const std::string &address) override;
-};
 
 class client_factory : public epee::net_utils::http::http_client_factory
 {

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -36,7 +36,6 @@
 #include <boost/program_options/variables_map.hpp>
 
 #include "net/http_server_impl_base.h"
-#include "net/http_client.h"
 #include "core_rpc_server_commands_defs.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "p2p/net_node.h"

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -36,7 +36,6 @@
 #include "common/util.h"
 #include "common/updates.h"
 #include "version.h"
-#include "net/http_client.h"
 #include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
 
@@ -45,7 +44,8 @@
 
 namespace Monero {
 
-WalletManagerImpl::WalletManagerImpl()
+WalletManagerImpl::WalletManagerImpl() :
+    m_http_client(net::http::client_factory().create())
 {
     tools::set_strict_default_file_permissions(true);
 }
@@ -229,7 +229,7 @@ std::string WalletManagerImpl::errorString() const
 
 void WalletManagerImpl::setDaemonAddress(const std::string &address)
 {
-    m_http_client.set_server(address, boost::none);
+    m_http_client->set_server(address, boost::none);
 }
 
 bool WalletManagerImpl::connected(uint32_t *version)
@@ -239,7 +239,7 @@ bool WalletManagerImpl::connected(uint32_t *version)
     req_t.jsonrpc = "2.0";
     req_t.id = epee::serialization::storage_entry(0);
     req_t.method = "get_version";
-    if (!epee::net_utils::invoke_http_json("/json_rpc", req_t, resp_t, m_http_client))
+    if (!epee::net_utils::invoke_http_json("/json_rpc", req_t, resp_t, *m_http_client))
       return false;
 
     if (version)
@@ -252,7 +252,7 @@ uint64_t WalletManagerImpl::blockchainHeight()
     cryptonote::COMMAND_RPC_GET_INFO::request ireq;
     cryptonote::COMMAND_RPC_GET_INFO::response ires;
 
-    if (!epee::net_utils::invoke_http_json("/getinfo", ireq, ires, m_http_client))
+    if (!epee::net_utils::invoke_http_json("/getinfo", ireq, ires, *m_http_client))
       return 0;
     return ires.height;
 }
@@ -262,7 +262,7 @@ uint64_t WalletManagerImpl::blockchainTargetHeight()
     cryptonote::COMMAND_RPC_GET_INFO::request ireq;
     cryptonote::COMMAND_RPC_GET_INFO::response ires;
 
-    if (!epee::net_utils::invoke_http_json("/getinfo", ireq, ires, m_http_client))
+    if (!epee::net_utils::invoke_http_json("/getinfo", ireq, ires, *m_http_client))
       return 0;
     return ires.target_height >= ires.height ? ires.target_height : ires.height;
 }
@@ -272,7 +272,7 @@ uint64_t WalletManagerImpl::networkDifficulty()
     cryptonote::COMMAND_RPC_GET_INFO::request ireq;
     cryptonote::COMMAND_RPC_GET_INFO::response ires;
 
-    if (!epee::net_utils::invoke_http_json("/getinfo", ireq, ires, m_http_client))
+    if (!epee::net_utils::invoke_http_json("/getinfo", ireq, ires, *m_http_client))
       return 0;
     return ires.difficulty;
 }
@@ -282,8 +282,7 @@ double WalletManagerImpl::miningHashRate()
     cryptonote::COMMAND_RPC_MINING_STATUS::request mreq;
     cryptonote::COMMAND_RPC_MINING_STATUS::response mres;
 
-    epee::net_utils::http::http_simple_client http_client;
-    if (!epee::net_utils::invoke_http_json("/mining_status", mreq, mres, m_http_client))
+    if (!epee::net_utils::invoke_http_json("/mining_status", mreq, mres, *m_http_client))
       return 0.0;
     if (!mres.active)
       return 0.0;
@@ -295,7 +294,7 @@ uint64_t WalletManagerImpl::blockTarget()
     cryptonote::COMMAND_RPC_GET_INFO::request ireq;
     cryptonote::COMMAND_RPC_GET_INFO::response ires;
 
-    if (!epee::net_utils::invoke_http_json("/getinfo", ireq, ires, m_http_client))
+    if (!epee::net_utils::invoke_http_json("/getinfo", ireq, ires, *m_http_client))
         return 0;
     return ires.target;
 }
@@ -305,7 +304,7 @@ bool WalletManagerImpl::isMining()
     cryptonote::COMMAND_RPC_MINING_STATUS::request mreq;
     cryptonote::COMMAND_RPC_MINING_STATUS::response mres;
 
-    if (!epee::net_utils::invoke_http_json("/mining_status", mreq, mres, m_http_client))
+    if (!epee::net_utils::invoke_http_json("/mining_status", mreq, mres, *m_http_client))
       return false;
     return mres.active;
 }
@@ -320,7 +319,7 @@ bool WalletManagerImpl::startMining(const std::string &address, uint32_t threads
     mreq.ignore_battery = ignore_battery;
     mreq.do_background_mining = background_mining;
 
-    if (!epee::net_utils::invoke_http_json("/start_mining", mreq, mres, m_http_client))
+    if (!epee::net_utils::invoke_http_json("/start_mining", mreq, mres, *m_http_client))
       return false;
     return mres.status == CORE_RPC_STATUS_OK;
 }
@@ -330,7 +329,7 @@ bool WalletManagerImpl::stopMining()
     cryptonote::COMMAND_RPC_STOP_MINING::request mreq;
     cryptonote::COMMAND_RPC_STOP_MINING::response mres;
 
-    if (!epee::net_utils::invoke_http_json("/stop_mining", mreq, mres, m_http_client))
+    if (!epee::net_utils::invoke_http_json("/stop_mining", mreq, mres, *m_http_client))
       return false;
     return mres.status == CORE_RPC_STATUS_OK;
 }
@@ -378,7 +377,7 @@ std::tuple<bool, std::string, std::string, std::string, std::string> WalletManag
 
 bool WalletManagerImpl::setProxy(const std::string &address)
 {
-    return m_http_client.set_proxy(address);
+    return m_http_client->set_proxy(address);
 }
 
 ///////////////////// WalletManagerFactory implementation //////////////////////

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -97,7 +97,7 @@ public:
 private:
     WalletManagerImpl();
     friend struct WalletManagerFactory;
-    net::http::client m_http_client;
+    std::unique_ptr<epee::net_utils::http::abstract_http_client> m_http_client;
     std::string m_errorString;
 };
 

--- a/src/wallet/message_transporter.cpp
+++ b/src/wallet/message_transporter.cpp
@@ -30,7 +30,6 @@
 #include "string_coding.h"
 #include <boost/format.hpp>
 #include "wallet_errors.h"
-#include "net/http_client.h"
 #include "net/net_parse_helpers.h"
 #include <algorithm>
 

--- a/src/wallet/message_transporter.h
+++ b/src/wallet/message_transporter.h
@@ -30,7 +30,6 @@
 #include "serialization/keyvalue_serialization.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "net/http_server_impl_base.h"
-#include "net/http_client.h"
 #include "net/abstract_http_client.h"
 #include "common/util.h"
 #include "wipeable_string.h"

--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -33,6 +33,7 @@
 #include <boost/uuid/random_generator.hpp>
 #include <unordered_map>
 
+#include "net/http.h"
 #include "include_base_utils.h"
 using namespace epee;
 #include "wallet/wallet2.h"
@@ -156,7 +157,8 @@ bool transactions_flow_test(std::string& working_folder,
     << "Target:  " << w2.get_account().get_public_address_str(MAINNET) << ENDL << "Path: " << working_folder + "/" + path_target_wallet);
 
   //lets do some money
-  epee::net_utils::http::http_simple_client http_client;
+  const std::unique_ptr<epee::net_utils::http::abstract_http_client> ptr_http_client = net::http::client_factory().create();
+  epee::net_utils::http::abstract_http_client & http_client = *ptr_http_client;
   COMMAND_RPC_STOP_MINING::request daemon1_req = AUTO_VAL_INIT(daemon1_req);
   COMMAND_RPC_STOP_MINING::response daemon1_rsp = AUTO_VAL_INIT(daemon1_rsp);
   bool r = http_client.set_server(daemon_addr_a, boost::none) && net_utils::invoke_http_json("/stop_mine", daemon1_req, daemon1_rsp, http_client, std::chrono::seconds(10));


### PR DESCRIPTION
Rebased continuation of #8200. This patch attempts to reduce the complexity of the `http_client` class, which is derived from `epee::net_utils::http::abstract_http_client` and can be pointed at using a pointer to the base class.

This should reduce the compilation time of the whole codebase by ~10% (according to the original patch).