### PR TITLE
wallet2_api: respect use_ssl

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -2526,7 +2526,10 @@ void WalletImpl::pendingTxPostProcess(PendingTransactionImpl * pending)
 
 bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_address, uint64_t upper_transaction_size_limit, bool ssl)
 {
-    if (!m_wallet->init(daemon_address, m_daemon_login, proxy_address, upper_transaction_size_limit))
+    const auto ssl_support = ssl
+        ? epee::net_utils::ssl_support_t::e_ssl_support_enabled
+        : epee::net_utils::ssl_support_t::e_ssl_support_disabled;
+    if (!m_wallet->init(daemon_address, m_daemon_login, proxy_address, upper_transaction_size_limit, true, ssl_support))
        return false;
 
     // in case new wallet, this will force fast-refresh (pulling hashes instead of blocks)

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -542,6 +542,7 @@ struct Wallet
      * \param upper_transaction_size_limit
      * \param daemon_username
      * \param daemon_password
+     * \param use_ssl - enable SSL for the daemon connection
      * \param lightWallet - deprecated
      * \param proxy_address - set proxy address, empty string to disable
      * \return  - true on success


### PR DESCRIPTION
Fixes #10992

`Wallet::init()` forwards `use_ssl` to `doInit()`, but `doInit()` currently leaves `wallet2` on SSL autodetection. This makes plain HTTP and onion daemon connections try TLS first even when callers explicitly disable it

Pass the requested SSL mode to `wallet2` and document the public parameter

Tests:
- `ctest --test-dir build --output-on-failure -R "^libwallet_api_tests$"`
- `ctest --test-dir build --output-on-failure -R "^unit_tests$"`
- local socket regression check confirming `use_ssl=false` starts directly with HTTP