### PR TITLE
epee: rearm idle handlers after exceptions

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -56,6 +56,7 @@
 #include <boost/optional.hpp>
 #include "byte_slice.h"
 #include "net_utils_base.h"
+#include "scope_guard.h"
 #include "syncobj.h"
 #include "connection_basic.hpp"
 #include "network_throttle-detail.hpp"
@@ -495,10 +496,16 @@ namespace net_utils
     bool global_timer_handler(/*const boost::system::error_code& err, */std::shared_ptr<idle_callback_conext<t_handler>> ptr)
     {
       //if handler return false - he don't want to be called anymore
+      epee::unique_scope_guard rearm_timer = [this, &ptr]() {
+        ptr->m_timer.expires_after(ptr->m_period);
+        ptr->m_timer.async_wait(boost::bind(&boosted_tcp_server<t_protocol_handler>::global_timer_handler<t_handler>, this, ptr));
+      };
       if(!ptr->call_handler())
+      {
+        rearm_timer.release();
         return true;
-      ptr->m_timer.expires_after(ptr->m_period);
-      ptr->m_timer.async_wait(boost::bind(&boosted_tcp_server<t_protocol_handler>::global_timer_handler<t_handler>, this, ptr));
+      }
+      rearm_timer.reset();
       return true;
     }
 

--- a/tests/unit_tests/epee_boosted_tcp_server.cpp
+++ b/tests/unit_tests/epee_boosted_tcp_server.cpp
@@ -139,6 +139,42 @@ TEST(boosted_tcp_server, worker_threads_are_exception_resistant)
   ASSERT_TRUE(srv.deinit_server());
 }
 
+TEST(boosted_tcp_server, idle_handlers_are_exception_resistant)
+{
+  test_tcp_server srv(epee::net_utils::e_connection_type_RPC);
+  ASSERT_TRUE(srv.init_server(0, test_server_host));
+
+  boost::mutex mtx;
+  boost::condition_variable cond;
+  unsigned int calls = 0;
+
+  ASSERT_TRUE(srv.add_idle_handler([&]() {
+    boost::unique_lock<boost::mutex> lock(mtx);
+    ++calls;
+    cond.notify_one();
+    if (calls == 1)
+      throw std::runtime_error("test");
+    return false;
+  }, std::chrono::milliseconds{10}));
+  ASSERT_TRUE(srv.run_server(1, false));
+
+  bool retried = false;
+  {
+    boost::unique_lock<boost::mutex> lock(mtx);
+    retried = cond.wait_for(lock, boost::chrono::seconds(5), [&calls] { return calls == 2; });
+  }
+  EXPECT_TRUE(retried);
+
+  boost::this_thread::sleep_for(boost::chrono::milliseconds{50});
+  {
+    boost::unique_lock<boost::mutex> lock(mtx);
+    EXPECT_EQ(2u, calls);
+  }
+
+  srv.send_stop_signal();
+  ASSERT_TRUE(srv.timed_wait_server_stop(5 * 1000));
+  ASSERT_TRUE(srv.deinit_server());
+}
 
 TEST(test_epee_connection, test_lifetime)
 {


### PR DESCRIPTION
an exception from an idle callback currently unwinds before its timer is rearmed. the worker thread survives and resumes its io_context, but that callback is never scheduled again

this rearms the timer before rethrowing, preserving the existing exception handling while keeping the idle callback scheduled. callbacks that return false still stop normally

the regression test fails on master after the first callback and passes with this change

refs #11059

tests:
- release build with `BUILD_TESTS=ON`, `BUILD_GUI_DEPS=ON`, and `ENABLE_FUZZ_TEST=ON`
- `ctest --test-dir build --output-on-failure -E core_tests` (23/23)
- `ctest --test-dir build --output-on-failure -R core_tests` (1/1)
- regression test repeated 50 times