### PR TITLE
wallet2: fix gamma picker output boundaries

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1098,7 +1098,7 @@ uint64_t gamma_picker::pick()
     return std::numeric_limits<uint64_t>::max(); // bad pick
   output_index = num_rct_outputs - 1 - output_index;
 
-  const uint64_t *it = std::lower_bound(begin, end, output_index);
+  const uint64_t *it = std::upper_bound(begin, end, output_index);
   THROW_WALLET_EXCEPTION_IF(it == end, error::wallet_internal_error, "output_index not found");
   uint64_t index = std::distance(begin, it);
 

--- a/tests/unit_tests/output_selection.cpp
+++ b/tests/unit_tests/output_selection.cpp
@@ -147,7 +147,7 @@ TEST(select_outputs, density)
     uint64_t o = picker.pick();
     if (o >= n_outs)
       continue;
-    auto it = std::lower_bound(offsets.begin(), offsets.end(), o);
+    auto it = std::upper_bound(offsets.begin(), offsets.end(), o);
     auto idx = std::distance(offsets.begin(), it);
     ASSERT_LT(idx, picks.size());
     ++picks[idx];
@@ -191,7 +191,7 @@ TEST(select_outputs, same_distribution)
     uint64_t o = picker.pick();
     if (o >= n_outs)
       continue;
-    auto it = std::lower_bound(offsets.begin(), offsets.end(), o);
+    auto it = std::upper_bound(offsets.begin(), offsets.end(), o);
     auto idx = std::distance(offsets.begin(), it);
     ASSERT_LT(idx, chain_picks.size());
     ++chain_picks[idx];
@@ -222,7 +222,7 @@ TEST(select_outputs, same_distribution)
 TEST(select_outputs, exact_unlock_block)
 {
   std::vector<uint64_t> offsets;
-  MKOFFSETS(300000, 1 + (crypto::rand<size_t>() & 0x1f));
+  MKOFFSETS(300000, 1);
   tools::gamma_picker picker(offsets);
 
   // Calculate output offset ranges for the very first block that is spendable.


### PR DESCRIPTION
`rct_offsets` stores cumulative exclusive output counts, while the gamma picker output index is zero-based. `lower_bound` therefore maps the first output of each block to the preceding block

Use `upper_bound` for the production lookup and the matching test-side mappings. The newest-spendable-block test now uses one output per block, which reproduces this boundary case every time

This fixes the boundary failure reported in #10350. The statistical test hardening in #8024 is separate

Tests:
- `build/tests/unit_tests/unit_tests --data-dir tests/data --gtest_filter="select_outputs.*"`
- `ctest --test-dir build/tests/unit_tests --output-on-failure -j2`
- the same checks with Clang 19
- boundary tests repeated 1000 times
- distribution tests repeated 25 times

Fixes #10350