### PR TITLE
device_trezor: show error when operations are cancelled

### DIFF
--- a/src/device_trezor/trezor/exceptions.hpp
+++ b/src/device_trezor/trezor/exceptions.hpp
@@ -160,6 +160,8 @@ namespace proto {
   public:
     using FailureException::FailureException;
     CancelledException(): FailureException("Trezor returned: cancelled operation"){}
+    CancelledException(boost::optional<uint32_t> code, boost::optional<std::string> message)
+        : FailureException(code, message) { reason = "Trezor returned: cancelled operation"; }
   };
 
   class PinExpectedException : public FailureException {


### PR DESCRIPTION
Before, this would simply return the following, which is quite vague:

```
Error: unexpected error: Trezor returned failure: code=4, message=Cancelled
```