### PR TITLE
src, epee: replace recursive mutexes with read-write lock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -953,6 +953,7 @@ endif()
 add_definitions(-DBOOST_ASIO_ENABLE_SEQUENTIAL_STRAND_ALLOCATION)
 add_definitions(-DBOOST_NO_AUTO_PTR)
 add_definitions(-DBOOST_UUID_DISABLE_ALIGNMENT) # This restores UUID's std::has_unique_object_representations property
+add_definitions(-DBOOST_THREAD_V2_SHARED_MUTEX) # Avoids writer starvation in boost::shared_mutex
 
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 if(MINGW)

--- a/contrib/epee/include/syncobj.h
+++ b/contrib/epee/include/syncobj.h
@@ -37,6 +37,8 @@
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/thread.hpp>
 
+#include "scope_guard.h"
+
 namespace epee
 {
 
@@ -83,6 +85,14 @@ namespace epee
 #define  CRITICAL_REGION_LOCAL1(x) { boost::this_thread::sleep_for(boost::chrono::milliseconds(epee::debug::g_test_dbg_lock_sleep()));} boost::unique_lock critical_region_var1(x)
 
 #define  CRITICAL_REGION_END() }
+
+#define RWLOCK(m_lock)                                                        \
+  m_lock.lock();                                                              \
+  const epee::scope_guard scope_exit_handler##m_lock([&](){ m_lock.unlock(); });
+
+#define RLOCK(m_lock)                                                         \
+  m_lock.lock_shared();                                                       \
+  const epee::scope_guard scope_exit_handler##m_lock([&](){ m_lock.unlock_shared(); });
 
 }
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -45,7 +45,8 @@ set(common_sources
   updates.cpp
   aligned.c
   timings.cc
-  combinator.cpp)
+  combinator.cpp
+  recursive_shared_mutex.cpp)
 
 if (STACK_TRACE)
   list(APPEND common_sources stack_trace.cpp)

--- a/src/common/recursive_shared_mutex.cpp
+++ b/src/common/recursive_shared_mutex.cpp
@@ -28,7 +28,7 @@
 
 #include "recursive_shared_mutex.h"
 
-#include <cassert>
+#include "misc_log_ex.h"
 
 namespace tools
 {
@@ -46,7 +46,8 @@ recursive_shared_mutex::recursive_shared_mutex()
 void recursive_shared_mutex::lock()
 {
     access_counter_t& access = thread_local_access_per_mutex[m_slot];
-    assert(0 == access || access & write_bit);
+    CHECK_AND_ASSERT_THROW_MES(0 == access || (access & write_bit),
+        "recursive_shared_mutex::lock(): thread already holds the shared lock; upgrading shared to exclusive is not supported");
 
     if (!access) m_rw_mutex.lock();
 
@@ -56,7 +57,8 @@ void recursive_shared_mutex::lock()
 bool recursive_shared_mutex::try_lock()
 {
     access_counter_t& access = thread_local_access_per_mutex[m_slot];
-    assert(0 == access || access & write_bit);
+    CHECK_AND_ASSERT_THROW_MES(0 == access || (access & write_bit),
+        "recursive_shared_mutex::try_lock(): thread already holds the shared lock; upgrading shared to exclusive is not supported");
 
     if (access || m_rw_mutex.try_lock())
     {
@@ -71,9 +73,13 @@ bool recursive_shared_mutex::try_lock()
 
 void recursive_shared_mutex::unlock()
 {
-    access_counter_t& access = thread_local_access_per_mutex[m_slot];
-    assert(access & depth_mask);
+    const auto it = thread_local_access_per_mutex.find(m_slot);
+    CHECK_AND_ASSERT_THROW_MES(it != thread_local_access_per_mutex.end() && (it->second & depth_mask),
+        "recursive_shared_mutex::unlock(): unlock() called without holding the exclusive lock");
+    CHECK_AND_ASSERT_THROW_MES(it->second & write_bit,
+        "recursive_shared_mutex::unlock(): thread holds the shared lock, not the exclusive lock; call unlock_shared() instead");
 
+    access_counter_t& access = it->second;
     const bool still_held = --access & depth_mask;
     if (!still_held)
     {
@@ -106,8 +112,14 @@ bool recursive_shared_mutex::try_lock_shared()
 
 void recursive_shared_mutex::unlock_shared()
 {
-    access_counter_t& access = thread_local_access_per_mutex[m_slot];
-    assert(access & depth_mask);
+    const auto it = thread_local_access_per_mutex.find(m_slot);
+    CHECK_AND_ASSERT_THROW_MES(it != thread_local_access_per_mutex.end() && (it->second & depth_mask),
+        "recursive_shared_mutex::unlock_shared(): unlock_shared() called without holding the lock");
+
+    access_counter_t& access = it->second;
+    const bool releasing_outermost = 1 == (access & depth_mask);
+    CHECK_AND_ASSERT_THROW_MES(!releasing_outermost || !(access & write_bit),
+        "recursive_shared_mutex::unlock_shared(): thread holds the exclusive lock; call unlock() instead");
 
     const bool still_held = --access & depth_mask;
     if (!still_held)

--- a/src/common/recursive_shared_mutex.cpp
+++ b/src/common/recursive_shared_mutex.cpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2024-2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "recursive_shared_mutex.h"
+
+#include <cassert>
+
+namespace tools
+{
+
+std::atomic<recursive_shared_mutex::slot_t> recursive_shared_mutex::shared_slot_counter{0};
+
+thread_local std::unordered_map<recursive_shared_mutex::slot_t, recursive_shared_mutex::access_counter_t>
+    recursive_shared_mutex::thread_local_access_per_mutex{};
+
+recursive_shared_mutex::recursive_shared_mutex()
+    : m_rw_mutex{}
+    , m_slot{shared_slot_counter++}
+{}
+
+void recursive_shared_mutex::lock()
+{
+    access_counter_t& access = thread_local_access_per_mutex[m_slot];
+    assert(0 == access || access & write_bit);
+
+    if (!access) m_rw_mutex.lock();
+
+    access = (access + 1) | write_bit;
+}
+
+bool recursive_shared_mutex::try_lock()
+{
+    access_counter_t& access = thread_local_access_per_mutex[m_slot];
+    assert(0 == access || access & write_bit);
+
+    if (access || m_rw_mutex.try_lock())
+    {
+        access = (access + 1) | write_bit;
+        return true;
+    }
+
+    if (!access) thread_local_access_per_mutex.erase(m_slot);
+
+    return false;
+}
+
+void recursive_shared_mutex::unlock()
+{
+    access_counter_t& access = thread_local_access_per_mutex[m_slot];
+    assert(access & depth_mask);
+
+    const bool still_held = --access & depth_mask;
+    if (!still_held)
+    {
+        m_rw_mutex.unlock();
+        thread_local_access_per_mutex.erase(m_slot);
+    }
+}
+
+void recursive_shared_mutex::lock_shared()
+{
+    access_counter_t& access = thread_local_access_per_mutex[m_slot];
+
+    if (!(access++)) m_rw_mutex.lock_shared();
+}
+
+bool recursive_shared_mutex::try_lock_shared()
+{
+    access_counter_t& access = thread_local_access_per_mutex[m_slot];
+
+    if (access || m_rw_mutex.try_lock_shared())
+    {
+        ++access;
+        return true;
+    }
+
+    if (!access) thread_local_access_per_mutex.erase(m_slot);
+
+    return false;
+}
+
+void recursive_shared_mutex::unlock_shared()
+{
+    access_counter_t& access = thread_local_access_per_mutex[m_slot];
+    assert(access & depth_mask);
+
+    const bool still_held = --access & depth_mask;
+    if (!still_held)
+    {
+        m_rw_mutex.unlock_shared();
+        thread_local_access_per_mutex.erase(m_slot);
+    }
+}
+
+} // namespace tools

--- a/src/common/recursive_shared_mutex.h
+++ b/src/common/recursive_shared_mutex.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2024-2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <limits>
+#include <unordered_map>
+
+#include <boost/thread/shared_mutex.hpp>
+
+namespace tools
+{
+
+class recursive_shared_mutex
+{
+public:
+    recursive_shared_mutex();
+
+    recursive_shared_mutex(const recursive_shared_mutex&)            = delete;
+    recursive_shared_mutex(recursive_shared_mutex&&)                 = delete;
+    recursive_shared_mutex& operator=(const recursive_shared_mutex&) = delete;
+    recursive_shared_mutex& operator=(recursive_shared_mutex&&)      = delete;
+
+    void lock();
+    bool try_lock();
+    void unlock();
+
+    void lock_shared();
+    bool try_lock_shared();
+    void unlock_shared();
+
+private:
+    using slot_t = std::uint32_t;
+    using access_counter_t = std::uint32_t;
+
+    static constexpr access_counter_t access_counter_max = std::numeric_limits<access_counter_t>::max();
+    static constexpr access_counter_t depth_mask = access_counter_max >> 1;
+    static constexpr access_counter_t write_bit = access_counter_max - depth_mask;
+
+    static std::atomic<slot_t> shared_slot_counter;
+
+    static thread_local std::unordered_map<slot_t, access_counter_t> thread_local_access_per_mutex;
+
+    boost::shared_mutex m_rw_mutex;
+    const slot_t m_slot;
+};
+
+} // namespace tools

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -578,7 +578,7 @@ void Blockchain::pop_blocks(uint64_t nblocks, const bool keep_txs)
 block Blockchain::pop_block_from_blockchain(bool keep_txs)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
 
   m_timestamps_and_difficulties_height = 0;
   m_reset_timestamps_and_difficulties_height = true;
@@ -716,7 +716,7 @@ block Blockchain::pop_block_from_blockchain(bool keep_txs)
 bool Blockchain::reset_and_set_genesis_block(const block& b)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
   m_timestamps_and_difficulties_height = 0;
   m_reset_timestamps_and_difficulties_height = true;
   invalidate_block_template_cache();
@@ -735,7 +735,7 @@ bool Blockchain::reset_and_set_genesis_block(const block& b)
 crypto::hash Blockchain::get_tail_id(uint64_t& height) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   return m_db->top_block_hash(&height);
 }
 //------------------------------------------------------------------
@@ -764,7 +764,7 @@ crypto::hash Blockchain::get_tail_id() const
 bool Blockchain::get_short_chain_history(std::list<crypto::hash>& ids, uint64_t& current_height) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   uint64_t i = 0;
   uint64_t current_multiplier = 1;
   uint64_t sz = current_height = m_db->height();
@@ -840,7 +840,7 @@ crypto::hash Blockchain::get_pending_block_id_by_height(uint64_t height) const
 bool Blockchain::get_block_by_hash(const crypto::hash &h, block &blk, bool *orphan) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   // try to find block in main chain
   try
@@ -905,7 +905,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
       return m_difficulty_for_next_block;
   }
 
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
   std::vector<uint64_t> timestamps;
   std::vector<difficulty_type> difficulties;
   uint64_t height;
@@ -986,7 +986,7 @@ size_t Blockchain::recalculate_difficulties(boost::optional<uint64_t> start_heig
     return 0;
   }
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
 
   const uint64_t start_height = start_height_opt ? *start_height_opt : check_difficulty_checkpoints().second;
   const uint64_t top_height = m_db->height() - 1;
@@ -1072,7 +1072,7 @@ size_t Blockchain::recalculate_difficulties(boost::optional<uint64_t> start_heig
 //------------------------------------------------------------------
 std::vector<time_t> Blockchain::get_last_block_timestamps(unsigned int blocks) const
 {
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   uint64_t height = m_db->height();
   if (blocks > height)
     blocks = height;
@@ -1088,7 +1088,7 @@ std::vector<time_t> Blockchain::get_last_block_timestamps(unsigned int blocks) c
 bool Blockchain::rollback_blockchain_switching(std::list<block>& original_chain, uint64_t rollback_height)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
 
   // fail if rollback_height passed is too high
   if (rollback_height > m_db->height())
@@ -1132,7 +1132,7 @@ bool Blockchain::rollback_blockchain_switching(std::list<block>& original_chain,
 bool Blockchain::switch_to_alternative_blockchain(std::list<block_extended_info>& alt_chain, bool discard_disconnected_chain)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
 
   m_timestamps_and_difficulties_height = 0;
   m_reset_timestamps_and_difficulties_height = true;
@@ -1268,7 +1268,7 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
   // based on its blocks alone, need to get more blocks from the main chain
   if(alt_chain.size()< DIFFICULTY_BLOCKS_COUNT)
   {
-    CRITICAL_REGION_LOCAL(m_blockchain_lock);
+    RLOCK(m_blockchain_lock);
 
     // Figure out start and stop offsets for main chain blocks
     size_t main_chain_stop_offset = alt_chain.size() ? alt_chain.front().height : bei.height;
@@ -1426,7 +1426,7 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
 void Blockchain::get_last_n_blocks_weights(std::vector<uint64_t>& weights, size_t count) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   auto h = m_db->height();
 
   // this function is meaningless for an empty blockchain...granted it should never be empty
@@ -1441,7 +1441,7 @@ void Blockchain::get_last_n_blocks_weights(std::vector<uint64_t>& weights, size_
 uint64_t Blockchain::get_long_term_block_weight_median(uint64_t start_height, size_t count) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
 
   PERF_TIMER(get_long_term_block_weights);
 
@@ -1527,7 +1527,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
 
   m_tx_pool.lock();
   const epee::scope_guard unlock_guard([&]() { m_tx_pool.unlock(); });
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
   if (m_btc_valid && !from_block) {
     // The pool cookie is atomic. The lack of locking is OK, as if it changes
     // just as we compare it, we'll just use a slightly old template, but
@@ -1824,7 +1824,7 @@ bool Blockchain::complete_timestamps_vector(uint64_t start_top_height, std::vect
   if(timestamps.size() >= BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW)
     return true;
 
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   size_t need_elements = BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW - timestamps.size();
   CHECK_AND_ASSERT_MES(start_top_height < m_db->height(), false, "internal error: passed start_height not < " << " m_db->height() -- " << start_top_height << " >= " << m_db->height());
   size_t stop_offset = start_top_height > need_elements ? start_top_height - need_elements : 0;
@@ -1902,7 +1902,7 @@ bool Blockchain::handle_alternative_block(const block& b, const crypto::hash& id
   block_verification_context& bvc, pool_supplement& extra_block_txs)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
   m_timestamps_and_difficulties_height = 0;
   m_reset_timestamps_and_difficulties_height = true;
   uint64_t block_height = get_block_height(b);
@@ -2166,7 +2166,7 @@ bool Blockchain::handle_alternative_block(const block& b, const crypto::hash& id
 bool Blockchain::get_blocks(uint64_t start_offset, size_t count, std::vector<std::pair<cryptonote::blobdata,block>>& blocks, std::vector<cryptonote::blobdata>& txs) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   if(start_offset >= m_db->height())
     return false;
 
@@ -2188,7 +2188,7 @@ bool Blockchain::get_blocks(uint64_t start_offset, size_t count, std::vector<std
 bool Blockchain::get_blocks(uint64_t start_offset, size_t count, std::vector<std::pair<cryptonote::blobdata,block>>& blocks) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   const uint64_t height = m_db->height();
   if(start_offset >= height)
     return false;
@@ -2216,7 +2216,7 @@ bool Blockchain::get_blocks(uint64_t start_offset, size_t count, std::vector<std
 bool Blockchain::handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, NOTIFY_RESPONSE_GET_OBJECTS::request& rsp)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   db_rtxn_guard rtxn_guard (m_db);
   rsp.current_blockchain_height = get_current_blockchain_height();
   std::vector<std::pair<cryptonote::blobdata,block>> blocks;
@@ -2263,7 +2263,7 @@ bool Blockchain::handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, NO
 bool Blockchain::get_alternative_blocks(std::vector<block>& blocks) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   blocks.reserve(m_db->get_alt_block_count());
   m_db->for_all_alt_blocks([&blocks](const crypto::hash &blkid, const cryptonote::alt_block_data_t &data, const cryptonote::blobdata_ref *blob) {
@@ -2285,7 +2285,7 @@ bool Blockchain::get_alternative_blocks(std::vector<block>& blocks) const
 size_t Blockchain::get_alternative_blocks_count() const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   return m_db->get_alt_block_count();
 }
 //------------------------------------------------------------------
@@ -2319,7 +2319,7 @@ crypto::public_key Blockchain::get_output_key(uint64_t amount, uint64_t global_i
 bool Blockchain::get_outs(const COMMAND_RPC_GET_OUTPUTS_BIN::request& req, COMMAND_RPC_GET_OUTPUTS_BIN::response& res) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   res.outs.clear();
   res.outs.reserve(req.outputs.size());
@@ -2419,7 +2419,7 @@ bool Blockchain::get_output_distribution(uint64_t amount, uint64_t from_height, 
 bool Blockchain::find_blockchain_supplement(const std::list<crypto::hash>& qblock_ids, uint64_t& starter_offset) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   // make sure the request includes at least the genesis block, otherwise
   // how can we expect to sync from the client that the block list came from?
@@ -2497,7 +2497,7 @@ template<class t_ids_container, class t_blocks_container, class t_missed_contain
 bool Blockchain::get_blocks(const t_ids_container& block_ids, t_blocks_container& blocks, t_missed_container& missed_bs) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   reserve_container(blocks, block_ids.size());
   for (const auto& block_hash : block_ids)
@@ -2582,7 +2582,7 @@ static bool fill(BlockchainDB *db, const crypto::hash &tx_hash, tx_blob_entry &t
 bool Blockchain::get_transactions_blobs(const std::vector<crypto::hash>& txs_ids, std::vector<cryptonote::blobdata>& txs, std::vector<crypto::hash>& missed_txs, bool pruned) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   txs.reserve(txs_ids.size());
   for (const auto& tx_hash : txs_ids)
@@ -2606,7 +2606,7 @@ bool Blockchain::get_transactions_blobs(const std::vector<crypto::hash>& txs_ids
 bool Blockchain::get_transactions_blobs(const std::vector<crypto::hash>& txs_ids, std::vector<tx_blob_entry>& txs, std::vector<crypto::hash>& missed_txs, bool pruned) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   txs.reserve(txs_ids.size());
   for (const auto& tx_hash : txs_ids)
@@ -2631,7 +2631,7 @@ template<class t_ids_container, class t_tx_container, class t_missed_container>
 bool Blockchain::get_split_transactions_blobs(const t_ids_container& txs_ids, t_tx_container& txs, t_missed_container& missed_txs) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   reserve_container(txs, txs_ids.size());
   for (const auto& tx_hash : txs_ids)
@@ -2665,7 +2665,7 @@ template<class t_ids_container, class t_tx_container, class t_missed_container>
 bool Blockchain::get_transactions(const t_ids_container& txs_ids, t_tx_container& txs, t_missed_container& missed_txs, bool pruned) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   reserve_container(txs, txs_ids.size());
   for (const auto& tx_hash : txs_ids)
@@ -2701,7 +2701,7 @@ bool Blockchain::get_transactions(const t_ids_container& txs_ids, t_tx_container
 bool Blockchain::find_blockchain_supplement(const std::list<crypto::hash>& qblock_ids, std::vector<crypto::hash>& hashes, std::vector<uint64_t>* weights, uint64_t& start_height, uint64_t& current_height, bool clip_pruned) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   // if we can't find the split point, return false
   if(!find_blockchain_supplement(qblock_ids, start_height))
@@ -2740,7 +2740,7 @@ bool Blockchain::find_blockchain_supplement(const std::list<crypto::hash>& qbloc
 bool Blockchain::find_blockchain_supplement(const std::list<crypto::hash>& qblock_ids, bool clip_pruned, NOTIFY_RESPONSE_CHAIN_ENTRY::request& resp) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   bool result = find_blockchain_supplement(qblock_ids, resp.m_block_ids, &resp.m_block_weights, resp.start_height, resp.total_height, clip_pruned);
   if (result)
@@ -2760,7 +2760,7 @@ bool Blockchain::find_blockchain_supplement(const std::list<crypto::hash>& qbloc
 bool Blockchain::find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::tuple<crypto::hash, crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, crypto::hash& top_hash, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, const bool qblock_ids_exclusive, size_t max_block_count, size_t max_tx_count) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
   top_hash = m_db->top_block_hash(&total_height);
   ++total_height;
@@ -2819,7 +2819,7 @@ bool Blockchain::add_block_as_invalid(const block& bl, const crypto::hash& h)
 bool Blockchain::add_block_as_invalid(const block_extended_info& bei, const crypto::hash& h)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
   auto i_res = m_invalid_blocks.insert(std::map<crypto::hash, block_extended_info>::value_type(h, bei));
   CHECK_AND_ASSERT_MES(i_res.second, false, "at insertion invalid by tx returned status existed");
   MINFO("BLOCK ADDED AS INVALID: " << h << std::endl << ", prev_id=" << bei.bl.prev_id << ", m_invalid_blocks count=" << m_invalid_blocks.size());
@@ -2829,7 +2829,7 @@ bool Blockchain::add_block_as_invalid(const block_extended_info& bei, const cryp
 void Blockchain::flush_invalid_blocks()
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
   m_invalid_blocks.clear();
 }
 //------------------------------------------------------------------
@@ -2867,7 +2867,7 @@ bool Blockchain::have_block_unlocked(const crypto::hash& id, int *where) const
 //------------------------------------------------------------------
 bool Blockchain::have_block(const crypto::hash& id, int *where) const
 {
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   return have_block_unlocked(id, where);
 }
 //------------------------------------------------------------------
@@ -2898,7 +2898,7 @@ size_t Blockchain::get_total_transactions() const
 bool Blockchain::check_for_double_spend(const transaction& tx, key_images_container& keys_this_block) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   struct add_transaction_input_visitor: public boost::static_visitor<bool>
   {
     key_images_container& m_spent_keys;
@@ -2958,7 +2958,7 @@ bool Blockchain::check_for_double_spend(const transaction& tx, key_images_contai
 bool Blockchain::get_tx_outputs_gindexs(const crypto::hash& tx_id, size_t n_txes, std::vector<std::vector<uint64_t>>& indexs) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   uint64_t tx_index;
   if (!m_db->tx_exists(tx_id, tx_index))
   {
@@ -2974,7 +2974,7 @@ bool Blockchain::get_tx_outputs_gindexs(const crypto::hash& tx_id, size_t n_txes
 bool Blockchain::get_tx_outputs_gindexs(const crypto::hash& tx_id, std::vector<uint64_t>& indexs) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   uint64_t tx_index;
   if (!m_db->tx_exists(tx_id, tx_index))
   {
@@ -3003,7 +3003,7 @@ bool Blockchain::check_tx_inputs(transaction& tx,
   bool kept_by_block) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
 
 #if defined(PER_BLOCK_CHECKPOINT)
   // check if we're doing per-block checkpointing
@@ -3629,7 +3629,7 @@ void Blockchain::get_dynamic_base_fee_estimate_2021_scaling(uint64_t base_reward
 
 void Blockchain::get_dynamic_base_fee_estimate_2021_scaling(uint64_t grace_blocks, std::vector<uint64_t> &fees) const
 {
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_lock);
   const uint8_t version = get_current_hard_fork_version();
   const uint64_t db_height = m_db->height();
 
@@ -3876,7 +3876,7 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
   LOG_PRINT_L3("Blockchain::" << __func__);
 
   TIME_MEASURE_START(block_processing_time);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
   TIME_MEASURE_START(t1);
 
   static bool seen_future_version = false;
@@ -4371,7 +4371,7 @@ bool Blockchain::prune_blockchain(uint32_t pruning_seed)
 {
   m_tx_pool.lock();
   const epee::scope_guard unlocker([&](){m_tx_pool.unlock();});
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
 
   return m_db->prune_blockchain(pruning_seed);
 }
@@ -4380,7 +4380,7 @@ bool Blockchain::update_blockchain_pruning()
 {
   m_tx_pool.lock();
   const epee::scope_guard unlocker([&](){m_tx_pool.unlock();});
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
 
   return m_db->update_pruning();
 }
@@ -4389,7 +4389,7 @@ bool Blockchain::check_blockchain_pruning()
 {
   m_tx_pool.lock();
   const epee::scope_guard unlocker([&](){m_tx_pool.unlock();});
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
 
   return m_db->check_pruning();
 }
@@ -4538,7 +4538,7 @@ void Blockchain::check_against_checkpoints(const checkpoints& points, bool enfor
   const auto& pts = points.get_points();
   bool stop_batch;
 
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
   stop_batch = m_db->batch_start();
   const uint64_t blockchain_height = m_db->height();
   for (const auto& pt : pts)
@@ -4731,7 +4731,7 @@ uint64_t Blockchain::prevalidate_block_hashes(uint64_t height, const std::vector
 
   CHECK_AND_ASSERT_MES(weights.empty() || weights.size() == hashes.size(), 0, "Unexpected weights size");
 
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_lock);
 
   // easy case: height >= hashes
   if (height >= m_blocks_hash_of_hashes.size() * HASH_OF_HASHES_STEP)
@@ -5289,7 +5289,7 @@ void Blockchain::add_block_notify(BlockNotifyCallback&& notify)
 {
   if (notify)
   {
-    CRITICAL_REGION_LOCAL(m_blockchain_lock);
+    RWLOCK(m_blockchain_lock);
     m_block_notifiers.push_back(std::move(notify));
   }
 }
@@ -5298,7 +5298,7 @@ void Blockchain::add_miner_notify(MinerNotifyCallback&& notify)
 {
   if (notify)
   {
-    CRITICAL_REGION_LOCAL(m_blockchain_lock);
+    RWLOCK(m_blockchain_lock);
     m_miner_notifiers.push_back(std::move(notify));
   }
 }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -64,6 +64,7 @@
 #include "checkpoints/checkpoints.h"
 #include "cryptonote_basic/hardfork.h"
 #include "blockchain_db/blockchain_db.h"
+#include "common/recursive_shared_mutex.h"
 
 namespace tools { class Notify; }
 
@@ -1172,7 +1173,7 @@ namespace cryptonote
 
     tx_memory_pool& m_tx_pool;
 
-    mutable epee::critical_section m_blockchain_lock; // TODO: add here reader/writer lock
+    mutable tools::recursive_shared_mutex m_blockchain_lock;
 
     // main chain
     size_t m_current_block_cumul_weight_limit;

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -77,6 +77,7 @@ set(unit_tests_sources
   parse_amount.cpp
   pruning.cpp
   random.cpp
+  recursive_shared_mutex.cpp
   rolling_median.cpp
   scaling_2021.cpp
   serialization.cpp

--- a/tests/unit_tests/recursive_shared_mutex.cpp
+++ b/tests/unit_tests/recursive_shared_mutex.cpp
@@ -1,0 +1,231 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+#include <boost/thread.hpp>
+
+#include "common/recursive_shared_mutex.h"
+
+TEST(recursive_shared_mutex, single_thread_write_recursion)
+{
+    tools::recursive_shared_mutex lock;
+    lock.lock();
+    lock.lock();
+    lock.unlock();
+    lock.unlock();
+}
+
+TEST(recursive_shared_mutex, single_thread_read_recursion)
+{
+    tools::recursive_shared_mutex lock;
+    lock.lock_shared();
+    lock.lock_shared();
+    lock.unlock_shared();
+    lock.unlock_shared();
+}
+
+TEST(recursive_shared_mutex, write_implies_read)
+{
+    tools::recursive_shared_mutex lock;
+    lock.lock();
+    lock.lock_shared();
+    lock.unlock_shared();
+    lock.unlock();
+}
+
+TEST(recursive_shared_mutex, try_lock_uncontended)
+{
+    tools::recursive_shared_mutex lock;
+    ASSERT_TRUE(lock.try_lock());
+    lock.unlock();
+
+    ASSERT_TRUE(lock.try_lock_shared());
+    lock.unlock_shared();
+}
+
+TEST(recursive_shared_mutex, upgrade_shared_to_exclusive_throws)
+{
+    tools::recursive_shared_mutex lock;
+    lock.lock_shared();
+    EXPECT_THROW(lock.lock(), std::runtime_error);
+    lock.unlock_shared();
+}
+
+TEST(recursive_shared_mutex, try_upgrade_shared_to_exclusive_throws)
+{
+    tools::recursive_shared_mutex lock;
+    lock.lock_shared();
+    EXPECT_THROW(lock.try_lock(), std::runtime_error);
+    lock.unlock_shared();
+}
+
+TEST(recursive_shared_mutex, stray_unlock_throws)
+{
+    tools::recursive_shared_mutex lock;
+    EXPECT_THROW(lock.unlock(), std::runtime_error);
+}
+
+TEST(recursive_shared_mutex, stray_unlock_shared_throws)
+{
+    tools::recursive_shared_mutex lock;
+    EXPECT_THROW(lock.unlock_shared(), std::runtime_error);
+}
+
+TEST(recursive_shared_mutex, unlock_while_holding_shared_only_throws)
+{
+    tools::recursive_shared_mutex lock;
+    lock.lock_shared();
+    EXPECT_THROW(lock.unlock(), std::runtime_error);
+    lock.unlock_shared();
+}
+
+TEST(recursive_shared_mutex, unlock_shared_while_holding_exclusive_throws)
+{
+    tools::recursive_shared_mutex lock;
+    lock.lock();
+    EXPECT_THROW(lock.unlock_shared(), std::runtime_error);
+    lock.unlock();
+}
+
+TEST(recursive_shared_mutex, unlock_shared_nested_under_exclusive_does_not_throw)
+{
+    tools::recursive_shared_mutex lock;
+    lock.lock();
+    lock.lock_shared();
+    lock.unlock_shared(); // not the outermost release, so this must not be mistaken for a mismatch
+    lock.unlock();
+}
+
+TEST(recursive_shared_mutex, misuse_does_not_poison_subsequent_use)
+{
+    tools::recursive_shared_mutex lock;
+    EXPECT_THROW(lock.unlock(), std::runtime_error);
+
+    // a prior stray unlock() must not leave the thread's counter corrupted
+    lock.lock();
+    lock.unlock();
+
+    lock.lock_shared();
+    lock.unlock_shared();
+}
+
+TEST(recursive_shared_mutex, concurrent_readers_do_not_block_each_other)
+{
+    tools::recursive_shared_mutex lock;
+    lock.lock_shared();
+
+    std::atomic<bool> acquired(false);
+    boost::thread other([&lock, &acquired]()
+    {
+        lock.lock_shared();
+        acquired = true;
+        lock.unlock_shared();
+    });
+
+    boost::this_thread::sleep_for(boost::chrono::milliseconds(200));
+    EXPECT_TRUE(acquired.load());
+
+    lock.unlock_shared();
+    other.join();
+}
+
+namespace
+{
+    constexpr int reading_cycles_min = 2;
+    constexpr int reading_cycles_max = 10;
+    constexpr int reading_step_duration_min = 1;
+    constexpr int reading_step_duration_max = 4;
+
+    constexpr int writing_cycles_min = 2;
+    constexpr int writing_cycles_max = 10;
+    constexpr int writing_step_duration_min = 1;
+    constexpr int writing_step_duration_max = 4;
+
+    void reader(tools::recursive_shared_mutex &lock);
+    void writer(tools::recursive_shared_mutex &lock);
+
+    void reader(tools::recursive_shared_mutex &lock)
+    {
+        std::random_device dev;
+        std::mt19937 rng(dev());
+        std::uniform_int_distribution<int> cycles_dist(reading_cycles_min, reading_cycles_max);
+        std::uniform_int_distribution<int> duration_dist(reading_step_duration_min, reading_step_duration_max);
+        const int reading_cycles = cycles_dist(rng);
+
+        lock.lock_shared();
+        for (int i = 0; i < reading_cycles; ++i)
+            boost::this_thread::sleep_for(boost::chrono::milliseconds(duration_dist(rng)));
+
+        const bool recurse = std::uniform_int_distribution<int>(0, 3)(rng) == 0; // ~25%
+        if (recurse)
+        {
+            if (std::uniform_int_distribution<int>(0, 1)(rng))
+                writer(lock);
+            else
+                reader(lock);
+        }
+        lock.unlock_shared();
+    }
+
+    void writer(tools::recursive_shared_mutex &lock)
+    {
+        std::random_device dev;
+        std::mt19937 rng(dev());
+        std::uniform_int_distribution<int> cycles_dist(writing_cycles_min, writing_cycles_max);
+        std::uniform_int_distribution<int> duration_dist(writing_step_duration_min, writing_step_duration_max);
+        const int writing_cycles = cycles_dist(rng);
+
+        lock.lock();
+        for (int i = 0; i < writing_cycles; ++i)
+            boost::this_thread::sleep_for(boost::chrono::milliseconds(duration_dist(rng)));
+
+        const bool recurse = std::uniform_int_distribution<int>(0, 3)(rng) == 0; // ~25%
+        if (recurse)
+        {
+            if (std::uniform_int_distribution<int>(0, 1)(rng))
+                writer(lock);
+            else
+                reader(lock);
+        }
+        lock.unlock();
+    }
+
+    void run_deadlock_stress_test(size_t num_threads)
+    {
+        tools::recursive_shared_mutex lock;
+        std::random_device dev;
+        std::mt19937 rng(dev());
+        std::uniform_int_distribution<int> which_dist(0, 1);
+
+        std::vector<boost::thread> threads;
+        threads.reserve(num_threads);
+        for (size_t i = 0; i < num_threads; ++i)
+        {
+            if (which_dist(rng))
+                threads.emplace_back(reader, std::ref(lock));
+            else
+                threads.emplace_back(writer, std::ref(lock));
+        }
+
+        for (auto &thread : threads)
+            thread.join();
+    }
+} // namespace
+
+TEST(recursive_shared_mutex, deadlock_stress_4_threads)
+{
+    run_deadlock_stress_test(4);
+}
+
+TEST(recursive_shared_mutex, deadlock_stress_16_threads)
+{
+    run_deadlock_stress_test(16);
+}
+
+TEST(recursive_shared_mutex, deadlock_stress_64_threads)
+{
+    run_deadlock_stress_test(64);
+}

--- a/tests/unit_tests/recursive_shared_mutex.cpp
+++ b/tests/unit_tests/recursive_shared_mutex.cpp
@@ -159,14 +159,11 @@ namespace
         for (int i = 0; i < reading_cycles; ++i)
             boost::this_thread::sleep_for(boost::chrono::milliseconds(duration_dist(rng)));
 
+        // a shared holder must never recurse into writer(): shared -> exclusive upgrade is
+        // unsupported and is now a hard failure, not silent mutual-exclusion corruption
         const bool recurse = std::uniform_int_distribution<int>(0, 3)(rng) == 0; // ~25%
         if (recurse)
-        {
-            if (std::uniform_int_distribution<int>(0, 1)(rng))
-                writer(lock);
-            else
-                reader(lock);
-        }
+            reader(lock);
         lock.unlock_shared();
     }
 


### PR DESCRIPTION
Replaces the recursive mutex used in `src/cryptonote_core/blockchain.{cpp,h}` with a read-write lock mechanism. This PR is heavily based on #9181, with a few tweaks and updates.

Related: #11063, #11051

Below is a graph of RPC wallet sync performance before and after these changes (also with #11051):
<img width="1163" height="875" alt="monerod-rpc-threads-three-way-fast-wallet-suite" src="https://github.com/user-attachments/assets/3f2a2625-c07c-4fc9-abc3-ce2d874c2c54" />