### PR TITLE
f tests: fix functional_tests_rpc.py string.join()

### DIFF
--- a/tests/functional_tests/functional_tests_rpc.py
+++ b/tests/functional_tests/functional_tests_rpc.py
@@ -27,7 +27,7 @@ try:
   sys.argv[4]
 except:
   print(USAGE)
-  print('Available tests: ' + string.join(DEFAULT_TESTS, ', '))
+  print('Available tests: ' + ', '.join(DEFAULT_TESTS))
   print('Or run all with "all"')
   sys.exit(0)
 


### PR DESCRIPTION

<img width="1604" height="550" alt="image" src="https://github.com/user-attachments/assets/a40d038c-1473-4901-ba7c-b076eb71dcdc" />
Fix crash on the usage path: string.join() was removed in Python 3, so running the script without a test argument crashed with AttributeError: module 'string' has no attribute 'join'
