### PR TITLE
simplewallet: don't exit when unable to get restore date

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4323,13 +4323,13 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
         {
           m_restore_height = m_wallet->get_blockchain_height_by_date(year, month, day);
           success_msg_writer() << tr("Restore height is: ") << m_restore_height;
+          m_wallet->explicit_refresh_from_block_height(true);
         }
         catch (const std::runtime_error& e)
         {
-          fail_msg_writer() << e.what();
-          return false;
+          message_writer(console_color_yellow, true) << tr("Could not connect to daemon to convert --restore-date into a restore height: ") << e.what();
+          message_writer(console_color_yellow, true) << tr("Restore height is: ") << m_restore_height;
         }
-        m_wallet->explicit_refresh_from_block_height(true);
       }
     }
     else


### PR DESCRIPTION
Makes it so that when `--restore-date` is used with `--generate-from-device` without an active daemon connection (i.e. in 'offline' mode), failing to fetch the corresponding restore height will not throw, resulting in the process exiting.