### PR TITLE
miner: allow zero background mining sleep

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -782,12 +782,13 @@ namespace cryptonote
           previous_process_time = current_process_time;
 
           // adjust the miner extra sleep variable
-          int64_t miner_extra_sleep_change = (-1 * (get_mining_target() - process_percentage) );
-          int64_t new_miner_extra_sleep = m_miner_extra_sleep + miner_extra_sleep_change;
-          // if you start the miner with few threads on a multicore system, this could
-          // fall below zero because all the time functions aggregate across all processors.
-          // I'm just hard limiting to 5 millis min sleep here, other options?
-          m_miner_extra_sleep = std::max( new_miner_extra_sleep , (int64_t)5 );
+          const int64_t miner_extra_sleep_change =
+            int64_t{process_percentage} - int64_t{get_mining_target()};
+          const int64_t new_miner_extra_sleep =
+            static_cast<int64_t>(m_miner_extra_sleep.load()) + miner_extra_sleep_change;
+          // A target above the available mining threads' capacity can drive this
+          // below zero because the time functions aggregate across all processors.
+          m_miner_extra_sleep = std::max(new_miner_extra_sleep, int64_t{0});
           MDEBUG("m_miner_extra_sleep " << m_miner_extra_sleep);
         }
         


### PR DESCRIPTION
Fixes #8986

The background mining controller clamps per-hash sleep to 5 ms, so targets above the aggregate capacity of the available mining threads keep throttling even when the controller needs to run them at full speed

This lets the controller saturate at zero sleep and keeps the adjustment arithmetic signed

Tests:
- `cmake --build build --target monerod unit_tests test_notifier --parallel 2`
- `./build/tests/unit_tests/unit_tests` (1299 passed, 2 skipped)
- regtest with one background mining thread and a 100% target (`307 -> 208 -> 109 -> 10 -> 0 ms`)
