### PR TITLE
functional_tests: remove unreachable code

### DIFF
--- a/tests/functional_tests/functional_tests_rpc.py
+++ b/tests/functional_tests/functional_tests_rpc.py
@@ -161,24 +161,14 @@ for test in tests:
 print('Stopping servers...')
 kill()
 
-# wait for exit, the poll method does not work (https://bugs.python.org/issue2475) so we wait, possibly forever if the process hangs
-if True:
-  for p in processes:
+# Wait up to 10 seconds for each process, then force termination.
+for p in processes:
+  try:
+    p.wait(timeout=10)
+  except subprocess.TimeoutExpired:
+    print('Failed to stop process ' + str(p.pid) + ', killing it')
+    p.kill()
     p.wait()
-else:
-  for i in range(10):
-    n_returncode = 0
-    for p in processes:
-      p.poll()
-      if p.returncode:
-        n_returncode += 1
-    if n_returncode == len(processes):
-      print('All done: ' + string.join([x.returncode for x in processes], ', '))
-      break
-    time.sleep(1)
-  for p in processes:
-    if not p.returncode:
-      print('Failed to stop process')
 
 if len(FAIL) == 0:
   print('Done, ' + str(len(PASS)) + '/' + str(len(tests)) + ' tests passed')


### PR DESCRIPTION
... and force kill process after timeout on `subprocess.Popen.wait()` is reached to prevent possibly hanging forever