### PR TITLE
tests: cover restricted add_aux_pow limit

### DIFF
--- a/tests/fuzz/fuzz_rpc/rpc_endpoints.cpp
+++ b/tests/fuzz/fuzz_rpc/rpc_endpoints.cpp
@@ -473,7 +473,7 @@ void fuzz_add_aux_pow(cryptonote::core_rpc_server& rpc, FuzzedDataProvider& prov
 
   req.blocktemplate_blob = provider.ConsumeRandomLengthString(128);
 
-  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 4);
+  size_t count = provider.ConsumeIntegralInRange<size_t>(0, 16);
   for (size_t i = 0; i < count; ++i) {
     cryptonote::COMMAND_RPC_ADD_AUX_POW::aux_pow_t aux;
     aux.id = provider.ConsumeRandomLengthString(32);


### PR DESCRIPTION
The restricted `add_aux_pow` path now rejects requests with more than 10 auxiliary proof-of-work entries, but the fuzz target only generated 0–4 entries. This changes the generated count range to 0–16 so fuzzing can exercise the new boundary while keeping the target unchanged.\n\nValidation: `git diff --check`; one-line diff reviewed.\n\nFixes the coverage gap identified after PR #10408.