### PR TITLE
ci: cancel stale workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
       - 'docs/**'
       - '**/README.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # The below variables reduce repetitions across similar targets
 env:
   REMOVE_BUNDLED_PACKAGES : sudo rm -rf /usr/local

--- a/.github/workflows/depends.yml
+++ b/.github/workflows/depends.yml
@@ -10,6 +10,10 @@ on:
       - 'docs/**'
       - '**/README.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   APT_SET_CONF: |
     tee -a /etc/apt/apt.conf.d/80-custom << EOF

--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -18,6 +18,10 @@ on:
       - '.github/workflows/guix.yml'
       - '**/Cargo.lock'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cache-sources:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Cancel older runs of the same workflow and ref when a newer push or pull request update arrives. Apply the same workflow-level concurrency policy to build, depends, and guix so superseded matrix work does not continue consuming CI resources.\n\nValidation:\n- Ruby YAML parser accepted all three workflow files\n- `git diff --check`\n\nThe workflow jobs themselves require GitHub-hosted runners and were not executed locally.