### PR TITLE
readme: line break between copyright headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Monero
 
-Copyright (c) 2014-2026, The Monero Project
+Copyright (c) 2014-2026, The Monero Project  
 Portions Copyright (c) 2012-2013 The Cryptonote developers.
 
 ## Table of Contents


### PR DESCRIPTION
Minor annoyance:

```
Copyright (c) 2014-2026, The Monero Project Portions Copyright (c) 2012-2013 The Cryptonote developers.
```

Instead of:

```
Copyright (c) 2014-2026, The Monero Project
Portions Copyright (c) 2012-2013 The Cryptonote developers.
```