### PR TITLE
ci: lint GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,28 @@
+name: lint/github-actions
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.10
+        run: |
+          archive="$RUNNER_TEMP/actionlint.tar.gz"
+          curl --fail --location --retry 3 --output "$archive" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_x86_64.tar.gz"
+          tar --extract --gzip --file "$archive" --directory "$RUNNER_TEMP"
+
+      - name: Lint workflow files
+        run: |
+          "$RUNNER_TEMP/actionlint" -color -shellcheck=


### PR DESCRIPTION
Add a focused actionlint workflow that runs only when files under `.github/workflows/**` change. It checks out the repository, installs the pinned actionlint v1.7.10 release, and runs it with shellcheck disabled to match the repository scope.\n\nValidation:\n- Ruby YAML parser accepted the workflow file\n- `git diff --check`\n\nThe actionlint binary could not be downloaded locally because the environment returned LibreSSL SSL_ERROR_SYSCALL while contacting the GitHub release URL; the hosted workflow is intended to provide the full validation.