### PR TITLE
wallet_rpc_server: leave unknown incoming tx hash empty

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2269,7 +2269,7 @@ namespace tools
         rpc_transfers.amount       = td.amount();
         rpc_transfers.spent        = td.m_spent;
         rpc_transfers.global_index = td.m_global_output_index;
-        rpc_transfers.tx_hash      = epee::string_tools::pod_to_hex(td.m_txid);
+        rpc_transfers.tx_hash      = td.m_txid == crypto::null_hash ? "" : epee::string_tools::pod_to_hex(td.m_txid);
         rpc_transfers.subaddr_index = {td.m_subaddr_index.major, td.m_subaddr_index.minor};
         rpc_transfers.key_image    = td.m_key_image_known ? epee::string_tools::pod_to_hex(td.m_key_image) : "";
         rpc_transfers.pubkey       = epee::string_tools::pod_to_hex(td.get_public_key());

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -47,7 +47,7 @@
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define WALLET_RPC_VERSION_MAJOR 1
-#define WALLET_RPC_VERSION_MINOR 32
+#define WALLET_RPC_VERSION_MINOR 33
 #define MAKE_WALLET_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define WALLET_RPC_VERSION MAKE_WALLET_RPC_VERSION(WALLET_RPC_VERSION_MAJOR, WALLET_RPC_VERSION_MINOR)
 namespace tools

--- a/tests/functional_tests/cold_signing.py
+++ b/tests/functional_tests/cold_signing.py
@@ -145,6 +145,9 @@ class ColdSigningTest():
             if do_check_key_images:
                 attributes_to_cmp.append("key_image")
             for i in range(len(hot_transfers_list)):
+                assert len(hot_transfers_list[i]['tx_hash']) == 64
+                assert hot_transfers_list[i]['tx_hash'] != '0' * 64
+                assert cold_transfers_list[i]['tx_hash'] == '', cold_transfers_list[i]['tx_hash']
                 for attr in attributes_to_cmp:
                     hot_val = hot_transfers_list[i][attr]
                     cold_val = cold_transfers_list[i][attr]


### PR DESCRIPTION
Fixes #9447

`import_outputs` sets `m_txid` to `crypto::null_hash` for imported
outputs because the output export format does not contain transaction
hashes.

`incoming_transfers` serialized that sentinel as 64 zeroes, making an
unknown value look like a transaction hash. Return an empty string when
the transaction hash is unknown. Known transaction hashes are unchanged.

Before:

```json
"tx_hash": "0000000000000000000000000000000000000000000000000000000000000000"
```

After:

```json
"tx_hash": ""
```

The cold signing functional test now verifies that online wallet
transfer hashes remain non-zero 64-character values and imported
offline wallet hashes are empty.

Tests:

- `make -j4 release-all`
- `cold_signing`
- `transfer`