### PR TITLE
simplewallet: remove redundant space in prompt

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -278,7 +278,7 @@ namespace
     PAUSE_READLINE();
     std::cout << prompt;
     if (yesno)
-      std::cout << "  [y/N]";
+      std::cout << " [y/N]";
     std::cout << ": " << std::flush;
 
     std::string buf;


### PR DESCRIPTION
I know this is probably the absolute epitome of a nitpick, but I see this every time I open the CLI wallet, and it doesn't look great.