### PR TITLE
net: reject i2p address ports, canonicalize host before dispatch

### DIFF
--- a/src/net/i2p_address.cpp
+++ b/src/net/i2p_address.cpp
@@ -146,9 +146,13 @@ namespace net
     expect<i2p_address> i2p_address::make(const boost::string_ref address)
     {
         boost::string_ref host = address.substr(0, address.rfind(':'));
+        const boost::string_ref port = address.substr(host.size() + (host.size() == address.size() ? 0 : 1));
+
         std::string normalized_host{host};
         net::canonicalize_host(normalized_host);
         MONERO_CHECK(host_check(normalized_host));
+
+        if (!port.empty()) return {net::error::invalid_port};
 
         static_assert(sizeof(i2p_address::host_) >= b32_length + sizeof(tld_b32) &&
                       sizeof(i2p_address::host_) >= i2p_name_max_length + sizeof(tld_i2p));

--- a/src/net/parse.cpp
+++ b/src/net/parse.cpp
@@ -33,6 +33,7 @@
 #include "net/socks.h"
 #include "net/tor_address.h"
 #include "net/i2p_address.h"
+#include "net/host.h"
 #include "string_tools.h"
 #include "string_tools_lexical.h"
 
@@ -163,6 +164,7 @@ namespace net
         bool ipv6 = false;
 
         get_network_address_host_and_port(std::string(address), host_str, port_str);
+        net::canonicalize_host(host_str);
 
         boost::string_ref host_str_ref(host_str);
         boost::string_ref port_str_ref(port_str);

--- a/tests/unit_tests/net.cpp
+++ b/tests/unit_tests/net.cpp
@@ -661,6 +661,19 @@ TEST(get_network_address, onion)
 
     address = net::get_network_address(std::string{v3_onion} + ":65536", 1000);
     EXPECT_EQ(net::error::invalid_port, address);
+
+    // dispatch to `tor_address::make` should not be case-sensitive, matching `canonicalize_host`
+    address = net::get_network_address(v3_onion_upper, 1000);
+    ASSERT_TRUE(bool(address));
+    EXPECT_EQ(epee::net_utils::address_type::tor, address->get_type_id());
+    EXPECT_STREQ(v3_onion, address->host_str().c_str());
+    EXPECT_EQ(std::string{v3_onion} + ":1000", address->str());
+
+    address = net::get_network_address(std::string{v3_onion_upper} + ":2000", 1000);
+    ASSERT_TRUE(bool(address));
+    EXPECT_EQ(epee::net_utils::address_type::tor, address->get_type_id());
+    EXPECT_STREQ(v3_onion, address->host_str().c_str());
+    EXPECT_EQ(std::string{v3_onion} + ":2000", address->str());
 }
 
 namespace
@@ -728,6 +741,13 @@ TEST(i2p_address, invalid)
     std::string i2p_standard{standard_i2p};
     i2p_standard.at(7) = 1;
     EXPECT_TRUE(net::i2p_address::make(i2p_standard).has_error());
+
+    // i2p addresses have no virtual ports, so any port suffix is rejected (see `i2p_address::port()`)
+    EXPECT_EQ(net::error::invalid_port, net::i2p_address::make(std::string{standard_i2p} + ":900a"));
+    EXPECT_EQ(net::error::invalid_port, net::i2p_address::make(std::string{standard_i2p} + ":65536"));
+    EXPECT_EQ(net::error::invalid_port, net::i2p_address::make(std::string{standard_i2p} + ":-1"));
+    EXPECT_EQ(net::error::invalid_port, net::i2p_address::make(std::string{b32_i2p} + ":kfsdhkfasd"));
+    EXPECT_EQ(net::error::invalid_port, net::i2p_address::make(std::string{standard_i2p} + ":80"));
 }
 
 TEST(i2p_address, unblockable_types)
@@ -789,7 +809,7 @@ TEST(i2p_address, valid_b32)
     EXPECT_FALSE(address2.less(*address1));
     EXPECT_FALSE(address1->less(address2));
 
-    address2 = MONERO_UNWRAP(net::i2p_address::make(std::string{b32_i2p_2} + ":6545"));
+    address2 = MONERO_UNWRAP(net::i2p_address::make(b32_i2p_2));
 
     EXPECT_EQ(1u, address2.port());
     EXPECT_STREQ(b32_i2p_2, address2.host_str());
@@ -806,7 +826,7 @@ TEST(i2p_address, valid_b32)
     EXPECT_FALSE(address2.less(*address1));
     EXPECT_TRUE(address1->less(address2));
 
-    net::i2p_address address3 = MONERO_UNWRAP(net::i2p_address::make(std::string{b32_i2p} + ":65535"));
+    net::i2p_address address3 = MONERO_UNWRAP(net::i2p_address::make(b32_i2p));
 
     EXPECT_EQ(1u, address3.port());
     EXPECT_STREQ(b32_i2p, address3.host_str());
@@ -862,7 +882,7 @@ TEST(i2p_address, valid_standard)
     EXPECT_FALSE(address2.less(*address1));
     EXPECT_FALSE(address1->less(address2));
 
-    address2 = MONERO_UNWRAP(net::i2p_address::make(std::string{standard_i2p_2} + ":6545"));
+    address2 = MONERO_UNWRAP(net::i2p_address::make(standard_i2p_2));
 
     EXPECT_EQ(1u, address2.port());
     EXPECT_STREQ(standard_i2p_2, address2.host_str());
@@ -879,7 +899,7 @@ TEST(i2p_address, valid_standard)
     EXPECT_FALSE(address1->less(address2));
     EXPECT_TRUE(address2.less(*address1));
 
-    net::i2p_address address3 = MONERO_UNWRAP(net::i2p_address::make(std::string{standard_i2p} + ":65535"));
+    net::i2p_address address3 = MONERO_UNWRAP(net::i2p_address::make(standard_i2p));
 
     EXPECT_EQ(1u, address3.port());
     EXPECT_STREQ(standard_i2p, address3.host_str());
@@ -1165,11 +1185,9 @@ TEST(get_network_address, i2p)
     EXPECT_STREQ(b32_i2p, address->host_str().c_str());
     EXPECT_EQ(std::string{b32_i2p}, address->str());
 
+    // i2p addresses have no virtual ports, so a port suffix is rejected
     address = net::get_network_address(std::string{b32_i2p} + ":2000", 1000);
-    ASSERT_TRUE(bool(address));
-    EXPECT_EQ(epee::net_utils::address_type::i2p, address->get_type_id());
-    EXPECT_STREQ(b32_i2p, address->host_str().c_str());
-    EXPECT_EQ(std::string{b32_i2p}, address->str());
+    EXPECT_EQ(net::error::invalid_port, address);
 
     address = net::get_network_address(standard_i2p, 1000);
     ASSERT_TRUE(bool(address));
@@ -1178,6 +1196,16 @@ TEST(get_network_address, i2p)
     EXPECT_EQ(std::string{standard_i2p}, address->str());
 
     address = net::get_network_address(std::string{standard_i2p} + ":2000", 1000);
+    EXPECT_EQ(net::error::invalid_port, address);
+
+    // dispatch to `i2p_address::make` should not be case-sensitive, matching `canonicalize_host`
+    address = net::get_network_address(b32_i2p_upper, 1000);
+    ASSERT_TRUE(bool(address));
+    EXPECT_EQ(epee::net_utils::address_type::i2p, address->get_type_id());
+    EXPECT_STREQ(b32_i2p, address->host_str().c_str());
+    EXPECT_EQ(std::string{b32_i2p}, address->str());
+
+    address = net::get_network_address("TEST.I2P", 1000);
     ASSERT_TRUE(bool(address));
     EXPECT_EQ(epee::net_utils::address_type::i2p, address->get_type_id());
     EXPECT_STREQ(standard_i2p, address->host_str().c_str());


### PR DESCRIPTION
- Ensures Tor/I2P hostnames are canonicalized before checking the TLD; previously, the case-sensitive check for the TLD was performed on the non-canonicalized string.
- Rejects provided ports of I2P addresses for correctness.
- Adds a few unit tests for good measure.