### PR TITLE
protocol: reduce log level for one-block sync candidates

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -518,7 +518,7 @@ namespace cryptonote
     uint64_t max_block_height = std::max(hshd.current_height,m_core.get_current_blockchain_height());
     uint64_t last_block_v1 = m_core.get_nettype() == TESTNET ? 624633 : m_core.get_nettype() == MAINNET ? 1009826 : (uint64_t)-1;
     uint64_t diff_v2 = max_block_height > last_block_v1 ? std::min(abs_diff, max_block_height - last_block_v1) : 0;
-    MCLOG(is_inital ? el::Level::Info : el::Level::Debug, "global", el::Color::Yellow, context <<  "Sync data returned a new top block candidate: " << m_core.get_current_blockchain_height() << " -> " << hshd.current_height
+    MCLOG(is_inital && abs_diff > 1 ? el::Level::Info : el::Level::Debug, "global", el::Color::Yellow, context <<  "Sync data returned a new top block candidate: " << m_core.get_current_blockchain_height() << " -> " << hshd.current_height
       << " [Your node is " << abs_diff << " blocks (" << tools::get_human_readable_timespan((abs_diff - diff_v2) * DIFFICULTY_TARGET_V1 + diff_v2 * DIFFICULTY_TARGET_V2) << ") "
       << (0 <= diff ? std::string("behind") : std::string("ahead"))
       << "] " << ENDL << "SYNCHRONIZATION started");


### PR DESCRIPTION
Should reduce noise at default log level.

```
2026-08-19 21:27:04.639 I [<redacted>:38396 INC] Sync data returned a new top block candidate: 3743850 -> 3743851 [Your node is 1 blocks (2.0 minutes) behind]
2026-08-19 21:27:04.639 I SYNCHRONIZATION started
2026-08-19 21:30:16.623 I [<redacted>:39894 INC] Sync data returned a new top block candidate: 3743852 -> 3743853 [Your node is 1 blocks (2.0 minutes) behind]
2026-08-19 21:30:16.623 I SYNCHRONIZATION started
2026-08-19 23:13:26.549 I [<redacted>:52302 INC] Sync data returned a new top block candidate: 3743910 -> 3743911 [Your node is 1 blocks (2.0 minutes) behind]
2026-08-19 23:13:26.549 I SYNCHRONIZATION started
2026-08-20 01:28:29.495 I [<redacted>:6438 INC] Sync data returned a new top block candidate: 3743985 -> 3743986 [Your node is 1 blocks (2.0 minutes) behind]
2026-08-20 01:28:29.495 I SYNCHRONIZATION started
```