### PR TITLE
txpool: allow 0-fee transactions received from RPC with `do_not_relay` set (but nothing else 0-fee)

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -170,7 +170,8 @@ struct txpool_tx_meta_t
   uint8_t is_local: 1;
   uint8_t dandelionpp_stem : 1;
   uint8_t is_forwarding: 1;
-  uint8_t bf_padding: 3;
+  uint8_t received_via_rpc: 1;
+  uint8_t bf_padding: 2;
 
   uint8_t padding[44]; // til 160 bytes
 

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -174,7 +174,7 @@ int check_flush(cryptonote::core &core, std::vector<block_complete_entry> &block
       tx_verification_context tvc = AUTO_VAL_INIT(tvc);
       CHECK_AND_ASSERT_THROW_MES(tx_blob.prunable_hash == crypto::null_hash,
         "block entry must not contain pruned txs");
-      core.handle_incoming_tx(tx_blob.blob, tvc, relay_method::block, true);
+      core.handle_incoming_tx(tx_blob.blob, tvc, relay_method::block, true, false);
       if(tvc.m_verifivation_failed)
       {
         cryptonote::transaction transaction;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -766,7 +766,7 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::handle_incoming_tx(const blobdata& tx_blob, tx_verification_context& tvc, relay_method tx_relay, bool relayed)
+  bool core::handle_incoming_tx(const blobdata& tx_blob, tx_verification_context& tvc, relay_method tx_relay, bool relayed, bool received_via_rpc)
   {
     tvc = {};
 
@@ -792,7 +792,7 @@ namespace cryptonote
     }
 
     const uint64_t tx_weight = get_transaction_weight(tx, tx_blob.size());
-    if (!add_new_tx(tx, txid, tx_blob, tx_weight, tvc, tx_relay, relayed))
+    if (!add_new_tx(tx, txid, tx_blob, tx_weight, tvc, tx_relay, relayed, received_via_rpc))
       return false;
 
     if (tvc.m_verifivation_failed)
@@ -1064,13 +1064,13 @@ namespace cryptonote
     return true;
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::add_new_tx(transaction& tx, tx_verification_context& tvc, relay_method tx_relay, bool relayed)
+  bool core::add_new_tx(transaction& tx, tx_verification_context& tvc, relay_method tx_relay, bool relayed, bool received_via_rpc)
   {
     crypto::hash tx_hash = get_transaction_hash(tx);
     blobdata bl;
     t_serializable_object_to_blob(tx, bl);
     size_t tx_weight = get_transaction_weight(tx, bl.size());
-    return add_new_tx(tx, tx_hash, bl, tx_weight, tvc, tx_relay, relayed);
+    return add_new_tx(tx, tx_hash, bl, tx_weight, tvc, tx_relay, relayed, received_via_rpc);
   }
   //-----------------------------------------------------------------------------------------------
   size_t core::get_blockchain_total_transactions() const
@@ -1078,7 +1078,7 @@ namespace cryptonote
     return m_blockchain_storage.get_total_transactions();
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::add_new_tx(transaction& tx, const crypto::hash& tx_hash, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, relay_method tx_relay, bool relayed)
+  bool core::add_new_tx(transaction& tx, const crypto::hash& tx_hash, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, relay_method tx_relay, bool relayed, bool received_via_rpc)
   {
     if(m_mempool.have_tx(tx_hash, relay_category::legacy))
     {
@@ -1093,7 +1093,7 @@ namespace cryptonote
     }
 
     uint8_t version = m_blockchain_storage.get_current_hard_fork_version();
-    const bool res = m_mempool.add_tx(tx, tx_hash, blob, tx_weight, tvc, tx_relay, relayed, version);
+    const bool res = m_mempool.add_tx(tx, tx_hash, blob, tx_weight, tvc, tx_relay, relayed, version, 0, crypto::null_hash, received_via_rpc);
 
     // If new incoming tx passed verification and entered the pool, notify ZMQ
     if (!tvc.m_verifivation_failed && res && matches_category(tvc.m_relay, relay_category::legacy))

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -123,10 +123,11 @@ namespace cryptonote
       * @param tvc metadata about the transaction's validity
       * @param tx_relay how the transaction was received
       * @param relayed whether or not the transaction was relayed to us
+      * @param received_via_rpc whether the transaction was received through the RPC server
       *
       * @return true if the transaction was accepted, false otherwise
       */
-     bool handle_incoming_tx(const blobdata& tx_blob, tx_verification_context& tvc, relay_method tx_relay, bool relayed);
+     bool handle_incoming_tx(const blobdata& tx_blob, tx_verification_context& tvc, relay_method tx_relay, bool relayed, bool received_via_rpc);
 
     /**
       * @brief handles a single incoming block
@@ -930,9 +931,10 @@ namespace cryptonote
       * @param tx_weight the weight of the transaction
       * @param tx_relay how the transaction was received
       * @param relayed whether or not the transaction was relayed to us
+      * @param received_via_rpc whether the transaction was received through the RPC server
       *
       */
-     bool add_new_tx(transaction& tx, const crypto::hash& tx_hash, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, relay_method tx_relay, bool relayed);
+     bool add_new_tx(transaction& tx, const crypto::hash& tx_hash, const cryptonote::blobdata &blob, size_t tx_weight, tx_verification_context& tvc, relay_method tx_relay, bool relayed, bool received_via_rpc);
 
      /**
       * @brief add a new transaction to the transaction pool
@@ -943,12 +945,13 @@ namespace cryptonote
       * @param tvc return-by-reference metadata about the transaction's verification process
       * @param tx_relay how the transaction was received
       * @param relayed whether or not the transaction was relayed to us
+      * @param received_via_rpc whether the transaction was received through the RPC server
       *
       * @return true if the transaction is already in the transaction pool,
       * is already in a block on the Blockchain, or is successfully added
       * to the transaction pool
       */
-     bool add_new_tx(transaction& tx, tx_verification_context& tvc, relay_method tx_relay, bool relayed);
+     bool add_new_tx(transaction& tx, tx_verification_context& tvc, relay_method tx_relay, bool relayed, bool received_via_rpc);
 
      /**
       * @copydoc Blockchain::add_new_block

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -138,7 +138,7 @@ namespace cryptonote
     const crypto::hash &id, const cryptonote::blobdata &blob, size_t tx_weight,
     tx_verification_context& tvc, relay_method tx_relay, bool relayed,
     uint8_t version, uint8_t nic_verified_hf_version,
-    const crypto::hash &valid_input_verification_id)
+    const crypto::hash &valid_input_verification_id, bool received_via_rpc)
   {
     const bool kept_by_block = (tx_relay == relay_method::block);
 
@@ -171,7 +171,7 @@ namespace cryptonote
       // get_tx_fee() can throw. It shouldn't throw because we check preconditions in
       // ver_non_input_consensus(), but let's put it in a try block just in case.
       fee = get_tx_fee(tx);
-      fee_good = kept_by_block || m_blockchain.check_fee(tx_weight, fee);
+      fee_good = kept_by_block || (received_via_rpc && tx_relay == relay_method::none) || m_blockchain.check_fee(tx_weight, fee);
     }
     catch(...) {}
     if (!fee_good) // if fee calculation failed or fee in relayed tx is too low...
@@ -244,6 +244,7 @@ namespace cryptonote
         meta.last_relayed_time = time(NULL);
         meta.relayed = relayed;
         meta.set_relay_method(tx_relay);
+        meta.received_via_rpc = received_via_rpc;
         meta.double_spend_seen = have_tx_keyimges_as_spent(tx, id);
         meta.pruned = tx.pruned;
         meta.bf_padding = 0;
@@ -320,6 +321,7 @@ namespace cryptonote
           meta.last_failed_height = 0;
           meta.last_failed_id = null_hash;
           meta.relayed = relayed;
+          meta.received_via_rpc = received_via_rpc;
           meta.double_spend_seen = false;
           meta.pruned = tx.pruned;
           meta.bf_padding = 0;
@@ -361,7 +363,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::add_tx(transaction &tx, tx_verification_context& tvc, relay_method tx_relay,
     bool relayed, uint8_t version, uint8_t nic_verified_hf_version,
-    const crypto::hash &valid_input_verification_id)
+    const crypto::hash &valid_input_verification_id, bool received_via_rpc)
   {
     crypto::hash h = null_hash;
     cryptonote::blobdata bl;
@@ -369,7 +371,7 @@ namespace cryptonote
     if (bl.size() == 0 || !get_transaction_hash(tx, h))
       return false;
     return add_tx(tx, h, bl, get_transaction_weight(tx, bl.size()), tvc, tx_relay, relayed, version,
-      nic_verified_hf_version, valid_input_verification_id);
+      nic_verified_hf_version, valid_input_verification_id, received_via_rpc);
   }
   //---------------------------------------------------------------------------------
   void tx_memory_pool::reduce_txpool_weight(size_t weight)
@@ -1308,6 +1310,7 @@ namespace cryptonote
       txi.weight = meta.weight;
       txi.fee = meta.fee;
       txi.kept_by_block = meta.kept_by_block;
+      txi.received_via_rpc = meta.received_via_rpc;
       txi.max_used_block_height = meta.max_used_block_height;
       txi.max_used_block_hash = meta.max_used_block_id;
       txi.last_failed_block_height = meta.last_failed_height;
@@ -1801,7 +1804,7 @@ namespace cryptonote
         cryptonote::tx_verification_context tvc{};
         relay_method tx_relay = e.meta.get_relay_method();
         if (!add_tx(tx, e.txid, blob, e.meta.weight, tvc, tx_relay, relayed, version,
-          /*nic_verified_hf_version=*/0, valid_input_verification_id))
+          /*nic_verified_hf_version=*/0, valid_input_verification_id, e.meta.received_via_rpc))
         {
           MINFO("Failed to re-validate tx " << e.txid << " for v" << (unsigned)version << ", dropped");
           continue;

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -104,13 +104,14 @@ namespace cryptonote
      * @tx_relay how the transaction was received
      * @param tx_weight the transaction's weight
      * @param valid_input_verification_id a previously valid verID if non-null
+     * @param received_via_rpc whether the transaction was received through the RPC server
      * @return True if tx passes verification checks AND is first observation
      *   of tx in `broadcasted` relay method.
      */
     bool add_tx(transaction &tx, const crypto::hash &id, const cryptonote::blobdata &blob,
       size_t tx_weight, tx_verification_context& tvc, relay_method tx_relay, bool relayed,
       uint8_t version, uint8_t nic_verified_hf_version = 0,
-      const crypto::hash &valid_input_verification_id = crypto::null_hash);
+      const crypto::hash &valid_input_verification_id = crypto::null_hash, bool received_via_rpc = false);
 
     /**
      * @brief add a transaction to the transaction pool
@@ -127,6 +128,7 @@ namespace cryptonote
      * @param version the version used to create the transaction
      * @param nic_verified_hf_version hard fork which "tx" is known to pass non-input consensus test
      * @param valid_input_verification_id a previously valid verID if non-null
+     * @param received_via_rpc whether the transaction was received through the RPC server
      *
      * If "nic_verified_hf_version" parameter is equal to "version" parameter, then we skip the
      * asserting `ver_non_input_consensus(tx)`, which greatly speeds up block popping and returning
@@ -139,7 +141,7 @@ namespace cryptonote
      */
     bool add_tx(transaction &tx, tx_verification_context& tvc, relay_method tx_relay, bool relayed,
       uint8_t version, uint8_t nic_verified_hf_version = 0,
-      const crypto::hash &valid_input_verification_id = crypto::null_hash);
+      const crypto::hash &valid_input_verification_id = crypto::null_hash, bool received_via_rpc = false);
 
     /**
      * @brief takes a transaction with the given hash from the pool

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -971,7 +971,7 @@ namespace cryptonote
     for (auto& tx : arg.txs)
     {
       tx_verification_context tvc{};
-      if (!m_core.handle_incoming_tx(tx, tvc, tx_relay, true) && !tvc.m_no_drop_offense)
+      if (!m_core.handle_incoming_tx(tx, tvc, tx_relay, true, false) && !tvc.m_no_drop_offense)
       {
         LOG_PRINT_CCONTEXT_L1("Tx verification failed, dropping connection");
         drop_connection(context, false, false);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1130,6 +1130,10 @@ namespace cryptonote
       }
       return true;
     }
+    transaction tx;
+    crypto::hash tx_hash;
+    CHECK_AND_ASSERT_MES(parse_and_validate_tx_from_blob(tx_blob, tx, tx_hash), false, "Failed to calculate transaction hash");
+    res.tx_hash = string_tools::pod_to_hex(tx_hash);
 
     if(tvc.m_relay == relay_method::none)
     {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1095,7 +1095,7 @@ namespace cryptonote
     res.sanity_check_failed = false;
 
     tx_verification_context tvc{};
-    if(!m_core.handle_incoming_tx(tx_blob, tvc, (req.do_not_relay ? relay_method::none : relay_method::local), false) || tvc.m_verifivation_failed)
+    if(!m_core.handle_incoming_tx(tx_blob, tvc, (req.do_not_relay ? relay_method::none : relay_method::local), false, true) || tvc.m_verifivation_failed)
     {
       res.status = "Failed";
       std::string reason = "";

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -615,6 +615,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
 
     struct response_t: public rpc_access_response_base
     {
+      std::string tx_hash;
       std::string reason;
       bool not_relayed;
       bool low_mixin;
@@ -631,6 +632,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_access_response_base)
+        KV_SERIALIZE(tx_hash)
         KV_SERIALIZE(reason)
         KV_SERIALIZE(not_relayed)
         KV_SERIALIZE(low_mixin)

--- a/src/rpc/daemon_handler.cpp
+++ b/src/rpc/daemon_handler.cpp
@@ -397,7 +397,7 @@ namespace rpc
 
     tx_verification_context tvc = AUTO_VAL_INIT(tvc);
 
-    if(!m_core.handle_incoming_tx(tx_blob, tvc, (relay ? relay_method::local : relay_method::none), false) || tvc.m_verifivation_failed)
+    if(!m_core.handle_incoming_tx(tx_blob, tvc, (relay ? relay_method::local : relay_method::none), false, false) || tvc.m_verifivation_failed)
     {
       if (tvc.m_verifivation_failed)
       {

--- a/src/rpc/message_data_structs.h
+++ b/src/rpc/message_data_structs.h
@@ -95,6 +95,7 @@ namespace rpc
     crypto::hash max_used_block_hash;
     uint64_t max_used_block_height;
     bool kept_by_block;
+    bool received_via_rpc;
     crypto::hash last_failed_block_hash;
     uint64_t last_failed_block_height;
     uint64_t receive_time;

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -914,6 +914,7 @@ void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::r
   INSERT_INTO_JSON_OBJECT(dest, max_used_block_hash, tx.max_used_block_hash);
   INSERT_INTO_JSON_OBJECT(dest, max_used_block_height, tx.max_used_block_height);
   INSERT_INTO_JSON_OBJECT(dest, kept_by_block, tx.kept_by_block);
+  INSERT_INTO_JSON_OBJECT(dest, received_via_rpc, tx.received_via_rpc);
   INSERT_INTO_JSON_OBJECT(dest, last_failed_block_hash, tx.last_failed_block_hash);
   INSERT_INTO_JSON_OBJECT(dest, last_failed_block_height, tx.last_failed_block_height);
   INSERT_INTO_JSON_OBJECT(dest, receive_time, tx.receive_time);
@@ -940,6 +941,7 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::rpc::tx_in_pool& tx)
   GET_FROM_JSON_OBJECT(val, tx.max_used_block_hash, max_used_block_hash);
   GET_FROM_JSON_OBJECT(val, tx.max_used_block_height, max_used_block_height);
   GET_FROM_JSON_OBJECT(val, tx.kept_by_block, kept_by_block);
+  GET_FROM_JSON_OBJECT(val, tx.received_via_rpc, received_via_rpc);
   GET_FROM_JSON_OBJECT(val, tx.last_failed_block_hash, last_failed_block_hash);
   GET_FROM_JSON_OBJECT(val, tx.last_failed_block_height, last_failed_block_height);
   GET_FROM_JSON_OBJECT(val, tx.receive_time, receive_time);

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -114,7 +114,8 @@ struct event_visitor_settings
     set_txs_keeped_by_block = 1 << 0,
     set_txs_do_not_relay = 1 << 1,
     set_local_relay = 1 << 2,
-    set_txs_stem = 1 << 3
+    set_txs_stem = 1 << 3,
+    set_txs_received_via_rpc = 1 << 4
   };
 
   event_visitor_settings(int a_mask = 0)
@@ -540,6 +541,7 @@ private:
   size_t m_ev_index;
 
   cryptonote::relay_method m_tx_relay;
+  bool m_received_via_rpc;
 
 public:
   push_core_event_visitor(cryptonote::core& c, const std::vector<test_event_entry>& events, t_test_class& validator)
@@ -548,6 +550,7 @@ public:
     , m_validator(validator)
     , m_ev_index(0)
     , m_tx_relay(cryptonote::relay_method::fluff)
+    , m_received_via_rpc(false)
   {
   }
 
@@ -586,6 +589,7 @@ public:
     {
       m_tx_relay = cryptonote::relay_method::fluff;
     }
+    m_received_via_rpc = settings.mask & event_visitor_settings::set_txs_received_via_rpc;
 
     return true;
   }
@@ -596,7 +600,7 @@ public:
 
     cryptonote::tx_verification_context tvc{};
     size_t pool_size = m_c.get_pool_transactions_count();
-    m_c.handle_incoming_tx(t_serializable_object_to_blob(tx), tvc, m_tx_relay, false);
+    m_c.handle_incoming_tx(t_serializable_object_to_blob(tx), tvc, m_tx_relay, false, m_received_via_rpc);
     bool tx_added = pool_size + 1 == m_c.get_pool_transactions_count();
     bool r = m_validator.check_tx_verification_context(tvc, tx_added, m_ev_index, tx);
     CHECK_AND_NO_ASSERT_MES(r, false, "tx verification context check failed");
@@ -617,7 +621,7 @@ public:
     }
     size_t pool_size = m_c.get_pool_transactions_count();
     for (size_t i = 0; i < tx_blobs.size(); ++i)
-      m_c.handle_incoming_tx(tx_blobs[i], tvcs[i], m_tx_relay, false);
+      m_c.handle_incoming_tx(tx_blobs[i], tvcs[i], m_tx_relay, false, m_received_via_rpc);
     size_t tx_added = m_c.get_pool_transactions_count() - pool_size;
     bool r = m_validator.check_tx_verification_context_array(tvcs, tx_added, m_ev_index, txs);
     CHECK_AND_NO_ASSERT_MES(r, false, "tx verification context check failed");
@@ -695,7 +699,7 @@ public:
 
     cryptonote::tx_verification_context tvc{};
     size_t pool_size = m_c.get_pool_transactions_count();
-    m_c.handle_incoming_tx(sr_tx.data, tvc, m_tx_relay, false);
+    m_c.handle_incoming_tx(sr_tx.data, tvc, m_tx_relay, false, m_received_via_rpc);
     bool tx_added = pool_size + 1 == m_c.get_pool_transactions_count();
 
     cryptonote::transaction tx;

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -162,6 +162,7 @@ int main(int argc, char* argv[])
     // Mempool
     GENERATE_AND_PLAY(txpool_spend_key_public);
     GENERATE_AND_PLAY(txpool_spend_key_all);
+    GENERATE_AND_PLAY(txpool_zero_fee);
     GENERATE_AND_PLAY(txpool_double_spend_norelay);
     GENERATE_AND_PLAY(txpool_double_spend_local);
     GENERATE_AND_PLAY(txpool_double_spend_keyimage);

--- a/tests/core_tests/tx_pool.cpp
+++ b/tests/core_tests/tx_pool.cpp
@@ -119,6 +119,97 @@ bool txpool_spend_key_all::generate(std::vector<test_event_entry>& events)
   return true;
 }
 
+txpool_zero_fee::txpool_zero_fee()
+  : txpool_base()
+  , m_invalid_tx_index(0)
+{
+  REGISTER_CALLBACK_METHOD(txpool_zero_fee, mark_invalid_tx);
+  REGISTER_CALLBACK_METHOD(txpool_zero_fee, check_tx);
+}
+
+bool txpool_zero_fee::generate(std::vector<test_event_entry>& events) const
+{
+  uint64_t send_amount = 1000;
+  uint64_t ts_start = 1338224400;
+  GENERATE_ACCOUNT(miner_account);
+  GENERATE_ACCOUNT(bob_account);
+  MAKE_GENESIS_BLOCK(events, blk_0, miner_account, ts_start);
+  REWIND_BLOCKS_N_HF(events, blk_0r, blk_0, miner_account, CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW + 1, 2);
+  MAKE_NEXT_BLOCK_HF(events, blk_hf4, blk_0r, miner_account, HF_VERSION_DYNAMIC_FEE);
+
+  cryptonote::transaction tx;
+  if (!construct_tx_to_key(events, tx, blk_hf4, miner_account, bob_account, send_amount, 0, 2, true))
+    return false;
+
+  SET_EVENT_VISITOR_SETT(events, event_visitor_settings::set_local_relay |
+    event_visitor_settings::set_txs_received_via_rpc);
+  DO_CALLBACK(events, "mark_invalid_tx");
+  events.push_back(tx);
+
+  SET_EVENT_VISITOR_SETT(events, event_visitor_settings::set_txs_do_not_relay);
+  DO_CALLBACK(events, "mark_invalid_tx");
+  events.push_back(tx);
+
+  SET_EVENT_VISITOR_SETT(events, event_visitor_settings::set_txs_do_not_relay |
+    event_visitor_settings::set_txs_received_via_rpc);
+  events.push_back(tx);
+  DO_CALLBACK(events, "check_tx");
+
+  // A P2P duplicate is ignored before the existing pool metadata can be updated.
+  SET_EVENT_VISITOR_SETT(events, 0);
+  events.push_back(tx);
+  DO_CALLBACK(events, "check_tx");
+
+  MAKE_NEXT_BLOCK_HF(events, blk_hf4_2, blk_hf4, miner_account, HF_VERSION_DYNAMIC_FEE);
+  DO_CALLBACK(events, "check_tx");
+
+  return true;
+}
+
+bool txpool_zero_fee::mark_invalid_tx(cryptonote::core&, size_t ev_index, const std::vector<test_event_entry>&)
+{
+  m_invalid_tx_index = ev_index + 1;
+  return true;
+}
+
+bool txpool_zero_fee::check_tx_verification_context(const cryptonote::tx_verification_context& tvc,
+  bool tx_added, size_t event_idx, const cryptonote::transaction&)
+{
+  if (event_idx == m_invalid_tx_index)
+    return tvc.m_verifivation_failed && tvc.m_fee_too_low && !tx_added;
+  return !tvc.m_verifivation_failed;
+}
+
+bool txpool_zero_fee::check_tx(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events)
+{
+  const cryptonote::transaction* tx = nullptr;
+  for (size_t i = ev_index; i > 0; --i)
+  {
+    if (events[i - 1].type() == typeid(cryptonote::transaction))
+    {
+      tx = &boost::get<cryptonote::transaction>(events[i - 1]);
+      break;
+    }
+  }
+  if (tx == nullptr)
+    return false;
+
+  cryptonote::txpool_tx_meta_t meta{};
+  if (!c.get_blockchain_storage().get_txpool_tx_meta(cryptonote::get_transaction_hash(*tx), meta))
+  {
+    MERROR("Zero-fee RPC transaction was not added to the pool");
+    return false;
+  }
+
+  if (meta.fee != 0 || !meta.received_via_rpc || !meta.do_not_relay || meta.kept_by_block)
+  {
+    MERROR("Zero-fee RPC transaction has incorrect pool metadata");
+    return false;
+  }
+
+  return true;
+}
+
 txpool_double_spend_base::txpool_double_spend_base()
   : txpool_base()
   , m_broadcasted_hashes()

--- a/tests/core_tests/tx_pool.h
+++ b/tests/core_tests/tx_pool.h
@@ -71,6 +71,33 @@ struct txpool_spend_key_all : txpool_base
   bool generate(std::vector<test_event_entry>& events);
 };
 
+struct txpool_zero_fee : txpool_base
+{
+  txpool_zero_fee();
+
+  bool generate(std::vector<test_event_entry>& events) const;
+  bool mark_invalid_tx(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
+  bool check_tx(cryptonote::core& c, size_t ev_index, const std::vector<test_event_entry>& events);
+  bool check_tx_verification_context(const cryptonote::tx_verification_context& tvc, bool tx_added,
+    size_t event_idx, const cryptonote::transaction& tx);
+
+private:
+  size_t m_invalid_tx_index;
+};
+
+template<>
+struct get_test_options<txpool_zero_fee>
+{
+  const std::pair<uint8_t, uint64_t> hard_forks[5] = {
+    {1, 0},
+    {2, 1},
+    {HF_VERSION_DYNAMIC_FEE, CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW + 2},
+    {HF_VERSION_DYNAMIC_FEE + 1, CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW + 4},
+    {0, 0}
+  };
+  const cryptonote::test_options test_options = {hard_forks, 0};
+};
+
 class txpool_double_spend_base : public txpool_base
 {
   std::unordered_set<crypto::hash> m_broadcasted_hashes;

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -281,6 +281,7 @@ class TransferTest():
         running_balances[0] -= 1000000000000 + fee
 
         res = daemon.send_raw_transaction(tx_blob)
+        assert res.tx_hash == txid
         assert res.not_relayed == False
         assert res.low_mixin == False
         assert res.double_spend == False

--- a/tests/fuzz/fuzz_rpc/initialisation.cpp
+++ b/tests/fuzz/fuzz_rpc/initialisation.cpp
@@ -301,7 +301,7 @@ bool generate_random_blocks(cryptonote::core& core, FuzzedDataProvider& provider
 
   for (const auto& tx_blob : cached_txs) {
     cryptonote::tx_verification_context tvc;
-    bool accepted = core.handle_incoming_tx(tx_blob, tvc, cryptonote::relay_method::block, true);
+    bool accepted = core.handle_incoming_tx(tx_blob, tvc, cryptonote::relay_method::block, true, false);
     if (accepted || tvc.m_added_to_pool) {
       // Store legit hashes
       cryptonote::transaction tx;

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -553,6 +553,13 @@ TEST(JsonSerialization, InvalidVectorBytes)
     EXPECT_THROW(cryptonote::json::fromJsonValue(doc, out), cryptonote::json::BAD_INPUT);
 }
 
+TEST(JsonSerialization, TxInPool)
+{
+  cryptonote::rpc::tx_in_pool tx{};
+  tx.received_via_rpc = true;
+  EXPECT_TRUE(test_json(tx).received_via_rpc);
+}
+
 TEST(JsonSerialization, DaemonInfo)
 {
   cryptonote::rpc::DaemonInfo info{};

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -77,7 +77,7 @@ public:
   bool have_block(const crypto::hash& id, int *where = NULL) const {return false;}
   bool have_block_unlocked(const crypto::hash& id, int *where = NULL) const {return false;}
   void get_blockchain_top(uint64_t& height, crypto::hash& top_id)const{height=0;top_id=crypto::null_hash;}
-  bool handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, cryptonote::relay_method tx_relay, bool relayed) { return true; }
+  bool handle_incoming_tx(const cryptonote::blobdata& tx_blob, cryptonote::tx_verification_context& tvc, cryptonote::relay_method tx_relay, bool relayed, bool received_via_rpc) { return true; }
   bool handle_single_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *b, cryptonote::block_verification_context& bvc, cryptonote::pool_supplement& extra_block_txs, bool update_miner_blocktemplate = true) { return true; }
   bool handle_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *block, cryptonote::block_verification_context& bvc, bool update_miner_blocktemplate = true) { return true; }
   bool handle_incoming_block(const cryptonote::blobdata& block_blob, const cryptonote::block *block, cryptonote::block_verification_context& bvc, cryptonote::pool_supplement& extra_block_txs, bool update_miner_blocktemplate = true) { return true; }


### PR DESCRIPTION
Follow up PR to yesterday's [MRL discussion](https://libera.monerologs.net/monero-research-lab/20260812#c700269-c700330) about [PoW-Admitted Zero-Fee Transactions for P2Pool](https://gist.github.com/SChernykh/aae5b2d414095e742437134ab20d4353)

The main reason for this PR is that P2Pool can't easily verify tx validity without monerod cooperation, and if a 0-fee transaction is not in monerod's mempool, it gets extremely hard to ensure consensus validity and no double spends (no used key images) on P2Pool side only.

Changes:

- Track transactions submitted through `send_raw_transaction` with a persistent `received_via_rpc` flag.
- Return `tx_hash` in `send_raw_transaction`
- Allow zero-fee transactions submitted through this RPC to enter the txpool when `do_not_relay` is set. Other RPC, P2P, and relay paths continue to enforce the normal fee requirements. The flag is preserved across restarts and txpool revalidation.
- Added tests covering rejected zero-fee submissions, successful RPC/no-relay submission, metadata persistence through hard-fork revalidation, and JSON serialization.

With this PR, P2Pool can submit 0-fee transactions to its local monerod's mempool with a guarantee that all consensus checks are done and no double spends happen, so these transactions can be safely mined.
