### PR TITLE
rpc: avoid copying block blobs

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -441,8 +441,8 @@ namespace cryptonote
     {
       res.blocks.resize(res.blocks.size()+1);
       res.blocks.back().pruned = req.prune;
-      res.blocks.back().block = bd.first.first;
       cumul_block_data_size += bd.first.first.size();
+      res.blocks.back().block = std::move(bd.first.first);
       res.output_indices.push_back(COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices());
       ntxes += bd.second.size();
       res.output_indices.back().indices.reserve(1 + bd.second.size());


### PR DESCRIPTION
The code as it currently stands seems to copy the entire full block blob when building `get_blocks.bin` responses, which is unnecessary. This patch should allow for a trivial improvement in speed/latency for wallet sync.