### PR TITLE
simplewallet: quote notes in transfer exports

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8673,7 +8673,7 @@ bool simple_wallet::export_transfers(const std::vector<std::string>& args_)
       << std::endl;
 
   uint64_t running_balance = 0;
-  auto formatter = boost::format("%8.8llu,%9.9s,%8.8s,%25.25s,%20.20s,%20.20s,%64.64s,%16.16s,%14.14s,%106.106s,%20.20s,\"%s\",%s,%s");
+  auto formatter = boost::format("%8.8llu,%9.9s,%8.8s,%25.25s,%20.20s,%20.20s,%64.64s,%16.16s,%14.14s,%106.106s,%20.20s,\"%s\",\"%s\",%s");
 
   for (const auto& transfer : all_transfers)
   {
@@ -8695,6 +8695,9 @@ bool simple_wallet::export_transfers(const std::vector<std::string>& args_)
         key_string = get_tx_key_stream(tx_key, additional_tx_keys);
     }
 
+    std::string note = transfer.note;
+    boost::replace_all(note, "\"", "\"\"");
+
     file << formatter
       % transfer.block
       % transfer.direction
@@ -8708,7 +8711,7 @@ bool simple_wallet::export_transfers(const std::vector<std::string>& args_)
       % (transfer.outputs.size() ? transfer.outputs[0].first : "-")
       % (transfer.outputs.size() ? print_money(transfer.outputs[0].second) : "")
       % boost::algorithm::join(transfer.index | boost::adaptors::transformed([](uint32_t i) { return std::to_string(i); }), ", ")
-      % transfer.note
+      % note
       % key_string
       << std::endl;
 


### PR DESCRIPTION
`export_transfers` writes transaction notes directly into CSV rows, so commas shift later fields and quotes can produce malformed records

this quotes the note field and doubles embedded quotes before writing it, fixing item 5 from #9360 without changing the other export behavior

tests:
- built `simplewallet`, `unit_tests`, and `test_notifier` with GCC 14.2
- full `unit_tests`: 1308 passed, 2 hardware-dependent tests skipped
- exported the `wallet_9svHk1` fixture with commas, quotes, and a newline in the note, then checked every record has 14 columns and the note round-trips unchanged through a CSV reader