### PR TITLE
rpc, common: remove dead code

### DIFF
--- a/src/common/perf_timer.h
+++ b/src/common/perf_timer.h
@@ -77,9 +77,7 @@ private:
 
 #define PERF_TIMER_NAME(name) pt_##name
 #define PERF_TIMER_UNIT(name, unit) tools::LoggingPerformanceTimer PERF_TIMER_NAME(name)(#name, "perf." MONERO_DEFAULT_LOG_CATEGORY, unit, tools::performance_timer_log_level)
-#define PERF_TIMER_UNIT_L(name, unit, l) tools::LoggingPerformanceTimer PERF_TIMER_NAME(name)t_##name(#name, "perf." MONERO_DEFAULT_LOG_CATEGORY, unit, l)
 #define PERF_TIMER(name) PERF_TIMER_UNIT(name, 1000000)
-#define PERF_TIMER_L(name, l) PERF_TIMER_UNIT_L(name, 1000000, l)
 #define PERF_TIMER_START_UNIT(name, unit) std::unique_ptr<tools::LoggingPerformanceTimer> PERF_TIMER_NAME(name)(new tools::LoggingPerformanceTimer(#name, "perf." MONERO_DEFAULT_LOG_CATEGORY, unit, el::Level::Info))
 #define PERF_TIMER_START(name) PERF_TIMER_START_UNIT(name, 1000000)
 #define PERF_TIMER_STOP(name) do { PERF_TIMER_NAME(name).reset(NULL); } while(0)

--- a/src/common/rpc_client.h
+++ b/src/common/rpc_client.h
@@ -60,33 +60,6 @@ namespace tools
     }
 
     template <typename T_req, typename T_res>
-    bool basic_json_rpc_request(
-        T_req & req
-      , T_res & res
-      , std::string const & method_name
-      )
-    {
-      t_http_connection connection(&m_http_client);
-
-      bool ok = connection.is_open();
-      if (!ok)
-      {
-        fail_msg_writer() << "Couldn't connect to daemon: " << m_http_client.get_host() << ":" << m_http_client.get_port();
-        return false;
-      }
-      ok = epee::net_utils::invoke_http_json_rpc("/json_rpc", method_name, req, res, m_http_client, t_http_connection::TIMEOUT());
-      if (!ok)
-      {
-        fail_msg_writer() << "basic_json_rpc_request: Daemon request failed";
-        return false;
-      }
-      else
-      {
-        return true;
-      }
-    }
-
-    template <typename T_req, typename T_res>
     bool json_rpc_request(
         T_req & req
       , T_res & res

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -136,14 +136,6 @@ namespace tools
   std::string get_special_folder_path(int nfolder, bool iscreate);
 #endif
 
-  /*! \brief Returns the OS version string
-   *
-   * \details This is a wrapper around the primitives
-   * get_windows_version_display_string() and
-   * get_nix_version_display_string()
-   */
-  std::string get_os_version_string();
-
   /*! \brief creates directories for a path
    *
    *  wrapper around boost::filesystem::create_directories.  

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -245,7 +245,6 @@ namespace cryptonote
     //-----------------------
 
 private:
-    bool check_core_busy();
     bool check_core_ready();
     bool add_host_fail(const connection_context *ctx, unsigned int score = 1);
     


### PR DESCRIPTION
Never had a caller:
- `t_rpc_client::basic_json_rpc_request`: added in 9193d6fb5 alongside `json_rpc_request`, which is the variant everything uses
- `PERF_TIMER_L`, added in 74dfdb0b3, and `PERF_TIMER_UNIT_L`, added in 19d7f568c: never invoked; the current definition from 289937979 does not even expand to valid C++, so any invocation would fail to compile

Declarations whose definition and callers were removed long ago:
- `check_core_busy`: 0f2c2d4c3 removed the obsolete busy-core checks and the definition, leaving the declaration
- `get_os_version_string`: 6b8dfb8fb removed the os-version daemon command together with the definition, leaving the declaration and its comment, which referenced helpers that no longer exist

The `FullMessage` members are dropped from this PR: `getRequest` is used by monero-lws, and the ZMQ code is still under development.
