### PR TITLE
doc: Declare draft-07 schema metadata

### DIFF
--- a/docs/schema/pub_chain_full.json
+++ b/docs/schema/pub_chain_full.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json-schema.org/draft-07/schema",
     "definitions": {
         "binary": {
             "type": "string",


### PR DESCRIPTION
## Summary

- Declare the JSON Schema draft used by `docs/schema/pub_chain_full.json`.
- Keep the published schema documents consistent with the other files in `docs/schema/`.

This metadata lets JSON Schema tooling identify the intended dialect without changing the schema definitions or validation rules.

## Tests

- `python3 -m json.tool docs/schema/pub_chain_full.json`
- `python3 -m json.tool docs/schema/pub_chain_minimal.json`
- `python3 -m json.tool docs/schema/pub_miner_full.json`
- `python3 -m json.tool docs/schema/pub_txpool_full.json`
- `python3 -m json.tool docs/schema/pub_txpool_minimal.json`
- Verified all five schema files declare `http://json-schema.org/draft-07/schema`.
