### PR TITLE
wallet2: return concrete low priority when adjust_priority fails

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8648,7 +8648,7 @@ fee_priority wallet2::adjust_priority(fee_priority priority)
       if (blocks.size() != 1)
       {
         MERROR("Bad estimated backlog array size");
-        return priority;
+        return fee_priority::Unimportant;
       }
       else if (blocks[0].first > 0)
       {
@@ -8660,7 +8660,7 @@ fee_priority wallet2::adjust_priority(fee_priority priority)
       uint64_t block_weight_limit = 0;
       const auto result = m_node_rpc_proxy.get_block_weight_limit(block_weight_limit);
       if (result)
-        return priority;
+        return fee_priority::Unimportant;
       const uint64_t full_reward_zone = block_weight_limit / 2;
 
       // get the last N block headers and sum the block sizes
@@ -8668,7 +8668,7 @@ fee_priority wallet2::adjust_priority(fee_priority priority)
       if (m_blockchain.size() < N)
       {
         MERROR("The blockchain is too short");
-        return priority;
+        return fee_priority::Unimportant;
       }
       cryptonote::COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::request getbh_req = AUTO_VAL_INIT(getbh_req);
       cryptonote::COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::response getbh_res = AUTO_VAL_INIT(getbh_res);
@@ -8684,7 +8684,7 @@ fee_priority wallet2::adjust_priority(fee_priority priority)
       if (getbh_res.headers.size() != N)
       {
         MERROR("Bad blockheaders size");
-        return priority;
+        return fee_priority::Unimportant;
       }
       size_t block_weight_sum = 0;
       for (const cryptonote::block_header_response &i : getbh_res.headers)
@@ -8707,6 +8707,7 @@ fee_priority wallet2::adjust_priority(fee_priority priority)
     {
       MERROR(e.what());
     }
+    return fee_priority::Unimportant; // fall back to low priority on failure, matching get_base_fee's handling of Default
   }
   return priority;
 }


### PR DESCRIPTION
`adjust_priority` makes three separate daemon RPC calls (backlog estimate, block weight limit, recent block headers), so it can fail transiently.

On failure it currently returns the default priority of 0, so a client receives 0 = DEFAULT instead of a concrete value. That's ambiguous as an error signal, since 0 is also the legitimate result when auto-low-priority is disabled or a default priority is configured, so a caller can't classify it.

This PR returns a priority of 1 from the failure paths instead, matching the fallback already used in get_base_fee, where a priority of 0 is coerced to 1 with the [comment](https://github.com/monero-project/monero/blob/c5d310af8d3472c04aca4e9b0092efb4d2bfac0e/src/wallet/wallet2.cpp#L8538) "should not end up here". Behavior within wallet2 is unchanged, the fallback just becomes explicit for the function contract.

The alternative is to throw a hard error, but that would turn a transient hiccup into a hard failure of transfer creation for all present callers. Since this function only answers a narrow, best-effort heuristic, "is the cheap fee tier safe right now?", falling back to a concrete value is the better contract.

Release PR: https://github.com/monero-project/monero/pull/11129