### PR TITLE
zmq: don't log eagain as an error in relay_to_pub

### DIFF
--- a/src/rpc/zmq_pub.cpp
+++ b/src/rpc/zmq_pub.cpp
@@ -491,7 +491,8 @@ bool zmq_pub::relay_to_pub(void* const relay, void* const pub)
   const expect<bool> relayed = relay_block_pub(relay, pub);
   if (!relayed)
   {
-    MERROR("Error relaying ZMQ/Pub: " << relayed.error().message());
+    if (relayed != net::zmq::make_error_code(EAGAIN))
+      MERROR("Error relaying ZMQ/Pub: " << relayed.error().message());
     return false;
   }
 


### PR DESCRIPTION
Since `ZMQ_DONTWAIT` is being used, `zmq_msg_recv` returns `EAGAIN` if no messages are available yet. This is normal for non-blocking reads and should not be logged as an error.