### PR TITLE
tests: cover restricted add_aux_pow RPC

### DIFF
--- a/tests/functional_tests/add_aux_pow_restricted.py
+++ b/tests/functional_tests/add_aux_pow_restricted.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+#encoding=utf-8
+
+"""Test the restricted RPC add_aux_pow entry limit."""
+
+from framework.daemon import Daemon
+
+
+ADDRESS = '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+
+
+class AddAuxPowRestrictedTest:
+    def run_test(self):
+        daemon = Daemon()
+        restricted_daemon = Daemon(restricted_rpc=True, port=18580)
+        template = daemon.getblocktemplate(ADDRESS)
+        aux_pow = [{'id': '00' * 32, 'hash': '00' * 32} for _ in range(11)]
+
+        try:
+            restricted_daemon.add_aux_pow(template.blocktemplate_blob, aux_pow)
+        except AssertionError as error:
+            message = str(error)
+            assert "'code': -19" in message, message
+            assert 'Too many aux pow hashes' in message, message
+        else:
+            raise AssertionError('restricted add_aux_pow accepted 11 aux_pow entries')
+
+
+if __name__ == '__main__':
+    AddAuxPowRestrictedTest().run_test()

--- a/tests/functional_tests/functional_tests_rpc.py
+++ b/tests/functional_tests/functional_tests_rpc.py
@@ -51,7 +51,7 @@ WALLET_DIRECTORY = builddir + "/functional-tests-directory"
 FUNCTIONAL_TESTS_DIRECTORY = builddir + "/tests/functional_tests"
 DIFFICULTY = 10
 
-monerod_base = [builddir + "/bin/monerod", "--regtest", "--fixed-difficulty", str(DIFFICULTY), "--p2p-bind-port", "monerod_p2p_port", "--rpc-bind-port", "monerod_rpc_port", "--zmq-rpc-bind-port", "monerod_zmq_port", "--zmq-pub", "monerod_zmq_pub", "--non-interactive", "--disable-dns-checkpoints", "--check-updates", "disabled", "--rpc-ssl", "disabled", "--data-dir", "monerod_data_dir", "--log-level", "1", "--rpc-max-connections-per-private-ip", "100", "--rpc-max-connections", "100"]
+monerod_base = [builddir + "/bin/monerod", "--regtest", "--fixed-difficulty", str(DIFFICULTY), "--p2p-bind-port", "monerod_p2p_port", "--rpc-bind-port", "monerod_rpc_port", "--rpc-restricted-bind-port", "monerod_restricted_rpc_port", "--zmq-rpc-bind-port", "monerod_zmq_port", "--zmq-pub", "monerod_zmq_pub", "--non-interactive", "--disable-dns-checkpoints", "--check-updates", "disabled", "--rpc-ssl", "disabled", "--data-dir", "monerod_data_dir", "--log-level", "1", "--rpc-max-connections-per-private-ip", "100", "--rpc-max-connections", "100"]
 
 monerod_extra = [
   ["--offline"],
@@ -77,7 +77,7 @@ outputs = []
 ports = []
 
 for i in range(N_MONERODS):
-  command_lines.append([str(18180+i) if x == "monerod_rpc_port" else str(18280+i) if x == "monerod_p2p_port" else str(18380+i) if x == "monerod_zmq_port" else "tcp://127.0.0.1:" + str(18480+i) if x == "monerod_zmq_pub" else builddir + "/functional-tests-directory/monerod" + str(i) if x == "monerod_data_dir" else x for x in monerod_base])
+  command_lines.append([str(18180+i) if x == "monerod_rpc_port" else str(18580+i) if x == "monerod_restricted_rpc_port" else str(18280+i) if x == "monerod_p2p_port" else str(18380+i) if x == "monerod_zmq_port" else "tcp://127.0.0.1:" + str(18480+i) if x == "monerod_zmq_pub" else builddir + "/functional-tests-directory/monerod" + str(i) if x == "monerod_data_dir" else x for x in monerod_base])
   if i < len(monerod_extra):
     command_lines[-1] += monerod_extra[i]
   outputs.append(open(FUNCTIONAL_TESTS_DIRECTORY + '/monerod' + str(i) + '.log', 'a+'))


### PR DESCRIPTION
Add functional coverage for the restricted `add_aux_pow` limit introduced by PR #10408. The harness now exposes a separate restricted RPC port, and the test obtains a regtest block template through the normal RPC then sends 11 aux_pow entries to the restricted endpoint. It asserts error code -19 and the `Too many aux pow hashes` message.\n\nValidation:\n- `python3 -m py_compile tests/functional_tests/add_aux_pow_restricted.py tests/functional_tests/functional_tests_rpc.py`\n- `git diff --check`\n\nThe full functional harness requires a built Monero tree and was not run in this filtered source checkout.