### PR TITLE
epee: ensure is_file_exist doesn't throw

### DIFF
--- a/contrib/epee/src/file_io_utils.cpp
+++ b/contrib/epee/src/file_io_utils.cpp
@@ -63,8 +63,15 @@ namespace file_io_utils
  
 	bool is_file_exist(const std::string& path)
 	{
-		boost::filesystem::path p(path);
-		return boost::filesystem::exists(p);
+		try
+		{
+			boost::filesystem::path p(path);
+			return boost::filesystem::exists(p);
+		}
+		catch (...)
+		{
+			return false;
+		}
 	}
 
 


### PR DESCRIPTION
Similar functions to this one do not throw, and every caller seems to assume this one doesn't.

Possibly related: #8151