### PR TITLE
blockchain_utilities: fix memory safety bugs

### DIFF
--- a/src/blockchain_utilities/blockchain_ancestry.cpp
+++ b/src/blockchain_utilities/blockchain_ancestry.cpp
@@ -39,6 +39,7 @@
 #include "cryptonote_basic/cryptonote_boost_serialization.h"
 #include "cryptonote_core/cryptonote_core.h"
 #include "version.h"
+#include "misc_log_ex.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "bcutil"
@@ -158,7 +159,11 @@ struct ancestry_state_t
     {
       std::unordered_map<uint64_t, cryptonote::block> old_block_cache;
       a & old_block_cache;
-      block_cache.resize(old_block_cache.size());
+      uint64_t max_height = 0;
+      for (const auto& i: old_block_cache)
+        max_height = std::max(max_height, i.first);
+      CHECK_AND_ASSERT_THROW_MES(old_block_cache.empty() || max_height < block_cache.max_size(), "Corrupt ancestry state: block height too large");
+      block_cache.resize(old_block_cache.empty() ? 0 : max_height + 1);
       for (const auto& i: old_block_cache)
         block_cache[i.first] = i.second;
     }

--- a/src/blockchain_utilities/blockchain_stats.cpp
+++ b/src/blockchain_utilities/blockchain_stats.cpp
@@ -334,7 +334,7 @@ plot 'stats.csv' index "DATA" using (timecolumn(1,"%Y-%m-%d")):4 with lines, '' 
           maxins = io;
         totins += io;
       }
-      if (do_ringsize) {
+      if (do_ringsize && !tx.vin.empty() && tx.vin[0].type() == typeid(cryptonote::txin_to_key)) {
         const cryptonote::txin_to_key& tx_in_to_key
                        = boost::get<cryptonote::txin_to_key>(tx.vin[0]);
         io = tx_in_to_key.key_offsets.size();


### PR DESCRIPTION
- An out-of-bounds write could have occurred when loading a pre-v2 ancestry state file; the vector is sized by map entry count but indexed by block height, so non-contiguous heights would overflow the buffer.
- `tx.vin[0]` is read with no bounds check under `--with-ringsize`, which results in an out-of-bounds read if a stored transaction has zero inputs.

Both of these issues were found by an LLM.