### PR TITLE
epee: parse HTTP methods case-sensitively

### DIFF
--- a/contrib/epee/include/net/http_protocol_handler.inl
+++ b/contrib/epee/include/net/http_protocol_handler.inl
@@ -400,7 +400,7 @@ namespace net_utils
   template<class t_connection_context>
 	bool simple_http_connection_handler<t_connection_context>::handle_invoke_query_line()
 	{ 
-		static const boost::regex rexp_match_command_line("^(((OPTIONS)|(GET)|(HEAD)|(POST)|(PUT)|(DELETE)|(TRACE)) (\\S+) HTTP/(\\d+)\\.(\\d+))\r?\n", boost::regex::icase | boost::regex::normal);
+		static const boost::regex rexp_match_command_line("^(((OPTIONS)|(GET)|(HEAD)|(POST)|(PUT)|(DELETE)|(TRACE)) (\\S+) HTTP/(\\d+)\\.(\\d+))\r?\n", boost::regex::normal);
 		//											    123         4     5      6      7     8        9        10          11     12    
 		//size_t match_len = 0;
 		boost::smatch result;	


### PR DESCRIPTION
HTTP method names are case-sensitive, but the request-line parser used `boost::regex::icase` and accepted lowercase names as their uppercase equivalents

remove the case-insensitive flag so method names are parsed case-sensitively

fixes #11118

tests:
- debug `http_server.*`
- release `http_server.*`
- release `unit_tests` (1299 tests, 1297 passed, 2 hardware checks skipped)
- full release build