### PR TITLE
cryptonote: support pruned weights for old RingCT

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -590,7 +590,7 @@ namespace cryptonote
   {
     CHECK_AND_ASSERT_MES(tx.pruned, std::numeric_limits<uint64_t>::max(), "get_pruned_transaction_weight does not support non pruned txes");
     CHECK_AND_ASSERT_MES(tx.version >= 2, std::numeric_limits<uint64_t>::max(), "get_pruned_transaction_weight does not support v1 txes");
-    CHECK_AND_ASSERT_MES(tx.rct_signatures.type == rct::RCTTypeBulletproof2 || tx.rct_signatures.type == rct::RCTTypeCLSAG || tx.rct_signatures.type == rct::RCTTypeBulletproofPlus,
+    CHECK_AND_ASSERT_MES(tx.rct_signatures.type >= rct::RCTTypeFull && tx.rct_signatures.type <= rct::RCTTypeBulletproofPlus,
         std::numeric_limits<uint64_t>::max(), "Unsupported rct_signatures type in get_pruned_transaction_weight");
     CHECK_AND_ASSERT_MES(!tx.vin.empty(), std::numeric_limits<uint64_t>::max(), "empty vin");
     CHECK_AND_ASSERT_MES(tx.vin[0].type() == typeid(cryptonote::txin_to_key), std::numeric_limits<uint64_t>::max(), "empty vin");
@@ -601,33 +601,49 @@ namespace cryptonote
     ::serialization::serialize(a, const_cast<transaction&>(tx));
     uint64_t weight = s.str().size(), extra;
 
-    // nbps (technically varint)
-    weight += 1;
+    const bool borromean = rct::is_rct_borromean(tx.rct_signatures.type);
+    size_t n_padded_outputs = 0;
+    if (borromean)
+    {
+      // calculate deterministic Borromean range proof size
+      extra = sizeof(rct::rangeSig) * tx.vout.size();
+      weight += extra;
+    }
+    else
+    {
+      // nbps (fixed width for the first BP type, varint afterwards)
+      weight += tx.rct_signatures.type == rct::RCTTypeBulletproof ? sizeof(uint32_t) : 1;
 
-    // calculate deterministic bulletproofs size (assumes canonical BP format)
-    size_t nrl = 0, n_padded_outputs;
-    while ((n_padded_outputs = (1u << nrl)) < tx.vout.size())
-      ++nrl;
-    nrl += 6;
-    extra = 32 * ((rct::is_rct_bulletproof_plus(tx.rct_signatures.type) ? 6 : 9) + 2 * nrl) + 2;
-    weight += extra;
+      // calculate deterministic bulletproofs size (assumes canonical BP format)
+      size_t nrl = 0;
+      while ((n_padded_outputs = (1u << nrl)) < tx.vout.size())
+        ++nrl;
+      nrl += 6;
+      extra = 32 * ((rct::is_rct_bulletproof_plus(tx.rct_signatures.type) ? 6 : 9) + 2 * nrl) + 2;
+      weight += extra;
+    }
 
     // calculate deterministic CLSAG/MLSAG data size
     const size_t ring_size = boost::get<cryptonote::txin_to_key>(tx.vin[0]).key_offsets.size();
-    if (rct::is_rct_clsag(tx.rct_signatures.type))
+    if (tx.rct_signatures.type == rct::RCTTypeFull)
+      extra = ring_size * (tx.vin.size() + 1) * 32 + 32 /* cc */;
+    else if (rct::is_rct_clsag(tx.rct_signatures.type))
       extra = tx.vin.size() * (ring_size + 2) * 32;
     else
       extra = tx.vin.size() * (ring_size * (1 + 1) * 32 + 32 /* cc */);
     weight += extra;
 
-    // calculate deterministic pseudoOuts size
-    extra =  32 * (tx.vin.size());
-    weight += extra;
+    if (!borromean)
+    {
+      // calculate deterministic pseudoOuts size
+      extra = 32 * tx.vin.size();
+      weight += extra;
 
-    // clawback
-    uint64_t bp_clawback = get_transaction_weight_clawback(tx, n_padded_outputs);
-    CHECK_AND_ASSERT_THROW_MES_L1(bp_clawback <= std::numeric_limits<uint64_t>::max() - weight, "Weight overflow");
-    weight += bp_clawback;
+      // clawback
+      uint64_t bp_clawback = get_transaction_weight_clawback(tx, n_padded_outputs);
+      CHECK_AND_ASSERT_THROW_MES_L1(bp_clawback <= std::numeric_limits<uint64_t>::max() - weight, "Weight overflow");
+      weight += bp_clawback;
+    }
 
     return weight;
   }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -2015,9 +2015,9 @@ skip:
     const uint32_t local_stripe = tools::get_pruning_stripe(m_core.get_blockchain_pruning_seed());
     if (local_stripe == 0)
       return false;
-    // don't request pre-bulletproof pruned blocks, we can't reconstruct their weight (yet)
-    static const uint64_t bp_fork_height = m_core.get_earliest_ideal_height_for_version(HF_VERSION_SMALLER_BP + 1);
-    if (first_block_height < bp_fork_height)
+    // v1 txes are sent in full, so pruned sync is only useful once RingCT txes can occur
+    static const uint64_t rct_fork_height = m_core.get_earliest_ideal_height_for_version(HF_VERSION_DYNAMIC_FEE);
+    if (first_block_height < rct_fork_height)
       return false;
     // assumes the span size is less or equal to the stripe size
     bool full_data_needed = tools::get_pruning_stripe(first_block_height, context.m_remote_blockchain_height, CRYPTONOTE_PRUNING_LOG_STRIPES) == local_stripe
@@ -2240,8 +2240,8 @@ skip:
         }
 
         const uint64_t first_block_height = context.m_last_response_height - context.m_needed_objects.size() + 1;
-        static const uint64_t bp_fork_height = m_core.get_earliest_ideal_height_for_version(8);
-        bool sync_pruned_blocks = m_sync_pruned_blocks && first_block_height >= bp_fork_height && m_core.get_blockchain_pruning_seed();
+        static const uint64_t rct_fork_height = m_core.get_earliest_ideal_height_for_version(HF_VERSION_DYNAMIC_FEE);
+        bool sync_pruned_blocks = m_sync_pruned_blocks && first_block_height >= rct_fork_height && m_core.get_blockchain_pruning_seed();
         span = m_block_queue.reserve_span(first_block_height, context.m_last_response_height, l_m_bss, context.m_connection_id, context.m_remote_address, sync_pruned_blocks, m_core.get_blockchain_pruning_seed(), context.m_pruning_seed, context.m_remote_blockchain_height, context.m_needed_objects);
         MDEBUG(context << " span from " << first_block_height << ": " << span.first << "/" << span.second);
         if (span.second > 0)

--- a/tests/unit_tests/cryptonote_format_utils.cpp
+++ b/tests/unit_tests/cryptonote_format_utils.cpp
@@ -447,3 +447,63 @@ TEST(cn_format_utils, generate_key_image_helper_additional_derivations_stay_alig
     ASSERT_TRUE(cryptonote::generate_key_image_helper(keys, subaddresses, out_key, tx_pub_key,
         additional_tx_pub_keys, 1, in_ephemeral, ki, hwdev));
 }
+
+namespace
+{
+cryptonote::transaction make_prunable_weight_tx(uint8_t type, size_t inputs, size_t outputs, size_t ring_size)
+{
+    cryptonote::transaction tx;
+    tx.version = 2;
+    tx.unlock_time = 0;
+    tx.vin.resize(inputs, cryptonote::txin_to_key{0, std::vector<uint64_t>(ring_size), crypto::key_image{}});
+    tx.vout.resize(outputs, cryptonote::tx_out{0, cryptonote::txout_to_key{}});
+
+    rct::rctSig &rv = tx.rct_signatures;
+    rv.type = type;
+    rv.ecdhInfo.resize(outputs);
+    rv.outPk.resize(outputs);
+
+    if (rct::is_rct_borromean(type))
+        rv.p.rangeSigs.resize(outputs);
+    else
+    {
+        size_t nrl = 6;
+        for (size_t padded_outputs = 1; padded_outputs < outputs; padded_outputs <<= 1)
+            ++nrl;
+        rv.p.bulletproofs.resize(1);
+        rv.p.bulletproofs[0].V.resize(outputs);
+        rv.p.bulletproofs[0].L.resize(nrl);
+        rv.p.bulletproofs[0].R.resize(nrl);
+        rv.p.pseudoOuts.resize(inputs);
+    }
+
+    if (type == rct::RCTTypeSimple)
+        rv.pseudoOuts.resize(inputs);
+
+    const size_t mg_count = type == rct::RCTTypeFull ? 1 : inputs;
+    rv.p.MGs.resize(mg_count);
+    for (rct::mgSig &mg: rv.p.MGs)
+        mg.ss.resize(ring_size, rct::keyV(type == rct::RCTTypeFull ? inputs + 1 : 2));
+
+    return tx;
+}
+
+void assert_pruned_weight_matches(cryptonote::transaction tx)
+{
+    const cryptonote::blobdata blob = cryptonote::tx_to_blob(tx);
+    ASSERT_FALSE(blob.empty());
+    const uint64_t full_weight = cryptonote::get_transaction_weight(tx, blob.size());
+
+    cryptonote::transaction pruned_tx;
+    ASSERT_TRUE(cryptonote::parse_and_validate_tx_base_from_blob(blob, pruned_tx));
+    ASSERT_TRUE(pruned_tx.pruned);
+    ASSERT_EQ(full_weight, cryptonote::get_pruned_transaction_weight(pruned_tx));
+}
+} // anonymous namespace
+
+TEST(cn_format_utils, pruned_old_rct_weight)
+{
+    assert_pruned_weight_matches(make_prunable_weight_tx(rct::RCTTypeFull, 3, 2, 5));
+    assert_pruned_weight_matches(make_prunable_weight_tx(rct::RCTTypeSimple, 3, 2, 7));
+    assert_pruned_weight_matches(make_prunable_weight_tx(rct::RCTTypeBulletproof, 2, 3, 11));
+}


### PR DESCRIPTION
fixes #6754

`get_pruned_transaction_weight()` can now reconstruct weights for Full, Simple and first-generation Bulletproof transactions

this lowers the v11 floor for pruned sync to the first RingCT fork, so old blocks with large Borromean proofs can be requested without the prunable data

v1 transactions are still sent in full by the existing block response path

tests:
- `unit_tests --gtest_filter=cn_format_utils.pruned_old_rct_weight:bulletproof.weight_pruned`
- full unit suite: 1309 passed, 2 disk tests skipped