### PR TITLE
crypto: handle unaligned Groestl input

### DIFF
--- a/src/crypto/groestl.c
+++ b/src/crypto/groestl.c
@@ -9,6 +9,7 @@
  */
 
 #include <stddef.h>
+#include <string.h>
 #include "groestl.h"
 #include "groestl_tables.h"
 
@@ -124,7 +125,7 @@ static void RND512Q(uint8_t *x, uint32_t *y, uint32_t r) {
 }
 
 /* compute compression function (short variants) */
-static void F512(uint32_t *h, const uint32_t *m) {
+static void F512(uint32_t *h, const uint8_t *m) {
   int i;
   uint32_t Ptmp[2*COLS512];
   uint32_t Qtmp[2*COLS512];
@@ -132,8 +133,10 @@ static void F512(uint32_t *h, const uint32_t *m) {
   uint32_t z[2*COLS512];
 
   for (i = 0; i < 2*COLS512; i++) {
-    z[i] = m[i];
-    Ptmp[i] = h[i]^m[i];
+    uint32_t word;
+    memcpy(&word, m + i*sizeof(word), sizeof(word));
+    z[i] = word;
+    Ptmp[i] = h[i]^word;
   }
 
   /* compute Q(m) */
@@ -175,7 +178,7 @@ static void Transform(hashState *ctx,
   /* digest message, one block at a time */
   for (; msglen >= SIZE512; 
        msglen -= SIZE512, input += SIZE512) {
-    F512(ctx->chaining,(uint32_t*)input);
+    F512(ctx->chaining, input);
 
     /* increment block counter */
     ctx->block_counter1++;

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstdint>
+#include <cstring>
 #include <gtest/gtest.h>
 #include <memory>
 #include <sstream>
@@ -100,6 +101,26 @@ TEST(Crypto, null_keys)
   memset(zero, 0, 32);
   ASSERT_EQ(memcmp(crypto::null_skey.data, zero, 32), 0);
   ASSERT_EQ(memcmp(crypto::null_pkey.data, zero, 32), 0);
+}
+
+TEST(Crypto, groestl_unaligned_input)
+{
+  constexpr std::size_t input_size = 128;
+  alignas(std::uint32_t) std::uint8_t aligned[input_size];
+  alignas(std::uint32_t) std::uint8_t input[input_size + alignof(std::uint32_t)];
+  char expected[crypto::HASH_SIZE];
+  char actual[crypto::HASH_SIZE];
+
+  for (std::size_t i = 0; i < input_size; ++i)
+    aligned[i] = static_cast<std::uint8_t>(i);
+  crypto::hash_extra_groestl(aligned, input_size, expected);
+
+  for (std::size_t offset = 0; offset < alignof(std::uint32_t); ++offset)
+  {
+    std::memcpy(input + offset, aligned, input_size);
+    crypto::hash_extra_groestl(input + offset, input_size, actual);
+    EXPECT_EQ(0, std::memcmp(expected, actual, sizeof(expected)));
+  }
 }
 
 TEST(Crypto, verify_32)


### PR DESCRIPTION
This removes unaligned `uint32_t` reads from Groestl's full-block path

`hash_extra_groestl` accepts byte buffers, but `Transform` passed each full block to `F512` as `uint32_t *`. Strict-alignment targets can raise `SIGBUS` when the input is not 4-byte aligned. Loading each word through `memcpy` keeps arbitrary inputs alignment-safe without adding a separate staging buffer

The regression test covers every alignment modulo 4 across two full blocks

Related to #10076

Tests:
- `./build-normal/tests/unit_tests/unit_tests --gtest_filter=Crypto.groestl_unaligned_input`
- `ctest --test-dir build-normal -R '^hash-extra-groestl$' --output-on-failure`
- `./build-normal/tests/crypto/cncrypto-tests tests/crypto/tests.txt`
- `./build-normal/tests/unit_tests/unit_tests`
- UBSan alignment harness across offsets 1, 2, and 3
