### PR TITLE
epee, common: pass unsigned char to <cctype> functions

### DIFF
--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -662,14 +662,14 @@ namespace net_utils
 				ptr = end + 1;
 				CHECK_AND_ASSERT_MES(epee::misc_utils::parse::isdigit(*ptr), false, "Invalid first response line: " + m_header_cache + ", ptr: " << ptr);
 				ul = strtoul(ptr, &end, 10);
-				CHECK_AND_ASSERT_MES(ul <= INT_MAX && isblank(*end), false, "Invalid first response line: " + m_header_cache + ", ptr: " << ptr);
+				CHECK_AND_ASSERT_MES(ul <= INT_MAX && isblank(static_cast<unsigned char>(*end)), false, "Invalid first response line: " + m_header_cache + ", ptr: " << ptr);
 				m_response_info.m_http_ver_lo = ul;
 				ptr = end + 1;
-				while (isblank(*ptr))
+				while (isblank(static_cast<unsigned char>(*ptr)))
 					++ptr;
 				CHECK_AND_ASSERT_MES(epee::misc_utils::parse::isdigit(*ptr), false, "Invalid first response line: " + m_header_cache);
 				ul = strtoul(ptr, &end, 10);
-				CHECK_AND_ASSERT_MES(ul >= 100 && ul <= 999 && isspace(*end), false, "Invalid first response line: " + m_header_cache);
+				CHECK_AND_ASSERT_MES(ul >= 100 && ul <= 999 && isspace(static_cast<unsigned char>(*end)), false, "Invalid first response line: " + m_header_cache);
 				m_response_info.m_response_code = ul;
 				ptr = end;
 				// ignore the optional text, till the end

--- a/contrib/epee/src/abstract_http_client.cpp
+++ b/contrib/epee/src/abstract_http_client.cpp
@@ -65,8 +65,8 @@ namespace net_utils
   std::string hex_to_dec_2bytes(const char *s)
   {
     const char *hex = get_hex_vals();
-    int i0 = get_index(hex, toupper(s[0]));
-    int i1 = get_index(hex, toupper(s[1]));
+    int i0 = get_index(hex, toupper(static_cast<unsigned char>(s[0])));
+    int i1 = get_index(hex, toupper(static_cast<unsigned char>(s[1])));
     if (i0 < 0 || i1 < 0)
       return std::string("%") + std::string(1, s[0]) + std::string(1, s[1]);
     return std::string(1, i0 * 16 | i1);

--- a/src/common/updates.cpp
+++ b/src/common/updates.cpp
@@ -73,7 +73,7 @@ namespace tools
 
       bool alnum = true;
       for (auto c: fields[3])
-        if (!isalnum(c))
+        if (!isalnum(static_cast<unsigned char>(c)))
           alnum = false;
       if (fields[3].size() != 64 && !alnum)
       {


### PR DESCRIPTION
The `<cctype>` functions require their argument to be representable as `unsigned char` or to equal `EOF`. `char` is signed on the platforms Monero targets, so every byte `>= 0x80` reaches them negative — undefined behaviour.

Six call sites, all handling bytes that arrive from outside the process:

| site | input |
| --- | --- |
| `hex_to_dec_2bytes()` (`abstract_http_client.cpp`) | percent-escapes in a payment URI |
| `http_client.h` ×3 | the status line of an HTTP response |
| `updates.cpp` | the hash field of a DNS update record |

For example, a URI whose escape carries a raw UTF-8 byte reaches `toupper()` like this:

```
char is SIGNED (CHAR_MIN=-128)
s[0] as char          = -61   <- passed to toupper() today
s[0] as unsigned char = 195   <- what the standard requires
precondition violated : YES (undefined behaviour)
```

glibc and the macOS libc tolerate `-128..-1` because their tables carry padding below zero, so this is quiet in practice on those. It is still out of contract, and libcs that index without that cushion have no such guarantee.

### Behaviour is unchanged

The cast preserves what these calls actually test. Verified over the whole ASCII range:

```
ASCII 0..127 unchanged by the cast: yes
```

And for a high byte such as `0xC3`, `toupper()` returns it unchanged in the C locale, it narrows back to `char`, `memchr()` misses it in the hex table, and `hex_to_dec_2bytes()` falls through to the existing literal `"%XY"` output — exactly as before.

### Not touched

- `epee::misc_utils::parse::isdigit/isalpha/isspace` are separate `char`-taking helpers defined in `parserse_base_utils.h`; they are already well defined for negative values.
- `is_base64()` in `string_coding.h` looks similar but already takes `unsigned char`.

### Testing

I could not run a full build here, so this is a syntax-level check rather than a compile of the whole tree. Each changed translation unit was checked in isolation against real headers:

```
clang++ -std=c++17 -fsyntax-only -Icontrib/epee/include -Isrc -Iexternal/easylogging++ \
  -Iexternal -I<boost> -I<libsodium> -I<openssl> <file>
```

- `contrib/epee/src/abstract_http_client.cpp` — 0 errors
- `src/common/updates.cpp` — 0 errors
- `contrib/epee/include/net/http_client.h` (via a TU that includes it) — 0 errors

This is framed as a correctness and portability fix. I am not claiming it is exploitable, and I have not investigated it as such.
