### PR TITLE
simplewallet: fix crash in sweep commands when address is omitted

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6975,6 +6975,13 @@ bool simple_wallet::sweep_main(uint32_t account, uint64_t below, const std::vect
       local_args.pop_back();
   }
 
+  if (local_args.empty())
+  {
+    fail_msg_writer() << tr("No address given");
+    print_usage();
+    return true;
+  }
+
   cryptonote::address_parse_info info;
   if (!cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), local_args[0], oa_prompter))
   {


### PR DESCRIPTION
This seems to occur only in debug builds (as well as in binaries from the Arch repos).

Edit: this might be happening because stack traces are now disabled by default in release builds.