### PR TITLE
daemon: fix yearly mining estimate

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -594,7 +594,7 @@ bool t_rpc_command_executor::mining_status() {
     double ratio = mres.speed * mres.block_target / (double)mres.difficulty;
     uint64_t daily = 86400ull / mres.block_target * mres.block_reward * ratio;
     uint64_t monthly = 86400ull / mres.block_target * 30.5 * mres.block_reward * ratio;
-    uint64_t yearly = 86400ull / mres.block_target * 356 * mres.block_reward * ratio;
+    uint64_t yearly = 86400ull / mres.block_target * 365 * mres.block_reward * ratio;
     tools::msg_writer() << "Expected: " << cryptonote::print_money(daily) << " monero daily, "
         << cryptonote::print_money(monthly) << " monero monthly, " << cryptonote::print_money(yearly) << " yearly";
   }


### PR DESCRIPTION
`mining_status` currently uses 356 days for its yearly income estimate, which makes the displayed value about 2.5% too low

this changes it to 365 days, matching the existing blocks-per-year calculation in `wallet2`

tests:
- `cmake --build build --target daemon unit_tests -j2`
- `cmake --build build --target test_notifier -j2`
- `build/tests/unit_tests/unit_tests --gtest_color=no` (1296 passed, 2 skipped)
