### PR TITLE
checkpoints: exclude equal height in get_nearest_checkpoint_height

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -163,7 +163,7 @@ namespace cryptonote
     if (m_points.empty())
       return 0;
 
-    auto it = m_points.upper_bound(block_height);
+    auto it = m_points.lower_bound(block_height);
     if (it == m_points.begin())
       return 0;
 

--- a/tests/unit_tests/checkpoints.cpp
+++ b/tests/unit_tests/checkpoints.cpp
@@ -164,3 +164,21 @@ TEST(checkpoints_is_alternative_block_allowed, handles_two_and_more_checkpoints)
   ASSERT_TRUE (cp.is_alternative_block_allowed(11, 10));
   ASSERT_TRUE (cp.is_alternative_block_allowed(11, 11));
 }
+
+TEST(checkpoints_get_nearest_checkpoint_height, returns_nearest_checkpoint_below_height)
+{
+  checkpoints cp;
+
+  ASSERT_EQ(0, cp.get_nearest_checkpoint_height(7));
+
+  ASSERT_TRUE(cp.add_checkpoint(5, "0000000000000000000000000000000000000000000000000000000000000000"));
+  ASSERT_TRUE(cp.add_checkpoint(9, "0000000000000000000000000000000000000000000000000000000000000000"));
+
+  ASSERT_EQ(0, cp.get_nearest_checkpoint_height(0));
+  ASSERT_EQ(0, cp.get_nearest_checkpoint_height(4));
+  ASSERT_EQ(0, cp.get_nearest_checkpoint_height(5));
+  ASSERT_EQ(5, cp.get_nearest_checkpoint_height(6));
+  ASSERT_EQ(5, cp.get_nearest_checkpoint_height(9));
+  ASSERT_EQ(9, cp.get_nearest_checkpoint_height(10));
+  ASSERT_EQ(9, cp.get_nearest_checkpoint_height(11));
+}


### PR DESCRIPTION
Restoring a wallet exactly at a checkpoint height skipped the fast_refresh anchor and hash-synced from genesis.

Release PR: https://github.com/monero-project/monero/pull/10856