### PR TITLE
wallet: avoid stale daemon calls during tx build

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9490,6 +9490,9 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
         chunk_req.outputs.push_back(req.outputs[offset + i]);
 
       const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex};
+      // Ring member selection above may outlive short remote keep-alive windows.
+      if (offset == 0)
+        m_http_client->disconnect();
       bool r = epee::net_utils::invoke_http_bin("/get_outs.bin", chunk_req, chunk_daemon_resp, *m_http_client, rpc_timeout);
       THROW_ON_RPC_RESPONSE_ERROR(r, {}, chunk_daemon_resp, "get_outs.bin", error::get_outs_error, get_rpc_status(m_trusted_daemon, chunk_daemon_resp.status));
       THROW_WALLET_EXCEPTION_IF(chunk_daemon_resp.outs.size() != chunk_req.outputs.size(), error::wallet_internal_error,
@@ -10088,11 +10091,8 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
   ptx.construction_data.extra = tx.extra;
   ptx.construction_data.unlock_time = 0;
   ptx.construction_data.use_rct = true;
-  ptx.construction_data.rct_config = {
-    rct::RangeProofPaddedBulletproof,
-    use_fork_rules(HF_VERSION_BULLETPROOF_PLUS, -10) ? 4 : 3
-  };
-  ptx.construction_data.use_view_tags = use_fork_rules(get_view_tag_fork(), 0);
+  ptx.construction_data.rct_config = rct_config;
+  ptx.construction_data.use_view_tags = use_view_tags;
   ptx.construction_data.dests = dsts;
   // record which subaddress indices are being used as inputs
   ptx.construction_data.subaddr_account = subaddr_account;


### PR DESCRIPTION
## Context

This is the stale-daemon portion split from #10940 following the maintainer's
recommendation. The EOF handling fix and its regression test remain in #10940.

During transaction creation, local ring-member selection can take longer than
short remote-daemon keep-alive windows. The first subsequent `/get_outs.bin`
request can therefore reuse a socket that the daemon has already closed.

## Changes

- disconnect once before the first `/get_outs.bin` chunk, after local ring
  member selection, so the request reconnects lazily;
- reuse the `rct_config` and `use_view_tags` values already used to construct
  the transaction instead of querying fork rules again after proof generation.

## Impact

The patch is limited to transaction construction. It does not retry or replay
a failed request, switch nodes, or change the `sendrawtransaction` path.

## Validation

- cleanly cherry-picked onto current `master`;
- `git diff --check` passes;
- the same commit previously passed all 18 upstream CI checks as part of
  #10940; the new PR CI is the authoritative check for the split branch.

Related downstream report: https://github.com/haveno-dex/haveno/issues/1093
