### PR TITLE
wallet: encode equals signs in URIs

### DIFF
--- a/contrib/epee/include/net/abstract_http_client.h
+++ b/contrib/epee/include/net/abstract_http_client.h
@@ -43,7 +43,7 @@ namespace net_utils
   inline const char* get_unsave_chars()
   {
     //static constexpr char unsave_chars[] = "\"<>%\\^[]`+$,@:;/!#?=&";
-    static constexpr const char unsave_chars[] = "\"<>%\\^[]`+$,@:;!#&";
+    static constexpr const char unsave_chars[] = "\"<>%\\^[]`+$,@:;!#&=";
     return unsave_chars;
   }
 

--- a/tests/unit_tests/uri.cpp
+++ b/tests/unit_tests/uri.cpp
@@ -274,3 +274,19 @@ TEST(uri, url_encoded_once)
   ASSERT_EQ(description, "foo 20");
 }
 
+TEST(uri, make_uri_encodes_equals)
+{
+  tools::wallet2 w(cryptonote::TESTNET);
+  std::string error;
+  const std::string uri = w.make_uri(TEST_ADDRESS, "", 0, "key=value", "name=value", error);
+
+  ASSERT_TRUE(error.empty());
+  ASSERT_EQ(uri, "monero:" TEST_ADDRESS"?recipient_name=name%3Dvalue&tx_description=key%3Dvalue");
+
+  std::string address, payment_id, recipient_name, description;
+  uint64_t amount;
+  std::vector<std::string> unknown_parameters;
+  ASSERT_TRUE(w.parse_uri(uri, address, payment_id, amount, description, recipient_name, unknown_parameters, error));
+  EXPECT_EQ(recipient_name, "name=value");
+  EXPECT_EQ(description, "key=value");
+}


### PR DESCRIPTION
## Summary

`make_uri()` currently leaves `=` unescaped in `recipient_name` and `tx_description`

`parse_uri()` uses `=` as the parameter delimiter, so those generated URIs fail to round-trip

encode it as `%3D` and cover both fields with a round-trip test

this handles the behavior change separately from the conversion refactor in #10265, as discussed there

## Tests

- `build-system/tests/unit_tests/unit_tests --gtest_filter='uri.*'`
- `python3 tests/functional_tests/functional_tests_rpc.py /usr/bin/python3 "$PWD/tests/functional_tests" "$PWD/build-system" uri`