### PR TITLE
epee: fix hex separator handling

### DIFF
--- a/contrib/epee/src/hex.cpp
+++ b/contrib/epee/src/hex.cpp
@@ -134,7 +134,7 @@ namespace epee
     // should we include a specific character
     auto include = [](char input) {
         // we ignore spaces and colons
-        return !std::isspace(input) && input != ':';
+        return !std::isspace(static_cast<unsigned char>(input)) && input != ':';
     };
 
     // the number of relevant characters to decode
@@ -153,7 +153,7 @@ namespace epee
 
     // convert a single hex character to an unsigned integer
     auto char_to_int = [](const char *input) {
-      switch (std::tolower(*input)) {
+      switch (std::tolower(static_cast<unsigned char>(*input))) {
         case '0': return  0;
         case '1': return  1;
         case '2': return  2;
@@ -184,6 +184,9 @@ namespace epee
 
       // convert two matching characters to int
       auto high = char_to_int(data++);
+      while (data != src.end() && !include(*data)) {
+        ++data;
+      }
       auto low  = char_to_int(data++);
 
       result.push_back(high << 4 | low);

--- a/tests/unit_tests/epee_utils.cpp
+++ b/tests/unit_tests/epee_utils.cpp
@@ -1221,6 +1221,9 @@ TEST(HexLocale, String)
     hex.assign("00:ff 0f:f0");
     EXPECT_EQ(source, epee::from_hex_locale::to_vector(hex));
 
+    hex.assign("0:0 f f 0:f f:0");
+    EXPECT_EQ(source, epee::from_hex_locale::to_vector(hex));
+
     hex.append("f0");
     EXPECT_EQ(source, epee::from_hex_locale::to_vector(boost::string_ref{hex.data(), hex.size() - 2}));
 }


### PR DESCRIPTION
## Summary

`from_hex_locale::to_vector()` first counts hexadecimal characters after excluding whitespace and colons. During decoding, however, separators were only skipped before the high nibble of each byte.

As a result, inputs such as `0:0` and `f f` passed the length check but then attempted to decode the separator as the low nibble, throwing `std::range_error`.

Skip separators before the low nibble as well, making decoding consistent with the initial character count and the documented behavior.

Also cast arguments passed to `std::isspace` and `std::tolower` to `unsigned char`. Passing a negative plain `char` to these functions has undefined behavior.

## Tests

Added regression coverage for colon and whitespace separators between hexadecimal nibbles.

```text
0:0 f f 0:f f:0
```

Tested with:

```shell
unit_tests --gtest_filter='HexLocale.*:FromHex.*:ToHex.*'
```