### PR TITLE
p2p: support external IP, inject address into peerlist

### DIFF
--- a/src/p2p/net_node.cpp
+++ b/src/p2p/net_node.cpp
@@ -134,6 +134,7 @@ namespace nodetool
       };
 
     const command_line::arg_descriptor<uint32_t>    arg_p2p_external_port  = {"p2p-external-port", "External port for p2p network protocol (if port forwarding used with NAT)", 0};
+    const command_line::arg_descriptor<std::string> arg_p2p_external_ip    = {"p2p-external-ip", "External IP for p2p network protocol. Accepts IPv4 or IPv6. Use with --p2p-external-port to specify the full external endpoint.", ""};
     const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip = {"allow-local-ip", "Allow local ip add to peer list, mostly in debug purposes"};
     const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_peer   = {"add-peer", "Manually add peer to local peerlist"};
     const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_priority_node   = {"add-priority-node", "Specify list of peers to connect to and attempt to keep the connection open"};

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -240,6 +240,8 @@ namespace nodetool
     node_server(t_payload_net_handler& payload_handler)
       : m_payload_handler(payload_handler),
         m_external_port(0),
+        m_external_ip(),
+
         m_rpc_port(0),
         m_allow_local_ip(false),
         m_hide_my_port(false),
@@ -271,6 +273,7 @@ namespace nodetool
     size_t get_public_gray_peers_count();
     void get_public_peerlist(std::vector<peerlist_entry>& gray, std::vector<peerlist_entry>& white);
     void get_peerlist(std::vector<peerlist_entry>& gray, std::vector<peerlist_entry>& white);
+    bool get_our_address(epee::net_utils::network_address& address, epee::net_utils::zone zone) const;
 
     void change_max_out_public_peers(size_t count);
     uint32_t get_max_out_public_peers() const;
@@ -427,6 +430,7 @@ namespace nodetool
     uint32_t m_listening_port;
     uint32_t m_listening_port_ipv6;
     uint32_t m_external_port;
+    std::string m_external_ip;
     uint16_t m_rpc_port;
     bool m_allow_local_ip;
     bool m_hide_my_port;
@@ -499,6 +503,8 @@ namespace nodetool
     extern const command_line::arg_descriptor<bool>        arg_p2p_use_ipv6;
     extern const command_line::arg_descriptor<bool>        arg_p2p_ignore_ipv4;
     extern const command_line::arg_descriptor<uint32_t>    arg_p2p_external_port;
+    extern const command_line::arg_descriptor<std::string> arg_p2p_external_ip;
+
     extern const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip;
     extern const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_peer;
     extern const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_priority_node;

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -198,6 +198,7 @@ namespace nodetool
     command_line::add_arg(desc, arg_p2p_use_ipv6);
     command_line::add_arg(desc, arg_p2p_ignore_ipv4);
     command_line::add_arg(desc, arg_p2p_external_port);
+    command_line::add_arg(desc, arg_p2p_external_ip);
     command_line::add_arg(desc, arg_p2p_allow_local_ip);
     command_line::add_arg(desc, arg_p2p_add_peer);
     command_line::add_arg(desc, arg_p2p_add_priority_node);
@@ -569,6 +570,7 @@ namespace nodetool
     public_zone.m_port_ipv6 = command_line::get_arg(vm, arg_p2p_bind_port_ipv6);
     public_zone.m_can_pingback = true;
     m_external_port = command_line::get_arg(vm, arg_p2p_external_port);
+    m_external_ip = command_line::get_arg(vm, arg_p2p_external_ip);
     m_allow_local_ip = command_line::get_arg(vm, arg_p2p_allow_local_ip);
     if (!command_line::is_arg_defaulted(vm, arg_igd))
     {
@@ -1120,6 +1122,74 @@ namespace nodetool
     }
     if(m_external_port)
       MDEBUG("External port defined as " << m_external_port);
+    if(public_zone.m_our_address.get_zone() == epee::net_utils::zone::public_)
+      MDEBUG("External address defined as " << public_zone.m_our_address.str());
+
+    if (!m_external_ip.empty())
+    {
+      std::string host_str;
+      std::string port_str;
+      net::get_network_address_host_and_port(m_external_ip, host_str, port_str);
+      if (!port_str.empty())
+      {
+        MERROR("Invalid --p2p-external-ip \"" << m_external_ip << "\": " << " port specified in IP address. Use --p2p-external_port to specify a port.");
+        return false;
+      }
+      boost::system::error_code ec;
+      const boost::asio::ip::address ext_addr = boost::asio::ip::make_address(host_str, ec);
+      if (ec)
+      {
+        MERROR("Invalid --p2p-external-ip \"" << m_external_ip << "\": " << ec.message());
+        return false;
+      }
+
+      if (ext_addr.is_v4())
+      {
+        const uint16_t port = m_external_port ? static_cast<uint16_t>(m_external_port) : static_cast<uint16_t>(m_listening_port);
+        if (port == 0)
+        {
+          MERROR("Cannot advertise external IPv4 address: effective port is 0. Set --p2p-external-port or ensure --p2p-bind-port is non-zero.");
+          return false;
+        }
+        const uint32_t ip_net = boost::asio::detail::socket_ops::host_to_network_long(ext_addr.to_v4().to_uint());
+        const epee::net_utils::ipv4_network_address ipv4_na(ip_net, port);
+        if (!m_allow_local_ip && (ipv4_na.is_loopback() || ipv4_na.is_local()))
+        {
+          MWARNING("--p2p-external-ip " << m_external_ip << " is a loopback/private address; ignoring. Use --allow-local-ip to override.");
+        }
+        else
+        {
+          public_zone.m_our_address = ipv4_na;
+          MLOG_GREEN(el::Level::Info, "External address set to " << public_zone.m_our_address.str());
+        }
+      }
+      else // IPv6
+      {
+        if (!m_use_ipv6)
+        {
+          MWARNING("--p2p-external-ip " << m_external_ip << " is an IPv6 address but --p2p-use-ipv6 is not set; ignoring.");
+        }
+        else
+        {
+          const uint16_t port = m_external_port ? static_cast<uint16_t>(m_external_port) : static_cast<uint16_t>(m_listening_port_ipv6);
+          if (port == 0)
+          {
+            MERROR("Cannot advertise external IPv6 address: effective port is 0. Set --p2p-external-port or ensure --p2p-bind-port-ipv6 is non-zero.");
+            return false;
+          }
+          const epee::net_utils::ipv6_network_address ipv6_na(ext_addr.to_v6(), port);
+          if (!m_allow_local_ip && (ipv6_na.is_loopback() || ipv6_na.is_local()))
+          {
+            MWARNING("--p2p-external-ip " << m_external_ip << " is a loopback/link-local IPv6 address; ignoring. Use --allow-local-ip to override.");
+          }
+          else
+          {
+            public_zone.m_our_address = ipv6_na;
+            MLOG_GREEN(el::Level::Info, "External address set to " << public_zone.m_our_address.str());
+          }
+        }
+      }
+    }
 
     return res;
   }
@@ -2188,6 +2258,18 @@ namespace nodetool
   }
   //-----------------------------------------------------------------------------------
   template<class t_payload_net_handler>
+  bool node_server<t_payload_net_handler>::get_our_address(epee::net_utils::network_address& address, epee::net_utils::zone zone) const
+  {
+    auto it = m_network_zones.find(zone);
+    if (it != m_network_zones.end())
+    {
+      address = it->second.m_our_address;
+      return true;
+    }
+    return false;
+  }
+  //-----------------------------------------------------------------------------------
+  template<class t_payload_net_handler>
   bool node_server<t_payload_net_handler>::idle_worker()
   {
     m_peer_handshake_idle_maker_interval.do_call(boost::bind(&node_server<t_payload_net_handler>::peer_sync_idle_maker, this));
@@ -2640,7 +2722,12 @@ namespace nodetool
     network_zone& zone = m_network_zones.at(zone_type);
 
     //will add self to peerlist if in same zone as outgoing later in this function
-    const bool outgoing_to_same_zone = !context.m_is_income && zone.m_our_address.get_zone() == zone_type;
+    //for anonymous zones the peer inserts its own address
+    //for the public zone, honour --hide-my-port: if set, do not inject our own address
+    const bool outgoing_to_same_zone = !context.m_is_income
+        && zone.m_our_address.get_zone() == zone_type
+        && !(zone_type == epee::net_utils::zone::public_ && m_hide_my_port);
+
     const uint32_t max_peerlist_size = P2P_DEFAULT_PEERS_IN_HANDSHAKE - (outgoing_to_same_zone ? 1 : 0);
 
     std::vector<peerlist_entry> local_peerlist_new;
@@ -2651,7 +2738,8 @@ namespace nodetool
 
     /* Tor/I2P nodes receiving connections via forwarding (from tor/i2p daemon)
     do not know the address of the connecting peer. This is relayed to them,
-    iff the node has setup an inbound hidden service.
+    iff the node has setup an inbound hidden service. Similarly, clearnet nodes 
+    with an advertised external address relay it.
 
     \note Insert into `local_peerlist_new` so that it is only sent once like
       the other peers. */

--- a/tests/unit_tests/node_server.cpp
+++ b/tests/unit_tests/node_server.cpp
@@ -315,7 +315,7 @@ namespace
     boost::filesystem::remove_all(path, ec);
   }
 
-  boost::program_options::variables_map make_regtest_options(const path_t& dir)
+  boost::program_options::variables_map make_regtest_options(const path_t& dir, std::vector<std::string> extra_args = {}, bool offline = true)
   {
     boost::program_options::options_description desc;
     cryptonote::core::init_options(desc);
@@ -330,8 +330,11 @@ namespace
       dir.string(),
       "--check-updates=disabled",
       "--disable-dns-checkpoints",
-      "--offline",
     };
+    if (offline)
+      args.push_back("--offline");
+
+    args.insert(args.end(), extra_args.begin(), extra_args.end());
 
     boost::program_options::variables_map vm;
     boost::program_options::store(
@@ -1620,6 +1623,172 @@ TEST(regtest, isolates_p2p_state_from_mainnet_data_dir)
   nodetool::peerlist_types regtest_public = regtest_storage->take_zone(epee::net_utils::zone::public_);
   EXPECT_TRUE(regtest_public.white.empty());
   EXPECT_TRUE(regtest_public.gray.empty());
+}
+
+TEST(node_server, external_ip_valid_default_port)
+{
+  const path_t dir = create_temp_dir("external_ip-%%%%%%%%%%%%%%%%");
+  ASSERT_TRUE(!dir.empty());
+  const epee::scope_guard cleanup([&dir]{ remove_tree(dir); });
+
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  // online mode: binds to ephemeral port, external IP inherits that listening port
+  const auto vm = make_regtest_options(dir, {"--p2p-external-ip=198.51.100.1", "--p2p-bind-port=0"}, false);
+  ASSERT_TRUE(server.init(vm));
+
+  epee::net_utils::network_address our_addr;
+  ASSERT_TRUE(server.get_our_address(our_addr, epee::net_utils::zone::public_));
+  EXPECT_EQ(our_addr.host_str(), "198.51.100.1");
+  EXPECT_GT(our_addr.port(), 0);
+  EXPECT_EQ(our_addr.port(), server.get_this_peer_port());
+  ASSERT_TRUE(server.deinit());
+}
+
+TEST(node_server, external_ip_combined_with_external_port)
+{
+  const path_t dir = create_temp_dir("external_ip-%%%%%%%%%%%%%%%%");
+  ASSERT_TRUE(!dir.empty());
+  const epee::scope_guard cleanup([&dir]{ remove_tree(dir); });
+
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  const auto vm = make_regtest_options(dir, {"--p2p-external-ip=198.51.100.1", "--p2p-external-port=38080", "--p2p-bind-port=0"}, false);
+  ASSERT_TRUE(server.init(vm));
+
+  epee::net_utils::network_address our_addr;
+  ASSERT_TRUE(server.get_our_address(our_addr, epee::net_utils::zone::public_));
+  EXPECT_EQ(our_addr.host_str(), "198.51.100.1");
+  EXPECT_EQ(our_addr.port(), 38080);
+  ASSERT_TRUE(server.deinit());
+}
+
+TEST(node_server, external_ip_valid_ipv6)
+{
+  const path_t dir = create_temp_dir("external_ip-%%%%%%%%%%%%%%%%");
+  ASSERT_TRUE(!dir.empty());
+  const epee::scope_guard cleanup([&dir]{ remove_tree(dir); });
+
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  const auto vm = make_regtest_options(dir, {
+    "--p2p-external-ip=2001:db8::1", 
+    "--p2p-use-ipv6", 
+    "--p2p-bind-port-ipv6=0",
+    "--p2p-external-port=18080"
+  }, false);
+  ASSERT_TRUE(server.init(vm));
+
+  epee::net_utils::network_address our_addr;
+  ASSERT_TRUE(server.get_our_address(our_addr, epee::net_utils::zone::public_));
+  EXPECT_EQ(our_addr.host_str(), "2001:db8::1");
+  EXPECT_EQ(our_addr.port(), 18080);
+  ASSERT_TRUE(server.deinit());
+}
+
+TEST(node_server, external_ip_ipv6_without_flag_ignored)
+{
+  const path_t dir = create_temp_dir("external_ip-%%%%%%%%%%%%%%%%");
+  ASSERT_TRUE(!dir.empty());
+  const epee::scope_guard cleanup([&dir]{ remove_tree(dir); });
+
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  // IPv6 external IP without --p2p-use-ipv6 should be ignored
+  const auto vm = make_regtest_options(dir, {"--p2p-external-ip=2001:db8::1", "--p2p-bind-port=0"}, false);
+  ASSERT_TRUE(server.init(vm));
+
+  epee::net_utils::network_address our_addr;
+  ASSERT_TRUE(server.get_our_address(our_addr, epee::net_utils::zone::public_));
+  EXPECT_EQ(our_addr.get_type_id(), epee::net_utils::address_type::invalid);
+  ASSERT_TRUE(server.deinit());
+}
+
+TEST(node_server, external_ip_port_in_ip_rejected)
+{
+  const path_t dir = create_temp_dir("external_ip-%%%%%%%%%%%%%%%%");
+  ASSERT_TRUE(!dir.empty());
+  const epee::scope_guard cleanup([&dir]{ remove_tree(dir); });
+
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  // IPv4 with port should fail
+  const auto vm_ipv4 = make_regtest_options(dir, {"--p2p-external-ip=198.51.100.1:28080", "--p2p-bind-port=0"}, false);
+  EXPECT_FALSE(server.init(vm_ipv4));
+
+  // IPv6 with port should fail
+  const auto vm_ipv6 = make_regtest_options(dir, {"--p2p-external-ip=[2001:db8::1]:28080", "--p2p-use-ipv6", "--p2p-bind-port=0"}, false);
+  EXPECT_FALSE(server.init(vm_ipv6));
+}
+
+TEST(node_server, external_ip_invalid_format)
+{
+  const path_t dir = create_temp_dir("external_ip-%%%%%%%%%%%%%%%%");
+  ASSERT_TRUE(!dir.empty());
+  const epee::scope_guard cleanup([&dir]{ remove_tree(dir); });
+
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  const auto vm = make_regtest_options(dir, {"--p2p-external-ip=invalid_ip_string", "--p2p-bind-port=0"}, false);
+  EXPECT_FALSE(server.init(vm));
+}
+
+TEST(node_server, external_ip_local_ignored_without_allow_local)
+{
+  const path_t dir = create_temp_dir("external_ip-%%%%%%%%%%%%%%%%");
+  ASSERT_TRUE(!dir.empty());
+  const epee::scope_guard cleanup([&dir]{ remove_tree(dir); });
+
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  const auto vm = make_regtest_options(dir, {"--p2p-external-ip=127.0.0.1", "--p2p-bind-port=0"}, false);
+  ASSERT_TRUE(server.init(vm));
+
+  epee::net_utils::network_address our_addr;
+  ASSERT_TRUE(server.get_our_address(our_addr, epee::net_utils::zone::public_));
+  EXPECT_EQ(our_addr.get_type_id(), epee::net_utils::address_type::invalid);
+  ASSERT_TRUE(server.deinit());
+}
+
+TEST(node_server, external_ip_local_allowed_with_allow_local)
+{
+  const path_t dir = create_temp_dir("external_ip-%%%%%%%%%%%%%%%%");
+  ASSERT_TRUE(!dir.empty());
+  const epee::scope_guard cleanup([&dir]{ remove_tree(dir); });
+
+  test_core pr_core;
+  cryptonote::t_cryptonote_protocol_handler<test_core> cprotocol(pr_core, NULL);
+  Server server(cprotocol);
+  cprotocol.set_p2p_endpoint(&server);
+
+  const auto vm = make_regtest_options(dir, {"--p2p-external-ip=192.168.1.1", "--allow-local-ip", "--p2p-bind-port=0"}, false);
+  ASSERT_TRUE(server.init(vm));
+
+  epee::net_utils::network_address our_addr;
+  ASSERT_TRUE(server.get_our_address(our_addr, epee::net_utils::zone::public_));
+  EXPECT_EQ(our_addr.host_str(), "192.168.1.1");
+  ASSERT_TRUE(server.deinit());
 }
 
 namespace nodetool { template class node_server<cryptonote::t_cryptonote_protocol_handler<test_core>>; }


### PR DESCRIPTION
Add support for external IP to allow nodes behind NAT, containers, reverse proxies etc, to advertise a reachable external IP + port to peers by injecting self-address into peerlist for public zone. This tries to solve #5979, #10791.

rework of closed PR #11171

- external IP resolution now occurs after the OS binds and sets `m_listening_port` or `m_listening_port_ipv6`.
- if `--p2p-external-port` is set, that port is used. Otherwise, it uses the real bound port (`m_listening_port` for IPv4, `m_listening_port_ipv6` for IPv6)
- external IP parsing and validation; loopback and private address handling
- if an IPv6 external IP is supplied without `--p2p-use-ipv6`, it logs a warning and ignores the address (`m_our_address` remains unset)
- test suite to validate external IP/port in online mode (binding to `127.0.0.1:0` ephemeral port)