### PR TITLE
p2p: add option to exempt local addresses from bans and restrictions

### DIFF
--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -134,7 +134,7 @@ namespace nodetool
       };
 
     const command_line::arg_descriptor<uint32_t>    arg_p2p_external_port  = {"p2p-external-port", "External port for p2p network protocol (if port forwarding used with NAT)", 0};
-    const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip = {"allow-local-ip", "Allow local ip add to peer list, mostly in debug purposes"};
+    const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip = {"allow-local-ip", "Allow local ip add to peer list, mostly in debug purposes. Also exempts local IPv4/IPv6 addresses from blocking and banning"};
     const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_peer   = {"add-peer", "Manually add peer to local peerlist"};
     const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_priority_node   = {"add-priority-node", "Specify list of peers to connect to and attempt to keep the connection open"};
     const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_exclusive_node   = {"add-exclusive-node", "Specify list of peers to connect to only."

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -265,6 +265,14 @@ namespace nodetool
   template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::is_remote_host_allowed(const epee::net_utils::network_address &address, time_t *t)
   {
+    if (m_allow_local_ip && (address.is_local() || address.is_loopback()) &&
+        (address.get_type_id() == epee::net_utils::ipv4_network_address::get_type_id() ||
+         address.get_type_id() == epee::net_utils::ipv6_network_address::get_type_id()))
+    {
+      MDEBUG("Local address " << address.host_str() << " is exempt from blocking/banning (--" << arg_p2p_allow_local_ip.name << ")");
+      return true;
+    }
+
     CRITICAL_REGION_LOCAL(m_blocked_hosts_lock);
 
     const time_t now = time(nullptr);

--- a/utils/fish/monerod.fish
+++ b/utils/fish/monerod.fish
@@ -61,7 +61,7 @@ complete -c monerod -l p2p-bind-port-ipv6 -d "Port for p2p network protocol (IPv
 complete -c monerod -l p2p-use-ipv6 -d "Enable IPv6 for p2p"
 complete -c monerod -l p2p-ignore-ipv4 -d "Ignore unsuccessful IPv4 bind for p2p"
 complete -c monerod -l p2p-external-port -r -d "External port for p2p network protocol (if port forwarding used with NAT). Default: 0"
-complete -c monerod -l allow-local-ip -d "Allow local ip add to peer list, mostly in debug purposes"
+complete -c monerod -l allow-local-ip -d "Allow local ip add to peer list, mostly in debug purposes. Also exempts local IPv4/IPv6 addresses from blocking and banning"
 complete -c monerod -l add-peer -r -d "Manually add peer to local peerlist"
 complete -c monerod -l add-priority-node -r -d "Specify list of peers to connect to and attempt to keep the connection open"
 complete -c monerod -l add-exclusive-node -r -d "Specify list of peers to connect to only. If this option is given the options add-priority-node and seed-node are ignored"


### PR DESCRIPTION
Continuation of #9929, with functionality gated behind the `--allow-local-ip` option.

Fixes #9928