### PR TITLE
serialization: bound varint reserve

### DIFF
--- a/src/serialization/container.h
+++ b/src/serialization/container.h
@@ -84,6 +84,9 @@ namespace serialization
     {
       using T = typename C::value_type;
 
+      if (use_container_varint<T>())
+        return c.reserve(std::min(N, std::max(std::size_t(1), B)));
+
       static constexpr std::size_t max_compression_ratio =
         is_blob_type<T>::type::value ? 1 :
         use_container_varint<T>() ? sizeof(T) :

--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -387,6 +387,19 @@ TEST(Serialization, deserializes_vector_reserve)
   ASSERT_LT(v.capacity(), 100); // could fail if lib allocates more in reserve call
 }
 
+TEST(Serialization, deserializes_varint_vector_reserve)
+{
+  std::vector<uint64_t> v;
+  string blob;
+
+  tools::write_varint(std::back_inserter(blob), unsigned(2));
+  blob.push_back(0);
+
+  ASSERT_FALSE(serialization::parse_binary(blob, v));
+  ASSERT_EQ(1, v.size());
+  ASSERT_LE(v.capacity(), 1);
+}
+
 
 namespace
 {


### PR DESCRIPTION
## Summary
- bound reserve sizing for containers serialized as varints by the bytes remaining in the message
- add a regression test for a partially truncated `std::vector<uint64_t>` payload

PR #10366 introduced byte-aware reserve sizing, but its `remaining_bytes / sizeof(T)` calculation can still reserve `sizeof(T)` elements for a varint container when fewer bytes remain. Varint values may use a single byte, so this follow-up uses the one-byte lower bound for `use_container_varint<T>()` containers while retaining the existing heuristic for other types.

The test exercises a count of two with only one element byte present and verifies that parsing fails after one element without over-reserving.

Tests:
- `git diff --check`
- Unit test not run locally: this filtered clone has no configured build directory.