### PR TITLE
common: handle case-insensitive Content-Range

### DIFF
--- a/src/common/download.cpp
+++ b/src/common/download.cpp
@@ -127,7 +127,8 @@ namespace tools
             bool got_range = false;
             for (const auto &kv: headers.m_header_info.m_etc_fields)
             {
-              if (kv.first == "Content-Range" && tools::content_range_starts_at(kv.second, offset))
+              if (!epee::string_tools::compare_no_case(kv.first, "Content-Range") &&
+                  tools::content_range_starts_at(kv.second, offset))
               {
                 got_range = true;
                 break;


### PR DESCRIPTION
resumed downloads currently look for the exact `Content-Range` spelling even though HTTP field names are case-insensitive

when a server returns lowercase `content-range`, the client discards the existing prefix and writes only the 206 body while still reporting success

this uses the existing case-insensitive comparison helper

tests:
- clean GCC 14 build of `unit_tests`
- `unit_tests --gtest_filter='download.*'` (1/1 passed)
- `git diff --check`