### PR TITLE
rpc, p2p: remove pay-to-use RPC leftovers

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -241,7 +241,6 @@ namespace nodetool
       : m_payload_handler(payload_handler),
         m_external_port(0),
         m_rpc_port(0),
-        m_rpc_credits_per_hash(0),
         m_allow_local_ip(false),
         m_hide_my_port(false),
         m_offline(false),
@@ -426,7 +425,6 @@ namespace nodetool
     uint32_t m_listening_port_ipv6;
     uint32_t m_external_port;
     uint16_t m_rpc_port;
-    uint32_t m_rpc_credits_per_hash;
     bool m_allow_local_ip;
     bool m_hide_my_port;
     bool m_offline;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2389,7 +2389,7 @@ namespace nodetool
     else
       node_data.my_port = 0;
     node_data.rpc_port = zone.m_can_pingback ? m_rpc_port : 0;
-    node_data.rpc_credits_per_hash = zone.m_can_pingback ? m_rpc_credits_per_hash : 0;
+    node_data.rpc_credits_per_hash = 0;
     node_data.network_id = m_network_id;
     node_data.support_flags = zone.m_config.m_support_flags;
     return true;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -65,9 +65,6 @@ using namespace epee;
 
 #define OUTPUT_HISTOGRAM_RECENT_CUTOFF_RESTRICTION (3 * 86400) // 3 days max, the wallet requests 1.8 days
 
-#define DEFAULT_PAYMENT_DIFFICULTY 1000
-#define DEFAULT_PAYMENT_CREDITS_PER_HASH 100
-
 #define RESTRICTED_BLOCK_HEADER_RANGE 1000
 #define RESTRICTED_TRANSACTIONS_COUNT 100
 #define RESTRICTED_SPENT_KEY_IMAGES_COUNT 5000
@@ -75,51 +72,10 @@ using namespace epee;
 
 static constexpr size_t GET_BLOCKS_BIN_MAX_ADDED_POOL_TX_BODIES = 20000;
 
-#define RPC_TRACKER(rpc) \
-  PERF_TIMER(rpc); \
-  RPCTracker tracker(#rpc, PERF_TIMER_NAME(rpc))
+#define RPC_TRACKER(rpc) PERF_TIMER(rpc)
 
 namespace
 {
-  class RPCTracker
-  {
-  public:
-    struct entry_t
-    {
-      uint64_t count;
-      uint64_t time;
-      uint64_t credits;
-    };
-
-    RPCTracker(const char *rpc, tools::LoggingPerformanceTimer &timer): rpc(rpc), timer(timer) {
-    }
-    ~RPCTracker() {
-      try
-      {
-        boost::unique_lock<boost::mutex> lock(mutex);
-        auto &e = tracker[rpc];
-        ++e.count;
-        e.time += timer.value();
-      }
-      catch (...) { /* ignore */ }
-    }
-    void pay(uint64_t amount) {
-      boost::unique_lock<boost::mutex> lock(mutex);
-      auto &e = tracker[rpc];
-      e.credits += amount;
-    }
-    const std::string &rpc_name() const { return rpc; }
-    static void clear() { boost::unique_lock<boost::mutex> lock(mutex); tracker.clear(); }
-    static std::unordered_map<std::string, entry_t> data() { boost::unique_lock<boost::mutex> lock(mutex); return tracker; }
-  private:
-    std::string rpc;
-    tools::LoggingPerformanceTimer &timer;
-    static boost::mutex mutex;
-    static std::unordered_map<std::string, entry_t> tracker;
-  };
-  boost::mutex RPCTracker::mutex;
-  std::unordered_map<std::string, RPCTracker::entry_t> RPCTracker::tracker;
-
   void add_reason(std::string &reasons, const char *reason)
   {
     if (!reasons.empty())


### PR DESCRIPTION
- `DEFAULT_PAYMENT_DIFFICULTY` / `DEFAULT_PAYMENT_CREDITS_PER_HASH`: unreferenced since the `--rpc-payment-*` options went.
- `RPCTracker`: `data()` was its only reader, so the map has been write-only since #10578, while the dtor still takes a mutex on every tracked RPC call. `RPC_TRACKER()` kept as a `PERF_TIMER()` alias so its 63 call sites stay untouched.
- `node_server::m_rpc_credits_per_hash`: setter's last caller went in #10578, the setter itself in 8d76584d0, so it can only hold 0. Explicit `= 0` kept because `basic_node_data` has no default member initialisers.

Left alone - follow-ups:
1. `rpc_access_request_base::client` and `rpc_access_response_base::{credits, top_hash}`: never written or read, but visible in the 28 commands inheriting each base, so it needs a `CORE_RPC_VERSION` minor bump. Both structs then collapse onto `rpc_request_base` / `rpc_response_base`.
2. `CORE_RPC_ERROR_CODE_PAYMENT_REQUIRED`, `CORE_RPC_ERROR_CODE_INVALID_CLIENT`, `CORE_RPC_STATUS_PAYMENT_REQUIRED`: no node path emits them, only wallet back-compat reads them.
3. `rpc_credits_per_hash` itself (49 lines, 12 files): `VARINT_FIELD` in `peerlist_entry_base`, so retiring it changes P2P and `peers.bin` serialisation.