### PR TITLE
simplewallet: suggest hw_reconnect on refresh

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5621,6 +5621,7 @@ bool simple_wallet::refresh_main(uint64_t start_height, enum ResetType reset, bo
   uint64_t fetched_blocks = 0;
   bool received_money = false;
   bool ok = false;
+  bool suggest_hw_reconnect = false;
   std::ostringstream ss;
   try
   {
@@ -5682,6 +5683,7 @@ bool simple_wallet::refresh_main(uint64_t start_height, enum ResetType reset, bo
   {
     LOG_ERROR("unexpected error: " << e.what());
     ss << tr("unexpected error: ") << e.what();
+    suggest_hw_reconnect = true;
   }
   catch (...)
   {
@@ -5691,7 +5693,10 @@ bool simple_wallet::refresh_main(uint64_t start_height, enum ResetType reset, bo
 
   if (!ok)
   {
-    fail_msg_writer() << tr("refresh failed: ") << ss.str() << ". " << tr("Blocks received: ") << fetched_blocks;
+    auto writer = fail_msg_writer();
+    writer << tr("refresh failed: ") << ss.str() << ". " << tr("Blocks received: ") << fetched_blocks;
+    if (suggest_hw_reconnect && m_wallet->key_on_device())
+      writer << "\n" << tr("Check that the HW wallet is connected and unlocked, then run 'hw_reconnect' before refreshing again.");
   }
 
   // prevent it from triggering the idle screen due to waiting for a foreground refresh


### PR DESCRIPTION
Fixes #11126

Hardware device errors during refresh reach the generic exception handler, so the CLI currently gives no recovery path

This adds an `hw_reconnect` hint for hardware wallets while leaving known daemon and wallet errors unchanged

Tests:
- `DNS_PUBLIC=tcp ctest --test-dir build-ci --output-on-failure -E core_tests`
- `ctest --test-dir build-core --output-on-failure -R core_tests`