### PR TITLE
src: deduplicate base32 encoding/decoding logic

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -29,6 +29,7 @@
 include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
 
 set(common_sources
+  base32.cpp
   base58.cpp
   command_line.cpp
   dns_utils.cpp

--- a/src/common/base32.cpp
+++ b/src/common/base32.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file are originally copyright (c) 2021-2026 SChernykh
+
+#include "base32.h"
+
+namespace tools
+{
+namespace base32
+{
+namespace
+{
+    constexpr const char alphabet[] = u8"abcdefghijklmnopqrstuvwxyz234567";
+    constexpr const std::uint16_t five_bit_mask{0x1F};
+}
+
+std::string encode(const epee::span<const std::uint8_t> data)
+{
+    if (data.empty()) return {};
+
+    std::string result{};
+    const std::size_t expected_size = ((data.size() * 8) + 4) / 5;
+    result.reserve(expected_size);
+
+    std::uint16_t val = 0;
+    std::uint8_t valb = 0;
+
+    for (const std::uint8_t byte : data)
+    {
+        val = (val << 8) | static_cast<std::uint16_t>(byte);
+        valb += 8;
+
+        while (valb >= 5)
+        {
+            valb -= 5;
+            result.push_back(alphabet[(val >> valb) & five_bit_mask]);
+        }
+    }
+
+    if (valb > 0)
+    {
+        result.push_back(alphabet[(val << (5 - valb)) & five_bit_mask]);
+    }
+
+    return result;
+}
+
+bool decode(const std::string_view input, std::vector<std::uint8_t>& data)
+{
+    data.clear();
+    if (input.empty()) return true;
+
+    data.reserve((input.size() * 5) / 8);
+
+    std::uint16_t val = 0;
+    std::uint8_t bits = 0;
+
+    for (const char c : input)
+    {
+        std::uint16_t digit;
+        if ('a' <= c && c <= 'z')
+            digit = static_cast<std::uint16_t>(c - 'a');
+        else if ('A' <= c && c <= 'Z')
+            digit = static_cast<std::uint16_t>(c - 'A');
+        else if ('2' <= c && c <= '7')
+            digit = static_cast<std::uint16_t>(c - '2') + 26;
+        else
+            return false;
+
+        val = (val << 5) | digit;
+        bits += 5;
+
+        if (bits >= 8)
+        {
+            bits -= 8;
+            data.push_back(static_cast<std::uint8_t>(val >> bits));
+        }
+    }
+
+    return true;
+}
+
+} // namespace base32
+} // namespace tools

--- a/src/common/base32.h
+++ b/src/common/base32.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file are originally copyright (c) 2021-2026 SChernykh
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "span.h"
+
+namespace tools
+{
+namespace base32
+{
+
+/**
+ * @brief Encodes bytes as an unpadded, lowercase Base32 string.
+ * @param data Bytes to encode.
+ * @return The Base32 encoding of `data`, or an empty string if `data` is empty.
+ */
+std::string encode(epee::span<const std::uint8_t> data);
+
+/**
+ * @brief Decodes an unpadded Base32 string into a vector of bytes.
+ * @param input Base32 string to decode.
+ * @param data Set to the decoded bytes on success; empty on failure.
+ * @return False if `input` contains an invalid Base32 character.
+ */
+bool decode(std::string_view input, std::vector<std::uint8_t>& data);
+
+} // namespace base32
+} // namespace tools

--- a/src/net/i2p_address.cpp
+++ b/src/net/i2p_address.cpp
@@ -31,7 +31,10 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <string_view>
+#include <vector>
 
+#include "common/base32.h"
 #include "net/error.h"
 #include "net/host.h"
 #include "serialization/keyvalue_serialization.h"
@@ -41,9 +44,6 @@ namespace net
 {
     namespace
     {
-        constexpr const char base32_alphabet[] =
-            u8"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz234567";
-
         //! Validate a Base32 address (.b32.i2p)
         expect<void> host_check_b32(boost::string_ref host) noexcept
         {
@@ -54,7 +54,9 @@ namespace net
 
             if (host.size() != b32_length)
                 return {net::error::invalid_i2p_address};
-            if (host.find_first_not_of(base32_alphabet) != boost::string_ref::npos)
+
+            std::vector<std::uint8_t> decoded{};
+            if (!tools::base32::decode(std::string_view{host.data(), host.size()}, decoded))
                 return {net::error::invalid_i2p_address};
 
             return success();

--- a/src/net/tor_address.cpp
+++ b/src/net/tor_address.cpp
@@ -25,8 +25,6 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Parts of this file are originally copyright (c) 2021-2026 SChernykh
 
 #include "tor_address.h"
 
@@ -37,7 +35,9 @@
 #include <cstring>
 #include <limits>
 #include <string_view>
+#include <vector>
 
+#include "common/base32.h"
 #include "net/error.h"
 #include "net/host.h"
 #include "serialization/keyvalue_serialization.h"
@@ -61,9 +61,6 @@ namespace net
         constexpr const unsigned legacy_length = 16;
         constexpr const unsigned v3_length = 56;
 
-        constexpr const char base32_alphabet[] =
-            u8"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz234567";
-
         expect<void> host_check(boost::string_ref host) noexcept
         {
             if (!host.ends_with(tld))
@@ -71,16 +68,18 @@ namespace net
 
             host.remove_suffix(sizeof(tld) - 1);
 
-            if (host.find_first_not_of(base32_alphabet) != boost::string_ref::npos)
-                return {net::error::invalid_tor_address};
-
             if (host.size() != v3_length)
                 return {host.size() == legacy_length
                     ? net::error::legacy_tor_address
                     : net::error::invalid_tor_address};
 
-            const std::string_view tmp{host.data(), host.size()};
-            const auto bytes = from_onion_v3(tmp);
+            std::vector<std::uint8_t> decoded{};
+            if (!tools::base32::decode(std::string_view{host.data(), host.size()}, decoded) ||
+                decoded.size() != v3_onion_payload_size)
+                return {net::error::invalid_tor_address};
+
+            std::array<std::uint8_t, v3_onion_payload_size> bytes{};
+            std::copy(decoded.begin(), decoded.end(), bytes.begin());
 
             if (!validate_v3_onion_checksum(bytes))
                 return {net::error::invalid_tor_address};
@@ -233,44 +232,12 @@ namespace net
     {
         if (address.size() != v3_length) return {};
 
-        uint8_t buf[v3_onion_payload_size + 4] = {};
-        uint8_t* p = buf;
-
-        uint64_t data = 0;
-        uint64_t bit_size = 0;
-
-        for (size_t i = 0; i < v3_length; ++i) {
-            const char c = address[i];
-            uint64_t digit = 0;
-
-            if ('a' <= c && c <= 'z') {
-                digit = static_cast<uint64_t>(c - 'a');
-            }
-            else if ('A' <= c && c <= 'Z') {
-                digit = static_cast<uint64_t>(c - 'A');
-            }
-            else if ('2' <= c && c <= '7') {
-                digit = static_cast<uint64_t>(c - '2') + 26;
-            }
-            else {
-                return {};
-            }
-
-            data = (data << 5) | digit;
-            bit_size += 5;
-
-            while (bit_size >= 8) {
-                bit_size -= 8;
-                *(p++) = static_cast<uint8_t>(data >> bit_size);
-            }
-        }
+        std::vector<std::uint8_t> decoded{};
+        if (!tools::base32::decode(address, decoded) || decoded.size() != v3_onion_payload_size)
+            return {};
 
         std::array<uint8_t, v3_onion_payload_size> result{};
-
-        for (size_t i = 0; i < v3_onion_payload_size; ++i) {
-            result[i] = buf[i];
-        }
-
+        std::copy(decoded.begin(), decoded.end(), result.begin());
         return result;
     }
 


### PR DESCRIPTION
Moves all Base32 {en,de}coding logic to a dedicated file in `src/common/`. This may also be useful in the future for Jamtis addresses (albeit with a different alphabet).