### PR TITLE
blockchain_db: remove DB batching code

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -719,75 +719,7 @@ public:
    */
   virtual std::string get_db_name() const = 0;
 
-  /**
-   * @brief tells the BlockchainDB to start a new "batch" of blocks
-   *
-   * If the subclass implements a batching method of caching blocks in RAM to
-   * be added to a backing store in groups, it should start a batch which will
-   * end either when <batch_num_blocks> has been added or batch_stop() has
-   * been called.  In either case, it should end the batch and write to its
-   * backing store.
-   *
-   * If a batch is already in-progress, this function must return false.
-   * If a batch was started by this call, it must return true.
-   *
-   * If any of this cannot be done, the subclass should throw the corresponding
-   * subclass of DB_EXCEPTION
-   *
-   * @param batch_num_blocks number of blocks to batch together
-   *
-   * @return true if we started the batch, false if already started
-   */
-  virtual bool batch_start(uint64_t batch_num_blocks=0, uint64_t batch_bytes=0) = 0;
-
-  /**
-   * @brief ends a batch transaction
-   *
-   * If the subclass implements batching, this function should store the
-   * batch it is currently on and mark it finished.
-   *
-   * If no batch is in-progress, this function should throw a DB_ERROR.
-   * This exception may change in the future if it is deemed necessary to
-   * have a more granular exception type for this scenario.
-   *
-   * If any of this cannot be done, the subclass should throw the corresponding
-   * subclass of DB_EXCEPTION
-   */
-  virtual void batch_stop() = 0;
-
-  /**
-   * @brief aborts a batch transaction
-   *
-   * If the subclass implements batching, this function should abort the
-   * batch it is currently on.
-   *
-   * If no batch is in-progress, this function should throw a DB_ERROR.
-   * This exception may change in the future if it is deemed necessary to
-   * have a more granular exception type for this scenario.
-   *
-   * If any of this cannot be done, the subclass should throw the corresponding
-   * subclass of DB_EXCEPTION
-   */
-  virtual void batch_abort() = 0;
-
-  /**
-   * @brief sets whether or not to batch transactions
-   *
-   * If the subclass implements batching, this function tells it to begin
-   * batching automatically.
-   *
-   * If the subclass implements batching and has a batch in-progress, a
-   * parameter of false should disable batching and call batch_stop() to
-   * store the current batch.
-   *
-   * If any of this cannot be done, the subclass should throw the corresponding
-   * subclass of DB_EXCEPTION
-   *
-   * @param bool batch whether or not to use batch transactions.
-   */
-  virtual void set_batch_transactions(bool) = 0;
-
-  virtual void block_wtxn_start() = 0;
+  virtual bool block_wtxn_start() = 0;
   virtual void block_wtxn_stop() = 0;
   virtual void block_wtxn_abort() = 0;
   virtual bool block_rtxn_start() const = 0;
@@ -1875,19 +1807,11 @@ class db_txn_guard
 public:
   db_txn_guard(BlockchainDB *db, bool readonly): db(db), readonly(readonly), active(false)
   {
-    if (readonly)
-    {
-      active = db->block_rtxn_start();
-    }
-    else
-    {
-      db->block_wtxn_start();
-      active = true;
-    }
+    active = readonly ? db->block_rtxn_start() : db->block_wtxn_start();
   }
   virtual ~db_txn_guard()
   {
-    stop();
+    abort();
   }
   void stop()
   {
@@ -1902,6 +1826,9 @@ public:
   }
   void abort()
   {
+    if (!active)
+      return;
+
     if (readonly)
       db->block_rtxn_abort();
     else

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -75,14 +75,14 @@ struct pre_rct_output_data_t
 #pragma pack(pop)
 
 template <typename T>
-inline void throw0(const T &e)
+[[noreturn]] inline void throw0(const T &e)
 {
   LOG_PRINT_L0(e.what());
   throw e;
 }
 
 template <typename T>
-inline void throw1(const T &e)
+[[noreturn]] inline void throw1(const T &e)
 {
   LOG_PRINT_L1(e.what());
   throw e;
@@ -361,17 +361,12 @@ mdb_txn_safe::~mdb_txn_safe()
     memset(&m_tinfo->m_ti_rflags, 0, sizeof(m_tinfo->m_ti_rflags));
   } else if (m_txn != nullptr)
   {
-    if (m_batch_txn) // this is a batch txn and should have been handled before this point for safety
-    {
-      LOG_PRINT_L0("WARNING: mdb_txn_safe: m_txn is a batch txn and it's not NULL in destructor - calling mdb_txn_abort()");
-    }
-    else
     {
       // Example of when this occurs: a lookup fails, so a read-only txn is
       // aborted through this destructor. However, successful read-only txns
       // ideally should have been committed when done and not end up here.
       //
-      // NOTE: not sure if this is ever reached for a non-batch write
+      // NOTE: not sure if this is ever reached for a write
       // transaction, but it's probably not ideal if it did.
       LOG_PRINT_L3("mdb_txn_safe: m_txn not NULL in destructor - calling mdb_txn_abort()");
     }
@@ -443,9 +438,6 @@ void mdb_txn_safe::increment_txns(int i)
 #define TXN_PREFIX(flags); \
   mdb_txn_safe auto_txn; \
   mdb_txn_safe* txn_ptr = &auto_txn; \
-  if (m_batch_active) \
-    txn_ptr = m_write_txn; \
-  else \
   { \
     if (auto mdb_res = lmdb_txn_begin(m_env, NULL, flags, auto_txn)) \
       throw0(DB_ERROR(lmdb_error(std::string("Failed to create a transaction for the db in ")+__FUNCTION__+": ", mdb_res).c_str())); \
@@ -462,7 +454,6 @@ void mdb_txn_safe::increment_txns(int i)
 
 #define TXN_POSTFIX_SUCCESS() \
   do { \
-    if (! m_batch_active) \
       auto_txn.commit(); \
   } while(0)
 
@@ -557,8 +548,6 @@ void BlockchainLMDB::do_resize(uint64_t increase_size)
   uint64_t new_mapsize = (uint64_t) mei.me_mapsize + add_size;
 
   // If given, use increase_size instead of above way of resizing.
-  // This is currently used for increasing by an estimated size at start of new
-  // batch txn.
   if (increase_size > 0)
     new_mapsize = mei.me_mapsize + increase_size;
 
@@ -566,16 +555,9 @@ void BlockchainLMDB::do_resize(uint64_t increase_size)
 
   mdb_txn_safe::prevent_new_txns();
 
-  if (m_write_txn != nullptr)
+  if (m_write_txn)
   {
-    if (m_batch_active)
-    {
-      throw0(DB_ERROR("lmdb resizing not yet supported when batch transactions enabled!"));
-    }
-    else
-    {
       throw0(DB_ERROR("attempting resize with write transaction in progress, this should not happen!"));
-    }
   }
 
   mdb_txn_safe::wait_no_active_txns();
@@ -589,7 +571,6 @@ void BlockchainLMDB::do_resize(uint64_t increase_size)
   mdb_txn_safe::allow_new_txns();
 }
 
-// threshold_size is used for batch transactions
 bool BlockchainLMDB::need_resize(uint64_t threshold_size) const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
@@ -602,10 +583,7 @@ bool BlockchainLMDB::need_resize(uint64_t threshold_size) const
 
   mdb_env_stat(m_env, &mst);
 
-  // size_used doesn't include data yet to be committed, which can be
-  // significant size during batch transactions. For that, we estimate the size
-  // needed at the beginning of the batch transaction and pass in the
-  // additional size needed.
+  // size_used doesn't include data yet to be committed.
   uint64_t size_used = mst.ms_psize * mei.me_last_pgno;
 
   MDEBUG("DB map size:     " << mei.me_mapsize);
@@ -635,112 +613,6 @@ bool BlockchainLMDB::need_resize(uint64_t threshold_size) const
 #else
   return false;
 #endif
-}
-
-void BlockchainLMDB::check_and_resize_for_batch(uint64_t batch_num_blocks, uint64_t batch_bytes)
-{
-  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  MTRACE("[" << __func__ << "] " << "checking DB size");
-  const uint64_t min_increase_size = 512 * (1 << 20);
-  uint64_t threshold_size = 0;
-  uint64_t increase_size = 0;
-  if (batch_num_blocks > 0)
-  {
-    threshold_size = get_estimated_batch_size(batch_num_blocks, batch_bytes);
-    MDEBUG("calculated batch size: " << threshold_size);
-
-    // The increased DB size could be a multiple of threshold_size, a fixed
-    // size increase (> threshold_size), or other variations.
-    //
-    // Currently we use the greater of threshold size and a minimum size. The
-    // minimum size increase is used to avoid frequent resizes when the batch
-    // size is set to a very small numbers of blocks.
-    increase_size = (threshold_size > min_increase_size) ? threshold_size : min_increase_size;
-    MDEBUG("increase size: " << increase_size);
-  }
-
-  // if threshold_size is 0 (i.e. number of blocks for batch not passed in), it
-  // will fall back to the percent-based threshold check instead of the
-  // size-based check
-  if (need_resize(threshold_size))
-  {
-    MGINFO("[batch] DB resize needed");
-    do_resize(increase_size);
-  }
-}
-
-uint64_t BlockchainLMDB::get_estimated_batch_size(uint64_t batch_num_blocks, uint64_t batch_bytes) const
-{
-  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  uint64_t threshold_size = 0;
-
-  // batch size estimate * batch safety factor = final size estimate
-  // Takes into account "reasonable" block size increases in batch.
-  float batch_safety_factor = 1.7f;
-  float batch_fudge_factor = batch_safety_factor * batch_num_blocks;
-  // estimate of stored block expanded from raw block, including denormalization and db overhead.
-  // Note that this probably doesn't grow linearly with block size.
-  float db_expand_factor = 4.5f;
-  uint64_t num_prev_blocks = 500;
-  // For resizing purposes, allow for at least 4k average block size.
-  uint64_t min_block_size = 4 * 1024;
-
-  uint64_t block_stop = 0;
-  uint64_t m_height = height();
-  if (m_height > 1)
-    block_stop = m_height - 1;
-  uint64_t block_start = 0;
-  if (block_stop >= num_prev_blocks)
-    block_start = block_stop - num_prev_blocks + 1;
-  uint32_t num_blocks_used = 0;
-  uint64_t total_block_size = 0;
-  MDEBUG("[" << __func__ << "] " << "m_height: " << m_height << "  block_start: " << block_start << "  block_stop: " << block_stop);
-  size_t avg_block_size = 0;
-  if (batch_bytes)
-  {
-    avg_block_size = batch_bytes / batch_num_blocks;
-    goto estim;
-  }
-  if (m_height == 0)
-  {
-    MDEBUG("No existing blocks to check for average block size");
-  }
-  else if (m_cum_count >= num_prev_blocks)
-  {
-    avg_block_size = m_cum_size / m_cum_count;
-    MDEBUG("average block size across recent " << m_cum_count << " blocks: " << avg_block_size);
-    m_cum_size = 0;
-    m_cum_count = 0;
-  }
-  else
-  {
-    {
-      TXN_PREFIX_RDONLY();
-      for (uint64_t block_num = block_start; block_num <= block_stop; ++block_num)
-      {
-        // we have access to block weight, which will be greater or equal to block size,
-        // so use this as a proxy. If it's too much off, we might have to check actual size,
-        // which involves reading more data, so is not really wanted
-        size_t block_weight = get_block_weight(block_num);
-        total_block_size += block_weight;
-        // Track number of blocks being totalled here instead of assuming, in case
-        // some blocks were to be skipped for being outliers.
-        ++num_blocks_used;
-      }
-    }
-    avg_block_size = total_block_size / (num_blocks_used ? num_blocks_used : 1);
-    MDEBUG("average block size across recent " << num_blocks_used << " blocks: " << avg_block_size);
-  }
-estim:
-  if (avg_block_size < min_block_size)
-    avg_block_size = min_block_size;
-  MDEBUG("estimated average block size for batch: " << avg_block_size);
-
-  // bigger safety margin on smaller block sizes
-  if (batch_fudge_factor < 5000.0)
-    batch_fudge_factor = 5000.0;
-  threshold_size = avg_block_size * db_expand_factor * batch_fudge_factor;
-  return threshold_size;
 }
 
 void BlockchainLMDB::add_block(const block& blk, size_t block_weight, uint64_t long_term_block_weight, const difficulty_type& cumulative_difficulty, const uint64_t& coins_generated,
@@ -814,11 +686,6 @@ void BlockchainLMDB::add_block(const block& blk, size_t block_weight, uint64_t l
   result = mdb_cursor_put(m_cur_block_heights, (MDB_val *)&zerokval, &val_h, 0);
   if (result)
     throw0(DB_ERROR(lmdb_error("Failed to add block height by hash to db transaction: ", result).c_str()));
-
-  // we use weight as a proxy for size, since we don't have size but weight is >= size
-  // and often actually equal
-  m_cum_size += block_weight;
-  m_cum_count++;
 }
 
 void BlockchainLMDB::remove_block()
@@ -1268,29 +1135,16 @@ BlockchainLMDB::~BlockchainLMDB()
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
 
-  // batch transaction shouldn't be active at this point. If it is, consider it aborted.
-  if (m_batch_active)
-  {
-    try { BlockchainLMDB::batch_abort(); }
-    catch (...) { /* ignore */ }
-  }
   if (m_open)
     BlockchainLMDB::close();
 }
 
-BlockchainLMDB::BlockchainLMDB(bool batch_transactions): BlockchainDB()
+BlockchainLMDB::BlockchainLMDB(): BlockchainDB()
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   // initialize folder to something "safe" just in case
   // someone accidentally misuses this class...
   m_folder = "thishsouldnotexistbecauseitisgibberish";
-
-  m_batch_transactions = batch_transactions;
-  m_write_txn = nullptr;
-  m_write_batch_txn = nullptr;
-  m_batch_active = false;
-  m_cum_size = 0;
-  m_cum_count = 0;
 
   // reset may also need changing when initialize things here
 
@@ -1601,11 +1455,6 @@ void BlockchainLMDB::open(const std::string& filename, const int db_flags)
 void BlockchainLMDB::close()
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  if (m_batch_active)
-  {
-    LOG_PRINT_L3("close() first calling batch_abort() due to active batch transaction");
-    BlockchainLMDB::batch_abort();
-  }
   BlockchainLMDB::sync();
   m_tinfo.reset();
 
@@ -1682,8 +1531,6 @@ void BlockchainLMDB::reset()
     throw0(DB_ERROR(lmdb_error("Failed to write version to database: ", result).c_str()));
 
   txn.commit();
-  m_cum_size = 0;
-  m_cum_count = 0;
 }
 
 std::vector<std::string> BlockchainLMDB::get_filenames() const
@@ -1724,9 +1571,7 @@ std::string BlockchainLMDB::get_db_name() const
   return std::string("lmdb");
 }
 
-// The below two macros are for DB access within block add/remove, whether
-// regular batch txn is in use or not. m_write_txn is used as a batch txn, even
-// if it's only within block add/remove.
+// The below two macros are for DB access within block add/remove.
 //
 // DB access functions that may be called both within block add/remove and
 // without should use these. If the function will be called ONLY within block
@@ -1735,8 +1580,8 @@ std::string BlockchainLMDB::get_db_name() const
 #define TXN_BLOCK_PREFIX(flags); \
   mdb_txn_safe auto_txn; \
   mdb_txn_safe* txn_ptr = &auto_txn; \
-  if (m_batch_active || m_write_txn) \
-    txn_ptr = m_write_txn; \
+  if (m_write_txn) \
+    txn_ptr = std::addressof(*m_write_txn); \
   else \
   { \
     if (auto mdb_res = lmdb_txn_begin(m_env, NULL, flags, auto_txn)) \
@@ -1745,7 +1590,7 @@ std::string BlockchainLMDB::get_db_name() const
 
 #define TXN_BLOCK_POSTFIX_SUCCESS() \
   do { \
-    if (! m_batch_active && ! m_write_txn) \
+    if (!m_write_txn) \
       auto_txn.commit(); \
   } while(0)
 
@@ -2723,13 +2568,13 @@ void BlockchainLMDB::correct_block_cumulative_difficulties(const uint64_t& start
   mdb_txn_cursors *m_cursors = &m_wcursors;
 
   int result = 0;
-  block_wtxn_start();
+  db_wtxn_guard db_lock(this);
   CURSOR(block_info)
 
   const uint64_t bc_height = height();
   if (start_height + new_cumulative_difficulties.size() != bc_height)
   {
-    block_wtxn_abort();
+    db_lock.abort();
     throw0(DB_ERROR("Incorrect new_cumulative_difficulties size"));
   }
 
@@ -2751,7 +2596,7 @@ void BlockchainLMDB::correct_block_cumulative_difficulties(const uint64_t& start
     if (result)
       throw0(DB_ERROR(lmdb_error("Failed to overwrite block info to db transaction: ", result).c_str()));
   }
-  block_wtxn_stop();
+  db_lock.stop();
 }
 
 uint64_t BlockchainLMDB::get_block_already_generated_coins(const uint64_t& height) const
@@ -3845,150 +3690,6 @@ bool BlockchainLMDB::for_all_outputs(uint64_t amount, const std::function<bool(u
   return fret;
 }
 
-// batch_num_blocks: (optional) Used to check if resize needed before batch transaction starts.
-bool BlockchainLMDB::batch_start(uint64_t batch_num_blocks, uint64_t batch_bytes)
-{
-  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  if (! m_batch_transactions)
-    throw0(DB_ERROR("batch transactions not enabled"));
-  if (m_batch_active)
-    return false;
-  if (m_write_batch_txn != nullptr)
-    return false;
-  if (m_write_txn)
-    throw0(DB_ERROR("batch transaction attempted, but m_write_txn already in use"));
-  check_open();
-
-  m_writer = boost::this_thread::get_id();
-  check_and_resize_for_batch(batch_num_blocks, batch_bytes);
-
-  m_write_batch_txn = new mdb_txn_safe();
-
-  // NOTE: need to make sure it's destroyed properly when done
-  if (auto mdb_res = lmdb_txn_begin(m_env, NULL, 0, *m_write_batch_txn))
-  {
-    delete m_write_batch_txn;
-    m_write_batch_txn = nullptr;
-    throw0(DB_ERROR(lmdb_error("Failed to create a transaction for the db: ", mdb_res).c_str()));
-  }
-  // indicates this transaction is for batch transactions, but not whether it's
-  // active
-  m_write_batch_txn->m_batch_txn = true;
-  m_write_txn = m_write_batch_txn;
-
-  m_batch_active = true;
-  memset(&m_wcursors, 0, sizeof(m_wcursors));
-  if (m_tinfo.get())
-  {
-    if (m_tinfo->m_ti_rflags.m_rf_txn)
-      mdb_txn_reset(m_tinfo->m_ti_rtxn);
-    memset(&m_tinfo->m_ti_rflags, 0, sizeof(m_tinfo->m_ti_rflags));
-  }
-
-  LOG_PRINT_L3("batch transaction: begin");
-  return true;
-}
-
-void BlockchainLMDB::batch_commit()
-{
-  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  if (! m_batch_transactions)
-    throw0(DB_ERROR("batch transactions not enabled"));
-  if (! m_batch_active)
-    throw1(DB_ERROR("batch transaction not in progress"));
-  if (m_write_batch_txn == nullptr)
-    throw1(DB_ERROR("batch transaction not in progress"));
-  if (m_writer != boost::this_thread::get_id())
-    throw1(DB_ERROR("batch transaction owned by other thread"));
-
-  check_open();
-
-  LOG_PRINT_L3("batch transaction: committing...");
-  TIME_MEASURE_START(time1);
-  m_write_txn->commit();
-  TIME_MEASURE_FINISH(time1);
-  time_commit1 += time1;
-  LOG_PRINT_L3("batch transaction: committed");
-
-  m_write_txn = nullptr;
-  delete m_write_batch_txn;
-  m_write_batch_txn = nullptr;
-  memset(&m_wcursors, 0, sizeof(m_wcursors));
-}
-
-void BlockchainLMDB::cleanup_batch()
-{
-  // for destruction of batch transaction
-  m_write_txn = nullptr;
-  delete m_write_batch_txn;
-  m_write_batch_txn = nullptr;
-  m_batch_active = false;
-  memset(&m_wcursors, 0, sizeof(m_wcursors));
-}
-
-void BlockchainLMDB::batch_stop()
-{
-  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  if (! m_batch_transactions)
-    throw0(DB_ERROR("batch transactions not enabled"));
-  if (! m_batch_active)
-    throw1(DB_ERROR("batch transaction not in progress"));
-  if (m_write_batch_txn == nullptr)
-    throw1(DB_ERROR("batch transaction not in progress"));
-  if (m_writer != boost::this_thread::get_id())
-    throw1(DB_ERROR("batch transaction owned by other thread"));
-  check_open();
-  LOG_PRINT_L3("batch transaction: committing...");
-  TIME_MEASURE_START(time1);
-  try
-  {
-    m_write_txn->commit();
-    TIME_MEASURE_FINISH(time1);
-    time_commit1 += time1;
-    cleanup_batch();
-  }
-  catch (const std::exception &e)
-  {
-    cleanup_batch();
-    throw;
-  }
-  LOG_PRINT_L3("batch transaction: end");
-}
-
-void BlockchainLMDB::batch_abort()
-{
-  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  if (! m_batch_transactions)
-    throw0(DB_ERROR("batch transactions not enabled"));
-  if (! m_batch_active)
-    throw1(DB_ERROR("batch transaction not in progress"));
-  if (m_write_batch_txn == nullptr)
-    throw1(DB_ERROR("batch transaction not in progress"));
-  if (m_writer != boost::this_thread::get_id())
-    throw1(DB_ERROR("batch transaction owned by other thread"));
-  check_open();
-  // for destruction of batch transaction
-  m_write_txn = nullptr;
-  // explicitly call in case mdb_env_close() (BlockchainLMDB::close()) called before BlockchainLMDB destructor called.
-  m_write_batch_txn->abort();
-  delete m_write_batch_txn;
-  m_write_batch_txn = nullptr;
-  m_batch_active = false;
-  memset(&m_wcursors, 0, sizeof(m_wcursors));
-  LOG_PRINT_L3("batch transaction: aborted");
-}
-
-void BlockchainLMDB::set_batch_transactions(bool batch_transactions)
-{
-  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
-  if ((batch_transactions) && (m_batch_transactions))
-  {
-    MINFO("batch transaction mode already enabled, but asked to enable batch mode");
-  }
-  m_batch_transactions = batch_transactions;
-  MINFO("batch transactions " << (m_batch_transactions ? "enabled" : "disabled"));
-}
-
 // return true if we started the txn, false if already started
 bool BlockchainLMDB::block_rtxn_start(MDB_txn **mtxn, mdb_txn_cursors **mcur) const
 {
@@ -4048,7 +3749,7 @@ bool BlockchainLMDB::block_rtxn_start() const
   return ret;
 }
 
-void BlockchainLMDB::block_wtxn_start()
+bool BlockchainLMDB::block_wtxn_start()
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   // Distinguish the exceptions here from exceptions that would be thrown while
@@ -4058,16 +3759,20 @@ void BlockchainLMDB::block_wtxn_start()
   // it and proceed as if there were an existing write txn, such as trying to
   // call block_txn_abort(). It also indicates a serious issue which will
   // probably be thrown up another layer.
-  if (! m_batch_active && m_write_txn)
-    throw0(DB_ERROR_TXN_START((std::string("Attempted to start new write txn when write txn already exists in ")+__FUNCTION__).c_str()));
-  if (! m_batch_active)
+  if (m_write_txn)
+  {
+    if (m_writer == boost::this_thread::get_id())
+      return false;
+    else
+      throw0(DB_ERROR_TXN_START((std::string("Attempted to start new write txn when another thread's write txn already exists in ")+__FUNCTION__).c_str()));
+  }
+  else
   {
     m_writer = boost::this_thread::get_id();
-    m_write_txn = new mdb_txn_safe();
+    m_write_txn.emplace();
     if (auto mdb_res = lmdb_txn_begin(m_env, NULL, 0, *m_write_txn))
     {
-      delete m_write_txn;
-      m_write_txn = nullptr;
+      m_write_txn.reset();
       throw0(DB_ERROR_TXN_START(lmdb_error("Failed to create a transaction for the db: ", mdb_res).c_str()));
     }
     memset(&m_wcursors, 0, sizeof(m_wcursors));
@@ -4077,8 +3782,9 @@ void BlockchainLMDB::block_wtxn_start()
         mdb_txn_reset(m_tinfo->m_ti_rtxn);
       memset(&m_tinfo->m_ti_rflags, 0, sizeof(m_tinfo->m_ti_rflags));
     }
-  } else if (m_writer != boost::this_thread::get_id())
-    throw0(DB_ERROR_TXN_START((std::string("Attempted to start new write txn when batch txn already exists in ")+__FUNCTION__).c_str()));
+
+    return true;
+  }
 }
 
 void BlockchainLMDB::block_wtxn_stop()
@@ -4089,17 +3795,15 @@ void BlockchainLMDB::block_wtxn_stop()
   if (m_writer != boost::this_thread::get_id())
     throw0(DB_ERROR_TXN_START((std::string("Attempted to stop write txn from the wrong thread in ")+__FUNCTION__).c_str()));
   {
-    if (! m_batch_active)
-	{
+    {
       TIME_MEASURE_START(time1);
       m_write_txn->commit();
       TIME_MEASURE_FINISH(time1);
       time_commit1 += time1;
 
-      delete m_write_txn;
-      m_write_txn = nullptr;
+      m_write_txn.reset();
       memset(&m_wcursors, 0, sizeof(m_wcursors));
-	}
+    }
   }
 }
 
@@ -4111,10 +3815,8 @@ void BlockchainLMDB::block_wtxn_abort()
   if (m_writer != boost::this_thread::get_id())
     throw0(DB_ERROR_TXN_START((std::string("Attempted to abort write txn from the wrong thread in ")+__FUNCTION__).c_str()));
 
-  if (! m_batch_active)
   {
-    delete m_write_txn;
-    m_write_txn = nullptr;
+    m_write_txn.reset();
     memset(&m_wcursors, 0, sizeof(m_wcursors));
   }
 }
@@ -4135,8 +3837,7 @@ uint64_t BlockchainLMDB::add_block(const std::pair<block, blobdata>& blk, size_t
 
   if (m_height % 1024 == 0)
   {
-    // for batch mode, DB resize check is done at start of batch transaction
-    if (! m_batch_active && need_resize())
+    if (need_resize())
     {
       LOG_PRINT_L0("LMDB memory map needs to be resized, doing that now.");
       do_resize();
@@ -4160,16 +3861,16 @@ void BlockchainLMDB::pop_block(block& blk, std::vector<transaction>* txs)
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
 
-  block_wtxn_start();
+  db_wtxn_guard db_lock(this);
 
   try
   {
     BlockchainDB::pop_block(blk, txs);
-    block_wtxn_stop();
+    db_lock.stop();
   }
   catch (...)
   {
-    block_wtxn_abort();
+    db_lock.abort();
     throw;
   }
 }
@@ -4652,7 +4353,7 @@ void BlockchainLMDB::migrate_0_1()
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   uint64_t i, z, m_height;
   int result;
-  mdb_txn_safe txn(false);
+  mdb_txn_safe &txn = m_write_txn.emplace(/*check=*/false);
   MDB_val k, v;
   char *ptr;
 
@@ -5065,15 +4766,16 @@ void BlockchainLMDB::migrate_0_1()
     lmdb_db_open(txn, "txr", MDB_INTEGERKEY | MDB_CREATE, m_txs, "Failed to open db handle for txr");
 
     txn.commit();
+    result = mdb_txn_begin(m_env, NULL, 0, txn);
+    if (result)
+      throw0(DB_ERROR(lmdb_error("Failed to create a transaction for the db: ", result).c_str()));
+    memset(&m_wcursors, 0, sizeof(m_wcursors));
 
     MDB_cursor *c_blocks, *c_txs, *c_props, *c_cur;
     i = 0;
     z = m_height;
 
     hk.mv_size = sizeof(crypto::hash);
-    set_batch_transactions(true);
-    batch_start(1000);
-    txn.m_txn = m_write_txn->m_txn;
     m_height = 0;
 
     while(1) {
@@ -5091,8 +4793,6 @@ void BlockchainLMDB::migrate_0_1()
           result = mdb_txn_begin(m_env, NULL, 0, txn);
           if (result)
             throw0(DB_ERROR(lmdb_error("Failed to create a transaction for the db: ", result).c_str()));
-          m_write_txn->m_txn = txn.m_txn;
-          m_write_batch_txn->m_txn = txn.m_txn;
           memset(&m_wcursors, 0, sizeof(m_wcursors));
         }
         result = mdb_cursor_open(txn, m_blocks, &c_blocks);
@@ -5133,7 +4833,11 @@ void BlockchainLMDB::migrate_0_1()
         result = mdb_cursor_del(c_props, 0);
         if (result)
           throw0(DB_ERROR(lmdb_error("Failed to delete a record from props: ", result).c_str()));
-        batch_stop();
+        txn.commit();
+        result = mdb_txn_begin(m_env, NULL, 0, txn);
+        if (result)
+          throw0(DB_ERROR(lmdb_error("Failed to create a transaction for the db: ", result).c_str()));
+        memset(&m_wcursors, 0, sizeof(m_wcursors));
         break;
       } else if (result)
         throw0(DB_ERROR(lmdb_error("Failed to get a record from blocks: ", result).c_str()));

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <atomic>
+#include <optional>
 
 #include "blockchain_db/blockchain_db.h"
 #include "cryptonote_basic/blobdatatype.h" // for type blobdata
@@ -132,10 +133,6 @@ struct mdb_txn_safe
 
   void commit(std::string message = "");
 
-  // This should only be needed for batch transaction which must be ensured to
-  // be aborted before mdb_env_close, not after. So we can't rely on
-  // BlockchainLMDB destructor to call mdb_txn_safe destructor, as that's too late
-  // to properly abort, since mdb_env_close would have been called earlier.
   void abort();
   void uncheck();
 
@@ -158,7 +155,6 @@ struct mdb_txn_safe
 
   mdb_threadinfo* m_tinfo;
   MDB_txn* m_txn;
-  bool m_batch_txn = false;
   bool m_check;
   static std::atomic<uint64_t> num_active_txns;
 
@@ -167,23 +163,10 @@ struct mdb_txn_safe
 };
 
 
-// If m_batch_active is set, a batch transaction exists beyond this class, such
-// as a batch import with verification enabled, or possibly (later) a batch
-// network sync.
-//
-// For some of the lookup methods, such as get_block_timestamp(), tx_exists(),
-// and get_tx(), when m_batch_active is set, the lookup uses the batch
-// transaction. This isn't only because the transaction is available, but it's
-// necessary so that lookups include the database updates only present in the
-// current batch write.
-//
-// A regular network sync without batch writes is expected to open a new read
-// transaction, as those lookups are part of the validation done prior to the
-// write for block and tx data, so no write transaction is open at the time.
 class BlockchainLMDB final: public BlockchainDB
 {
 public:
-  BlockchainLMDB(bool batch_transactions=true);
+  BlockchainLMDB();
   ~BlockchainLMDB();
 
   void open(const std::string& filename, const int mdb_flags=0) override;
@@ -327,13 +310,7 @@ public:
                             , const std::vector<std::pair<transaction, blobdata>>& txs
                             ) override;
 
-  void set_batch_transactions(bool batch_transactions) override;
-  bool batch_start(uint64_t batch_num_blocks=0, uint64_t batch_bytes=0) override;
-  void batch_commit();
-  void batch_stop() override;
-  void batch_abort() override;
-
-  void block_wtxn_start() override;
+  bool block_wtxn_start() override;
   void block_wtxn_stop() override;
   void block_wtxn_abort() override;
   bool block_rtxn_start() const override;
@@ -369,8 +346,6 @@ private:
   void do_resize(uint64_t size_increase=0);
 
   bool need_resize(uint64_t threshold_size=0) const;
-  void check_and_resize_for_batch(uint64_t batch_num_blocks, uint64_t batch_bytes);
-  uint64_t get_estimated_batch_size(uint64_t batch_num_blocks, uint64_t batch_bytes) const;
 
   void add_block( const block& blk
                 , size_t block_weight
@@ -447,8 +422,6 @@ private:
   // migrate from DB version 4 to 5
   void migrate_4_5();
 
-  void cleanup_batch();
-
 private:
   MDB_env* m_env;
 
@@ -479,15 +452,9 @@ private:
 
   MDB_dbi m_properties;
 
-  mutable uint64_t m_cum_size;	// used in batch size estimation
-  mutable unsigned int m_cum_count;
   std::string m_folder;
-  mdb_txn_safe* m_write_txn; // may point to either a short-lived txn or a batch txn
-  mdb_txn_safe* m_write_batch_txn; // persist batch txn outside of BlockchainLMDB
+  std::optional<mdb_txn_safe> m_write_txn;
   boost::thread::id m_writer;
-
-  bool m_batch_transactions; // support for batch transactions
-  bool m_batch_active; // whether batch transaction is in progress
 
   mdb_txn_cursors m_wcursors;
   mutable boost::thread_specific_ptr<mdb_threadinfo> m_tinfo;

--- a/src/blockchain_db/locked_txn.h
+++ b/src/blockchain_db/locked_txn.h
@@ -34,22 +34,10 @@
 
 namespace cryptonote
 {
-    // This class is meant to create a batch when none currently exists.
-    // If a batch exists, it can't be from another thread, since we can
-    // only be called with the txpool lock taken, and it is held during
-    // the whole prepare/handle/cleanup incoming block sequence.
-    class LockedTXN {
+    // Compatability wrapper for db_wtxn_guard
+    class LockedTXN: public db_wtxn_guard {
     public:
-      LockedTXN(BlockchainDB &db): m_db(db), m_batch(false), m_active(false) {
-        m_batch = m_db.batch_start();
-        m_active = true;
-      }
-      void commit() { try { if (m_batch && m_active) { m_db.batch_stop(); m_active = false; } } catch (const std::exception &e) { MWARNING("LockedTXN::commit filtering exception: " << e.what()); } }
-      void abort() { try { if (m_batch && m_active) { m_db.batch_abort(); m_active = false; } } catch (const std::exception &e) { MWARNING("LockedTXN::abort filtering exception: " << e.what()); } }
-      ~LockedTXN() { abort(); }
-    private:
-      BlockchainDB &m_db;
-      bool m_batch;
-      bool m_active;
+      LockedTXN(BlockchainDB &db): db_wtxn_guard(&db) {}
+      void commit() { stop(); }
     };
 }

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -52,11 +52,7 @@ public:
   virtual std::vector<std::string> get_filenames() const override { return std::vector<std::string>(); }
   virtual bool remove_data_file(const std::string& folder) const override { return true; }
   virtual std::string get_db_name() const override { return std::string(); }
-  virtual bool batch_start(uint64_t batch_num_blocks=0, uint64_t batch_bytes=0) override { return true; }
-  virtual void batch_stop() override {}
-  virtual void batch_abort() override {}
-  virtual void set_batch_transactions(bool) override {}
-  virtual void block_wtxn_start() override {}
+  virtual bool block_wtxn_start() override { return true; }
   virtual void block_wtxn_stop() override {}
   virtual void block_wtxn_abort() override {}
   virtual bool block_rtxn_start() const override { return true; }

--- a/src/blockchain_utilities/README.md
+++ b/src/blockchain_utilities/README.md
@@ -23,21 +23,17 @@ This loads the existing blockchain and exports it to `$MONERO_DATA_DIR/export/bl
 This imports blocks from `$MONERO_DATA_DIR/export/blockchain.raw` (exported using the
 `monero-blockchain-export` tool as described above) into the current database.
 
-Defaults: `--batch on`, `--batch size 20000`, `--verify on`
-
-Batch size refers to number of blocks and can be adjusted for performance based on available RAM.
+Defaults: `--verify on`
 
 Verification should only be turned off if importing from a trusted blockchain.
 
-If you encounter an error like "resizing not supported in batch mode", you can just re-run
-the `monero-blockchain-import` command again, and it will restart from where it left off.
 
 ```bash
 ## use default settings to import blockchain.raw into database
 $ monero-blockchain-import
 
-## fast import with large batch size, database mode "fastest", verification off
-$ monero-blockchain-import --batch-size 20000 --database lmdb#fastest --verify off
+## fast import with database mode "fastest", verification off
+$ monero-blockchain-import --database lmdb#fastest --verify off
 
 ```
 

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -49,24 +49,10 @@
 namespace
 {
 // CONFIG
-bool opt_batch   = true;
 bool opt_verify  = true; // use add_new_block, which does verification before calling add_block
 bool opt_resume  = true;
 bool opt_testnet = true;
 bool opt_stagenet = true;
-
-// number of blocks per batch transaction
-// adjustable through command-line argument according to available RAM
-#if ARCH_WIDTH != 32
-uint64_t db_batch_size = 20000;
-#else
-// set a lower default batch size, pending possible LMDB issue with large transaction size
-uint64_t db_batch_size = 100;
-#endif
-
-// when verifying, use a smaller default batch size so progress is more
-// frequently saved
-uint64_t db_batch_size_verify = 5000;
 
 std::string refresh_string = "\r                                    \r";
 }
@@ -93,33 +79,11 @@ int get_db_flags_from_mode(const std::string& db_mode)
 
 int pop_blocks(cryptonote::core& core, int num_blocks)
 {
-  bool use_batch = opt_batch;
-
-  if (use_batch)
-    core.get_blockchain_storage().get_db().batch_start();
-
-  int quit = 0;
   block popped_block;
   for (int i=0; i < num_blocks; ++i)
   {
     // simple_core.m_storage.pop_block_from_blockchain() is private, so call directly through db
     core.get_blockchain_storage().get_db().pop_block(popped_block, /*txs=*/nullptr);
-    quit = 1;
-  }
-
-
-  if (use_batch)
-  {
-    if (quit > 1)
-    {
-      // There was an error, so don't commit pending data.
-      // Destructor will abort write txn.
-    }
-    else
-    {
-      core.get_blockchain_storage().get_db().batch_stop();
-    }
-    core.get_blockchain_storage().get_db().show_stats();
   }
 
   return num_blocks;
@@ -129,7 +93,7 @@ int check_flush(cryptonote::core &core, std::vector<block_complete_entry> &block
 {
   if (blocks.empty())
     return 0;
-  if (!force && blocks.size() < db_batch_size)
+  if (!force)
     return 0;
 
   // wait till we can verify a full HOH without extra, for speed
@@ -292,8 +256,6 @@ int import_from_file(cryptonote::core& core, const std::string& import_file_path
   MINFO("start block: " << start_height << "  stop block: " <<
       block_stop);
 
-  bool use_batch = opt_batch && !opt_verify;
-
   MINFO("Reading blockchain from bootstrap file...");
   std::cout << ENDL;
 
@@ -312,17 +274,6 @@ int import_from_file(cryptonote::core& core, const std::string& import_file_path
     h = start_height;
   }
 
-  if (use_batch)
-  {
-    uint64_t bytes, h2;
-    bool q2;
-    pos = import_file.tellg();
-    bytes = bootstrap.count_bytes(import_file, db_batch_size, h2, q2);
-    if (import_file.eof())
-      import_file.clear();
-    import_file.seekg(pos);
-    core.get_blockchain_storage().get_db().batch_start(db_batch_size, bytes);
-  }
   while (! quit)
   {
     uint32_t chunk_size;
@@ -498,25 +449,6 @@ int import_from_file(cryptonote::core& core, const std::string& import_file_path
             quit = 2; // make sure we don't commit partial block data
             break;
           }
-
-          if (use_batch)
-          {
-            if ((h-1) % db_batch_size == 0)
-            {
-              uint64_t bytes, h2;
-              bool q2;
-              std::cout << refresh_string;
-              // zero-based height
-              std::cout << ENDL << "[- batch commit at height " << h-1 << " -]" << ENDL;
-              core.get_blockchain_storage().get_db().batch_stop();
-              pos = import_file.tellg();
-              bytes = bootstrap.count_bytes(import_file, db_batch_size, h2, q2);
-              import_file.seekg(pos);
-              core.get_blockchain_storage().get_db().batch_start(db_batch_size, bytes);
-              std::cout << ENDL;
-              core.get_blockchain_storage().get_db().show_stats();
-            }
-          }
         }
         ++num_imported;
       }
@@ -537,19 +469,6 @@ quitting:
     int ret = check_flush(core, blocks, true);
     if (ret)
       return ret;
-  }
-
-  if (use_batch)
-  {
-    if (quit > 1)
-    {
-      // There was an error, so don't commit pending data.
-      // Destructor will abort write txn.
-    }
-    else
-    {
-      core.get_blockchain_storage().get_db().batch_stop();
-    }
   }
 
   core.get_blockchain_storage().get_db().show_stats();
@@ -583,7 +502,6 @@ int main(int argc, char* argv[])
   const command_line::arg_descriptor<std::string> arg_input_file = {"input-file", "Specify input file", "", true};
   const command_line::arg_descriptor<std::string> arg_log_level   = {"log-level",  "0-4 or categories", ""};
   const command_line::arg_descriptor<uint64_t> arg_block_stop  = {"block-stop", "Stop at block number", block_stop};
-  const command_line::arg_descriptor<uint64_t> arg_batch_size  = {"batch-size", "", db_batch_size};
   const command_line::arg_descriptor<uint64_t> arg_pop_blocks  = {"pop-blocks", "Remove blocks from end of blockchain", num_blocks};
   const command_line::arg_descriptor<bool>        arg_drop_hf  = {"drop-hard-fork", "Drop hard fork subdbs", false};
   const command_line::arg_descriptor<bool>     arg_count_blocks = {
@@ -593,14 +511,11 @@ int main(int argc, char* argv[])
   };
   const command_line::arg_descriptor<bool> arg_noverify =  {"dangerous-unverified-import",
     "Blindly trust the import file and use potentially malicious blocks and transactions during import (only enable if you exported the file yourself)", false};
-  const command_line::arg_descriptor<bool> arg_batch  =  {"batch",
-    "Batch transactions for faster import", true};
   const command_line::arg_descriptor<bool> arg_resume =  {"resume",
     "Resume from current height if output database already exists", true};
 
   command_line::add_arg(desc_cmd_sett, arg_input_file);
   command_line::add_arg(desc_cmd_sett, arg_log_level);
-  command_line::add_arg(desc_cmd_sett, arg_batch_size);
   command_line::add_arg(desc_cmd_sett, arg_block_stop);
 
   command_line::add_arg(desc_cmd_only, arg_count_blocks);
@@ -612,7 +527,6 @@ int main(int argc, char* argv[])
   // command_line helpers support only boolean switch, not boolean argument
   desc_cmd_sett.add_options()
     (arg_noverify.name, make_semantic(arg_noverify), arg_noverify.description)
-    (arg_batch.name,  make_semantic(arg_batch),  arg_batch.description)
     (arg_resume.name, make_semantic(arg_resume), arg_resume.description)
     ;
 
@@ -631,39 +545,14 @@ int main(int argc, char* argv[])
     return 1;
 
   opt_verify    = !command_line::get_arg(vm, arg_noverify);
-  opt_batch     = command_line::get_arg(vm, arg_batch);
   opt_resume    = command_line::get_arg(vm, arg_resume);
   block_stop    = command_line::get_arg(vm, arg_block_stop);
-  db_batch_size = command_line::get_arg(vm, arg_batch_size);
 
   if (command_line::get_arg(vm, command_line::arg_help))
   {
     std::cout << "Monero '" << MONERO_RELEASE_NAME << "' (v" << MONERO_VERSION_FULL << ")" << ENDL << ENDL;
     std::cout << desc_options << std::endl;
     return 1;
-  }
-
-  if (! opt_batch && !command_line::is_arg_defaulted(vm, arg_batch_size))
-  {
-    std::cerr << "Error: batch-size set, but batch option not enabled" << ENDL;
-    return 1;
-  }
-  if (! db_batch_size)
-  {
-    std::cerr << "Error: batch-size must be > 0" << ENDL;
-    return 1;
-  }
-  if (opt_verify && command_line::is_arg_defaulted(vm, arg_batch_size))
-  {
-    // usually want batch size default lower if verify on, so progress can be
-    // frequently saved.
-    //
-    // currently, with Windows, default batch size is low, so ignore
-    // default db_batch_size_verify unless it's even lower
-    if (db_batch_size > db_batch_size_verify)
-    {
-      db_batch_size = db_batch_size_verify;
-    }
   }
 
   m_config_folder = command_line::get_arg(vm, cryptonote::arg_data_dir);
@@ -694,15 +583,6 @@ int main(int argc, char* argv[])
 
   MINFO("database: LMDB");
   MINFO("verify:  " << std::boolalpha << opt_verify << std::noboolalpha);
-  if (opt_batch)
-  {
-    MINFO("batch:   " << std::boolalpha << opt_batch << std::noboolalpha
-        << "  batch size: " << db_batch_size);
-  }
-  else
-  {
-    MINFO("batch:   " << std::boolalpha << opt_batch << std::noboolalpha);
-  }
   MINFO("resume:  " << std::boolalpha << opt_resume  << std::noboolalpha);
   MINFO("nettype: " << (opt_testnet ? "testnet" : opt_stagenet ? "stagenet" : "mainnet"));
 
@@ -738,7 +618,6 @@ int main(int argc, char* argv[])
     std::cerr << "Failed to initialize core" << ENDL;
     return 1;
   }
-  core.get_blockchain_storage().get_db().set_batch_transactions(true);
 
   if (!command_line::is_arg_defaulted(vm, arg_pop_blocks))
   {

--- a/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
+++ b/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
@@ -28,6 +28,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include "blockchain_db/locked_txn.h"
 #include "common/command_line.h"
 #include "serialization/crypto.h"
 #include "cryptonote_core/cryptonote_core.h"
@@ -234,7 +235,7 @@ int main(int argc, char* argv[])
     stop_requested = true;
   });
 
-  db->batch_start();
+  LockedTXN db_txn(*db);
 
   size_t num_total_outputs = 0, num_prunable_outputs = 0, num_known_spent_outputs = 0, num_eligible_outputs = 0, num_eligible_known_spent_outputs = 0;
   for (auto i = known_spent_outputs.begin(); i != known_spent_outputs.end(); ++i)
@@ -266,7 +267,7 @@ int main(int argc, char* argv[])
     num_prunable_outputs += i->second;
   }
 
-  db->batch_stop();
+  db_txn.commit();
 
   MINFO("Total outputs: " << num_total_outputs);
   MINFO("Known spent outputs: " << num_known_spent_outputs);

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -31,6 +31,7 @@
 
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "blockchain_db/blockchain_db.h"
+#include "blockchain_db/locked_txn.h"
 #include "hardfork.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -201,10 +202,10 @@ uint8_t HardFork::get_block_version(uint64_t height) const
 bool HardFork::reorganize_from_block_height(uint64_t height)
 {
   CRITICAL_REGION_LOCAL(lock);
+  LockedTXN db_txn(db);
+
   if (height >= db.height())
     return false;
-
-  bool stop_batch = db.batch_start();
 
   versions.clear();
 
@@ -232,8 +233,7 @@ bool HardFork::reorganize_from_block_height(uint64_t height)
     add(db.get_block_from_height(h), h);
   }
 
-  if (stop_batch)
-    db.batch_stop();
+  db_txn.commit();
 
   return true;
 }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -94,7 +94,6 @@ Blockchain::Blockchain(tx_memory_pool& tx_pool) :
   m_difficulty_for_next_block_top_hash(crypto::null_hash),
   m_difficulty_for_next_block(1),
   m_btc_valid(false),
-  m_batch_success(true),
   m_prepare_height(0)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
@@ -342,7 +341,6 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
     block bl;
     block_verification_context bvc = {};
     generate_genesis_block(bl, get_config(m_nettype).GENESIS_TX, get_config(m_nettype).GENESIS_NONCE);
-    db_wtxn_guard wtxn_guard(m_db);
     add_new_block(bl, bvc);
     CHECK_AND_ASSERT_MES(!bvc.m_verifivation_failed, false, "Failed to add genesis block to blockchain");
   }
@@ -532,14 +530,11 @@ bool Blockchain::deinit()
 }
 //------------------------------------------------------------------
 // This function removes blocks from the top of blockchain.
-// It starts a batch and calls private method pop_block_from_blockchain().
 void Blockchain::pop_blocks(uint64_t nblocks, const bool keep_txs)
 {
   uint64_t i = 0;
   CRITICAL_REGION_LOCAL(m_tx_pool);
   CRITICAL_REGION_LOCAL1(m_blockchain_lock);
-
-  bool stop_batch = m_db->batch_start();
 
   try
   {
@@ -555,15 +550,10 @@ void Blockchain::pop_blocks(uint64_t nblocks, const bool keep_txs)
   catch (const std::exception& e)
   {
     LOG_ERROR("Error when popping blocks after processing " << i << " blocks: " << e.what());
-    if (stop_batch)
-      m_db->batch_abort();
     return;
   }
 
   CHECK_AND_ASSERT_THROW_MES(update_next_cumulative_weight_limit(), "Error updating next cumulative weight limit");
-
-  if (stop_batch)
-    m_db->batch_stop();
 
   if (m_hardfork->get_current_version() >= RX_BLOCK_VERSION)
   {
@@ -724,7 +714,6 @@ bool Blockchain::reset_and_set_genesis_block(const block& b)
   m_db->drop_alt_blocks();
   m_hardfork->init();
 
-  db_wtxn_guard wtxn_guard(m_db);
   block_verification_context bvc = {};
   add_new_block(b, bvc);
   if (!update_next_cumulative_weight_limit())
@@ -4288,7 +4277,6 @@ leave:
     catch (const KEY_IMAGE_EXISTS& e)
     {
       LOG_ERROR("Error adding block with hash: " << id << " to blockchain, what = " << e.what());
-      m_batch_success = false;
       bvc.m_verifivation_failed = true;
       return_txs_to_pool();
       return false;
@@ -4297,7 +4285,6 @@ leave:
     {
       //TODO: figure out the best way to deal with this failure
       LOG_ERROR("Error adding block with hash: " << id << " to blockchain, what = " << e.what());
-      m_batch_success = false;
       bvc.m_verifivation_failed = true;
       return_txs_to_pool();
       return false;
@@ -4498,7 +4485,7 @@ bool Blockchain::add_new_block(const block& bl, block_verification_context& bvc,
   crypto::hash id = get_block_hash(bl);
   CRITICAL_REGION_LOCAL(m_tx_pool);//to avoid deadlock lets lock tx_pool for whole add/reorganize process
   CRITICAL_REGION_LOCAL1(m_blockchain_lock);
-  db_rtxn_guard rtxn_guard(m_db);
+  db_wtxn_guard wtxn_guard(m_db);
   int where = 0;
   if(have_block(id, &where))
   {
@@ -4510,18 +4497,23 @@ bool Blockchain::add_new_block(const block& bl, block_verification_context& bvc,
   }
 
   //check that block refers to chain tail
+  bool block_handle_res = false;
   if(!(bl.prev_id == get_tail_id()))
   {
     //chain switching or wrong block
     bvc.m_added_to_main_chain = false;
-    rtxn_guard.stop();
-    return handle_alternative_block(bl, id, bvc, extra_block_txs);
+    block_handle_res = handle_alternative_block(bl, id, bvc, extra_block_txs);
     //never relay alternative blocks
   }
+  else
+  {
+    block_handle_res = handle_block_to_main_chain(bl, id, bvc, extra_block_txs);
+  }
 
-  rtxn_guard.stop();
-  return handle_block_to_main_chain(bl, id, bvc, extra_block_txs);
+  if (block_handle_res)
+    wtxn_guard.stop();
 
+  return block_handle_res;
   }
   catch (const std::exception &e)
   {
@@ -4536,10 +4528,8 @@ bool Blockchain::add_new_block(const block& bl, block_verification_context& bvc,
 void Blockchain::check_against_checkpoints(const checkpoints& points, bool enforce)
 {
   const auto& pts = points.get_points();
-  bool stop_batch;
 
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
-  stop_batch = m_db->batch_start();
   const uint64_t blockchain_height = m_db->height();
   for (const auto& pt : pts)
   {
@@ -4564,8 +4554,6 @@ void Blockchain::check_against_checkpoints(const checkpoints& points, bool enfor
       }
     }
   }
-  if (stop_batch)
-    m_db->batch_stop();
 }
 //------------------------------------------------------------------
 // returns false if any of the checkpoints loading returns false.
@@ -4633,33 +4621,11 @@ void Blockchain::block_longhash_worker(uint64_t height, const epee::span<const b
 //------------------------------------------------------------------
 bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)
 {
-  bool success = false;
-
   MTRACE("Blockchain::" << __func__);
   CRITICAL_REGION_BEGIN(m_blockchain_lock);
   TIME_MEASURE_START(t1);
 
-  try
-  {
-    if (m_batch_success)
-    {
-      m_db->batch_stop();
-      if (m_reset_timestamps_and_difficulties_height)
-      {
-        m_timestamps_and_difficulties_height = 0;
-        m_reset_timestamps_and_difficulties_height = false;
-      }
-    }
-    else
-      m_db->batch_abort();
-    success = true;
-  }
-  catch (const std::exception &e)
-  {
-    MERROR("Exception in cleanup_handle_incoming_blocks: " << e.what());
-  }
-
-  if (success && m_sync_counter > 0)
+  if (m_sync_counter > 0)
   {
     if (force_sync)
     {
@@ -4704,7 +4670,7 @@ bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)
 
   update_blockchain_pruning();
 
-  return success;
+  return true;
 }
 
 //------------------------------------------------------------------
@@ -4867,7 +4833,6 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
 {
   MTRACE("Blockchain::" << __func__);
   TIME_MEASURE_START(prepare);
-  bool stop_batch;
   uint64_t bytes = 0;
   size_t total_txs = 0;
   blocks.clear();
@@ -4902,14 +4867,6 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
     total_txs += entry.txs.size();
   }
   m_bytes_to_sync += bytes;
-  while (!(stop_batch = m_db->batch_start(blocks_entry.size(), bytes))) {
-    m_blockchain_lock.unlock();
-    m_tx_pool.unlock();
-    epee::misc_utils::sleep_no_w(1000);
-    m_tx_pool.lock();
-    m_blockchain_lock.lock();
-  }
-  m_batch_success = true;
 
   const uint64_t height = m_db->height();
   if ((height + blocks_entry.size()) < m_blocks_hash_check.size())
@@ -5208,16 +5165,6 @@ void Blockchain::prepare_handle_incoming_block_no_preprocess(const size_t block_
   // increment sync byte counter to trigger sync against database backing store
   // later in cleanup_handle_incoming_blocks()
   m_bytes_to_sync += block_byte_estimate;
-
-  // spin until we start a batch
-  while (!m_db->batch_start(1, block_byte_estimate)) {
-    m_blockchain_lock.unlock();
-    m_tx_pool.unlock();
-    epee::misc_utils::sleep_no_w(1000);
-    m_tx_pool.lock();
-    m_blockchain_lock.lock();
-  }
-  m_batch_success = true;
 }
 
 void Blockchain::add_txpool_tx(const crypto::hash &txid, const cryptonote::blobdata &blob, const txpool_tx_meta_t &meta)

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1242,9 +1242,6 @@ namespace cryptonote
     uint64_t m_btc_seed_height;
     bool m_btc_valid;
 
-
-    bool m_batch_success;
-
     TxpoolNotifyCallback m_txpool_notifier;
     mutable std::mutex m_txpool_notifier_mutex;
 

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -794,7 +794,6 @@ inline bool do_replay_events_get_core(std::vector<test_event_entry>& events, cry
     MERROR("Failed to init core");
     return false;
   }
-  c.get_blockchain_storage().get_db().set_batch_transactions(true);
 
   // start with a clean pool
   std::vector<crypto::hash> pool_txs;

--- a/tests/fuzz/fuzz_rpc/initialisation.cpp
+++ b/tests/fuzz/fuzz_rpc/initialisation.cpp
@@ -289,8 +289,6 @@ bool generate_random_blocks(cryptonote::core& core, FuzzedDataProvider& provider
     }
   }
 
-  core.get_blockchain_storage().get_db().batch_start();
-
   bool added_block = false;
   for (const auto& blk : cached_blocks) {
     cryptonote::block_verification_context bvc{};

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -29,6 +29,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include "gtest/gtest.h"
+#include "blockchain_db/locked_txn.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "p2p/net_node.h"
 #include "p2p/net_node.inl"
@@ -846,7 +847,7 @@ TEST(cryptonote_protocol_handler, race_condition)
     const block_t &block,
     const stat::chain &stat
   ){
-    core.get_blockchain_storage().get_db().batch_start({}, {});
+    cryptonote::LockedTXN db_txn(core.get_blockchain_storage().get_db());
     core.get_blockchain_storage().get_db().add_block(
       {block, cryptonote::block_to_blob(block)},
       cryptonote::get_transaction_weight(block.miner_tx),
@@ -857,7 +858,7 @@ TEST(cryptonote_protocol_handler, race_condition)
       stat.reward,
       {}
     );
-    core.get_blockchain_storage().get_db().batch_stop();
+    db_txn.commit();
   };
   struct messages {
     struct core {


### PR DESCRIPTION
This PR removes blockchain database batching, a process where multiple blocks are added to the database in one write transaction. This removes a lot of code and simplifies logic. Performance testing TBD, though my hypothesis is that no noticeable effect will occur on most platforms, unless using safe sync mode with a HDD. 