### PR TITLE
wallet2: fix data races in refresh error handlers

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4177,6 +4177,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
         }
         catch (const tools::error::out_of_hashchain_bounds_error&)
         {
+          waiter.wait();
           MINFO("Daemon claims next refresh block is out of hash chain bounds, resetting hash chain");
           uint64_t stop_height = m_blockchain.offset();
           std::vector<crypto::hash> tip(m_blockchain.size() - m_blockchain.offset());
@@ -4200,6 +4201,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
         }
         catch (const std::exception &e)
         {
+          waiter.wait();
           MERROR("Error parsing blocks: " << e.what());
           exception = std::current_exception();
           error = true;


### PR DESCRIPTION
Found while reviewing #11150

The task submitted at wallet2.cpp:4170 shares `short_chain_history`, `start_height`, `error` and `exception` with the refresh thread. Both `catch` handlers around `process_parsed_blocks()` write to that state but the task is not waited for until 4209. The first handler never gets that far because it always throws at 4199.

The two added `wait()` calls ignore their return value on purpose: `waiter` never clears its error flag once a task has failed so the checked `wait()` below still reports it.