### PR TITLE
simplewallet: rename duplicate amount headers for clarity

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8681,7 +8681,7 @@ bool simple_wallet::export_transfers(const std::vector<std::string>& args_)
   // header
   file <<
       boost::format("%8.8s,%9.9s,%8.8s,%25.25s,%20.20s,%20.20s,%64.64s,%16.16s,%14.14s,%106.106s,%20.20s,%s,%s,%s") %
-      tr("block") % tr("direction") % tr("unlocked") % tr("timestamp") % tr("amount") % tr("running balance") % tr("hash") % tr("payment ID") % tr("fee") % tr("destination") % tr("amount") % tr("index") % tr("note") % tr("tx key")
+      tr("block") % tr("direction") % tr("unlocked") % tr("timestamp") % tr("transaction amount") % tr("running balance") % tr("hash") % tr("payment ID") % tr("fee") % tr("destination") % tr("destination amount") % tr("index") % tr("note") % tr("tx key")
       << std::endl;
 
   uint64_t running_balance = 0;


### PR DESCRIPTION
Fixes #8171

`export_transfers` still uses `amount` for both the transaction total and the per-destination amount on master

those values differ for multi-destination transactions, and header-based CSV readers can silently discard one of them

this forward-ports the labels from #8177, which was merged only into release-v0.17, without changing column order or values

this changes the two CSV header names for consumers that match them literally

tests:
- clean GCC 14 build of `monero-wallet-cli`
- `export_transfers all` on an offline wallet
- verified all 14 CSV headers are unique and match the expected order
- `git diff --check`