### PR TITLE
ci: remove libunwind-headers brew package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           brew uninstall cmake
           brew update
-          brew install --quiet cmake boost hidapi openssl zmq unbound libunwind-headers protobuf ccache
+          brew install --quiet cmake boost hidapi openssl zmq unbound protobuf ccache
       - name: build
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{env.MAKE_JOB_COUNT}}


### PR DESCRIPTION
>libunwind-headers has been deprecated because it is not maintained upstream! It will be disabled on 2027-05-17.
