### PR TITLE
p2p: don't reset timeout timer for handshakes

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -269,6 +269,8 @@ public:
     }
     virtual bool reset_timer(bool first) override final
     {
+      if (m_command == connection_context::handshake_command() && !first)
+        return true;
       std::shared_ptr<anvoke_handler> self;
       if (!m_cancel_timer_called && (self = this->weak_from_this().lock()) && (first || m_timer.cancel() > 0))
       {


### PR DESCRIPTION
The handshake timeout should just be an absolute timeout, we don't care about partial messages received during the handshake.