### PR TITLE
lmdb: correct environment error spelling

### DIFF
--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -78,7 +78,7 @@ static void open(MDB_env *&env, const boost::filesystem::path &path, uint64_t db
     flags |= MDB_RDONLY;
 
   dbr = mdb_env_create(&env);
-  if (dbr) throw std::runtime_error("Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
+  if (dbr) throw std::runtime_error("Failed to create LMDB environment: " + std::string(mdb_strerror(dbr)));
   dbr = mdb_env_set_maxdbs(env, 32);
   if (dbr) throw std::runtime_error("Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
   dbr = mdb_env_open(env, path.string().c_str(), flags, 0664);

--- a/src/wallet/ringdb.cpp
+++ b/src/wallet/ringdb.cpp
@@ -207,7 +207,7 @@ ringdb::ringdb(std::string filename, const std::string &genesis):
   tools::create_directories_if_necessary(filename);
 
   dbr = mdb_env_create(&env);
-  THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to create LDMB environment: " + std::string(mdb_strerror(dbr)));
+  THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to create LMDB environment: " + std::string(mdb_strerror(dbr)));
   dbr = mdb_env_set_maxdbs(env, 2);
   THROW_WALLET_EXCEPTION_IF(dbr, tools::error::wallet_internal_error, "Failed to set max env dbs: " + std::string(mdb_strerror(dbr)));
   const std::string actual_filename = get_rings_filename(filename); 


### PR DESCRIPTION
Correct the user-visible `LDMB` typo in the LMDB environment creation errors emitted by the wallet ring database and blockchain prune utility.\n\nThis keeps the existing behavior and only fixes the database name in the diagnostic text.\n\nValidation:\n- `git diff --check`\n- confirmed no remaining `LDMB` hit in the two affected source files