### PR TITLE
src: reduce unnecessary copies/allocations

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3736,6 +3736,7 @@ bool Blockchain::check_tx_input(size_t tx_version, const txin_to_key& txin, cons
   };
 
   output_keys.clear();
+  output_keys.reserve(txin.key_offsets.size());
 
   // collect output keys
   outputs_visitor vi(output_keys, *this, hf_version);
@@ -4291,7 +4292,7 @@ leave:
     {
       uint64_t long_term_block_weight = get_next_long_term_block_weight(block_weight);
       cryptonote::blobdata bd = cryptonote::block_to_blob(bl);
-      new_height = m_db->add_block(std::make_pair(std::move(bl), std::move(bd)), block_weight, long_term_block_weight, cumulative_difficulty, already_generated_coins, txs);
+      new_height = m_db->add_block(std::make_pair(bl, std::move(bd)), block_weight, long_term_block_weight, cumulative_difficulty, already_generated_coins, txs);
     }
     catch (const KEY_IMAGE_EXISTS& e)
     {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1777,9 +1777,10 @@ namespace cryptonote
     const uint32_t max_nonce = restricted ? 16384 : 65535;
     bool collision = true;
     std::vector<uint32_t> slots(aux_pow.size());
+    std::vector<bool> slot_seen(aux_pow.size(), false);
     for (nonce = 0; nonce <= max_nonce; ++nonce)
     {
-      std::vector<bool> slot_seen(aux_pow.size(), false);
+      slot_seen.assign(aux_pow.size(), false);
       collision = false;
       for (size_t idx = 0; idx < aux_pow.size(); ++idx)
         slots[idx] = 0xffffffff;


### PR DESCRIPTION
Attempts to reduce the number of redundant copies/allocations; also removes some uses of `std::move` that are no-ops.