### PR TITLE
depends: protobuf: don't use android system logging

### DIFF
--- a/contrib/depends/packages/protobuf.mk
+++ b/contrib/depends/packages/protobuf.mk
@@ -5,6 +5,7 @@ $(package)_download_path=$(native_$(package)_download_path)
 $(package)_file_name=$(native_$(package)_file_name)
 $(package)_sha256_hash=$(native_$(package)_sha256_hash)
 $(package)_dependencies=native_$(package)
+$(package)_patches=no-android-logging.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --with-protoc=$(build_prefix)/bin/protoc
@@ -13,6 +14,10 @@ endef
 
 define $(package)_config_cmds
   $($(package)_autoconf) AR_FLAGS=$($(package)_arflags)
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/no-android-logging.patch
 endef
 
 define $(package)_build_cmds

--- a/contrib/depends/patches/protobuf/no-android-logging.patch
+++ b/contrib/depends/patches/protobuf/no-android-logging.patch
@@ -1,0 +1,22 @@
+diff --git a/src/google/protobuf/stubs/common.cc b/src/google/protobuf/stubs/common.cc
+index e0a807f..7f2e7e7 100644
+--- a/src/google/protobuf/stubs/common.cc
++++ b/src/google/protobuf/stubs/common.cc
+@@ -45,7 +45,7 @@
+ #include <windows.h>
+ #define snprintf _snprintf    // see comment in strutil.cc
+ #endif
+-#if defined(__ANDROID__)
++#if 0
+ #include <android/log.h>
+ #endif
+ 
+@@ -121,7 +121,7 @@ std::string VersionString(int version) {
+ 
+ namespace internal {
+ 
+-#if defined(__ANDROID__)
++#if 0
+ inline void DefaultLogHandler(LogLevel level, const char* filename, int line,
+                               const std::string& message) {
+   if (level < GOOGLE_PROTOBUF_MIN_LOG_LEVEL) {

--- a/src/device_trezor/CMakeLists.txt
+++ b/src/device_trezor/CMakeLists.txt
@@ -75,7 +75,7 @@ if(DEVICE_TREZOR_READY)
         message(STATUS "Trezor: debugging enabled")
     endif()
 
-    if(ANDROID)
+    if(ANDROID AND NOT DEPENDS)
         set(TREZOR_EXTRA_LIBRARIES "log")
     endif()
 


### PR DESCRIPTION
So we don't need to link against `log` for no reason.

`log` isn't available as a static library in the Android NDK, preventing us from statically linking the Android build.