### PR TITLE
uri: add multi-destination support to make_uri and parse_uri

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6443,8 +6443,7 @@ bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool ca
   vector<cryptonote::tx_destination_entry> dsts;
   for (size_t i = 0; i < local_args.size(); )
   {
-    dsts_info.emplace_back();
-    cryptonote::address_parse_info & info = dsts_info.back();
+    cryptonote::address_parse_info info;
     cryptonote::tx_destination_entry de;
     bool r = true;
 
@@ -6452,9 +6451,56 @@ bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool ca
     std::string address_uri, payment_id_uri, tx_description, recipient_name, error;
     std::vector<std::string> unknown_parameters;
     uint64_t amount = 0;
-    bool has_uri = m_wallet->parse_uri(local_args[i], address_uri, payment_id_uri, amount, tx_description, recipient_name, unknown_parameters, error);
+    std::vector<tools::wallet2::uri_destination> uri_destinations;
+    bool has_uri = m_wallet->parse_uri(local_args[i], uri_destinations, payment_id_uri, tx_description, recipient_name, unknown_parameters, error);
+    if (has_uri && uri_destinations.size() > 1)
+    {
+      // multi-destination URI: expand into one destination per address
+      if (!payment_id_uri.empty())
+      {
+        fail_msg_writer() << tr("a multi-destination URI cannot specify a payment id");
+        return false;
+      }
+      for (const tools::wallet2::uri_destination &urid: uri_destinations)
+      {
+        cryptonote::address_parse_info ur_info;
+        if (!cryptonote::get_account_address_from_str_or_url(ur_info, m_wallet->nettype(), urid.address, m_wallet->is_dns_enabled(), oa_prompter))
+        {
+          fail_msg_writer() << tr("failed to parse address");
+          return false;
+        }
+        cryptonote::tx_destination_entry ur_de;
+        ur_de.addr = ur_info.address;
+        ur_de.is_subaddress = ur_info.is_subaddress;
+        ur_de.is_integrated = ur_info.has_payment_id;
+        ur_de.amount = urid.amount;
+        ur_de.original = local_args[i];
+        if (ur_info.has_payment_id)
+        {
+          if (payment_id_seen)
+          {
+            fail_msg_writer() << tr("a single transaction cannot use more than one payment id");
+            return false;
+          }
+          std::string extra_nonce;
+          set_encrypted_payment_id_to_tx_extra_nonce(extra_nonce, ur_info.payment_id);
+          if (!add_extra_nonce_to_tx_extra(extra, extra_nonce))
+          {
+            fail_msg_writer() << tr("failed to set up payment id, though it was decoded correctly");
+            return false;
+          }
+          payment_id_seen = true;
+        }
+        dsts_info.push_back(ur_info);
+        dsts.push_back(ur_de);
+      }
+      ++i;
+      continue;
+    }
     if (has_uri)
     {
+      address_uri = uri_destinations[0].address;
+      amount = uri_destinations[0].amount;
       r = cryptonote::get_account_address_from_str_or_url(info, m_wallet->nettype(), address_uri, m_wallet->is_dns_enabled(), oa_prompter);
       if (payment_id_uri.size() == 16)
       {
@@ -6532,6 +6578,7 @@ bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool ca
       payment_id_seen = true;
     }
 
+    dsts_info.push_back(info);
     dsts.push_back(de);
   }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -14903,7 +14903,68 @@ std::string wallet2::make_uri(const std::string &address, const std::string &pay
   return uri;
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::parse_uri(const std::string &uri, std::string &address, std::string &payment_id, uint64_t &amount, std::string &tx_description, std::string &recipient_name, std::vector<std::string> &unknown_parameters, std::string &error)
+std::string wallet2::make_uri(const std::vector<uri_destination> &destinations, const std::string &tx_description, const std::string &recipient_names, std::string &error) const
+{
+  if (destinations.empty())
+  {
+    error = "No destinations given";
+    return std::string();
+  }
+
+  size_t num_integrated = 0;
+  std::string addresses;
+  for (size_t i = 0; i < destinations.size(); ++i)
+  {
+    cryptonote::address_parse_info info;
+    if (!get_account_address_from_str(info, nettype(), destinations[i].address))
+    {
+      error = std::string("wrong address: ") + destinations[i].address;
+      return std::string();
+    }
+    if (info.has_payment_id)
+      ++num_integrated;
+    if (i)
+      addresses += ";";
+    addresses += destinations[i].address;
+  }
+
+  // only one destination of a transaction may carry a payment id, whether integrated or not
+  if (num_integrated > 1)
+  {
+    error = "A transaction can have at most one integrated address";
+    return std::string();
+  }
+
+  std::string uri = "monero:" + addresses;
+  unsigned int n_fields = 0;
+
+  if (destinations.size() > 1 || destinations[0].amount > 0)
+  {
+    // URI encoded amounts are in decimal units, not atomic units
+    std::string amounts;
+    for (size_t i = 0; i < destinations.size(); ++i)
+    {
+      if (i)
+        amounts += ";";
+      amounts += cryptonote::print_money(destinations[i].amount);
+    }
+    uri += (n_fields++ ? "&" : "?") + std::string("tx_amount=") + amounts;
+  }
+
+  if (!recipient_names.empty())
+  {
+    uri += (n_fields++ ? "&" : "?") + std::string("recipient_name=") + epee::net_utils::conver_to_url_format(recipient_names);
+  }
+
+  if (!tx_description.empty())
+  {
+    uri += (n_fields++ ? "&" : "?") + std::string("tx_description=") + epee::net_utils::conver_to_url_format(tx_description);
+  }
+
+  return uri;
+}
+//----------------------------------------------------------------------------------------------------
+bool wallet2::parse_uri(const std::string &uri, std::vector<uri_destination> &destinations, std::string &payment_id, std::string &tx_description, std::string &recipient_names, std::vector<std::string> &unknown_parameters, std::string &error)
 {
   if (uri.substr(0, 7) != "monero:")
   {
@@ -14913,29 +14974,55 @@ bool wallet2::parse_uri(const std::string &uri, std::string &address, std::strin
 
   std::string remainder = uri.substr(7);
   const char *ptr = strchr(remainder.c_str(), '?');
-  address = ptr ? remainder.substr(0, ptr-remainder.c_str()) : remainder;
+  const std::string address_list = ptr ? remainder.substr(0, ptr-remainder.c_str()) : remainder;
+  const std::string body = ptr ? remainder.substr(address_list.size() + 1) : "";
 
-  cryptonote::address_parse_info info;
-  if(!get_account_address_from_str(info, nettype(), address))
+  // all addresses are validated up front; they are separated by semicolons, and at most
+  // one of them may be an integrated address
+  std::vector<std::string> address_strings;
+  boost::split(address_strings, address_list, boost::is_any_of(";"));
+  if (address_strings.empty() || (address_strings.size() == 1 && address_strings[0].empty()))
   {
-    error = std::string("URI has wrong address: ") + address;
+    error = std::string("URI has no address: ") + uri;
     return false;
+  }
+  std::vector<uri_destination> parsed;
+  size_t num_integrated = 0;
+  for (const std::string &address: address_strings)
+  {
+    cryptonote::address_parse_info info;
+    if (!get_account_address_from_str(info, nettype(), address))
+    {
+      error = std::string("URI has wrong address: ") + address;
+      return false;
+    }
+    if (info.has_payment_id)
+    {
+      if (++num_integrated > 1)
+      {
+        error = "URI has more than one integrated address";
+        return false;
+      }
+    }
+    uri_destination d;
+    d.address = address;
+    d.amount = 0;
+    parsed.push_back(std::move(d));
   }
 
   payment_id.clear();
-  amount = 0;
   tx_description.clear();
-  recipient_name.clear();
+  recipient_names.clear();
   unknown_parameters.clear();
   error.clear();
 
-  if (!strchr(remainder.c_str(), '?'))
+  if (body.empty())
+  {
+    destinations = std::move(parsed);
     return true;
+  }
 
   std::vector<std::string> arguments;
-  std::string body = remainder.substr(address.size() + 1);
-  if (body.empty())
-    return true;
   boost::split(arguments, body, boost::is_any_of("&"));
   std::set<std::string> have_arg;
   for (const auto &arg: arguments)
@@ -14949,22 +15036,33 @@ bool wallet2::parse_uri(const std::string &uri, std::string &address, std::strin
     }
     if (have_arg.find(kv[0]) != have_arg.end())
     {
-      error = std::string("URI has more than one instance of " + kv[0]);
+      error = std::string("URI has more than one instance of ") + kv[0];
       return false;
     }
     have_arg.insert(kv[0]);
 
     if (kv[0] == "tx_amount")
     {
-      if (!cryptonote::parse_amount(amount, kv[1]))
+      // amounts are separated by semicolons, matching the number of destinations one-to-one
+      std::vector<std::string> amount_strings;
+      boost::split(amount_strings, kv[1], boost::is_any_of(";"));
+      if (amount_strings.size() != parsed.size())
       {
-        error = std::string("URI has invalid amount: ") + kv[1];
+        error = std::string("URI has a different number of amounts and destinations: ") + kv[1];
         return false;
+      }
+      for (size_t i = 0; i < amount_strings.size(); ++i)
+      {
+        if (!cryptonote::parse_amount(parsed[i].amount, amount_strings[i]))
+        {
+          error = std::string("URI has invalid amount: ") + amount_strings[i];
+          return false;
+        }
       }
     }
     else if (kv[0] == "tx_payment_id")
     {
-      if (info.has_payment_id)
+      if (num_integrated > 0)
       {
         error = "Separate payment id given with an integrated address";
         return false;
@@ -14979,7 +15077,7 @@ bool wallet2::parse_uri(const std::string &uri, std::string &address, std::strin
     }
     else if (kv[0] == "recipient_name")
     {
-      recipient_name = epee::net_utils::convert_from_url_format(kv[1]);
+      recipient_names = epee::net_utils::convert_from_url_format(kv[1]);
     }
     else if (kv[0] == "tx_description")
     {
@@ -14990,8 +15088,25 @@ bool wallet2::parse_uri(const std::string &uri, std::string &address, std::strin
       unknown_parameters.push_back(arg);
     }
   }
+  destinations = std::move(parsed);
   return true;
 }
+//----------------------------------------------------------------------------------------------------
+bool wallet2::parse_uri(const std::string &uri, std::string &address, std::string &payment_id, uint64_t &amount, std::string &tx_description, std::string &recipient_name, std::vector<std::string> &unknown_parameters, std::string &error)
+{
+  std::vector<uri_destination> destinations;
+  if (!parse_uri(uri, destinations, payment_id, tx_description, recipient_name, unknown_parameters, error))
+    return false;
+  if (destinations.size() > 1)
+  {
+    error = "URI has more than one destination";
+    return false;
+  }
+  address = destinations[0].address;
+  amount = destinations[0].amount;
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_blockchain_height_by_date(uint16_t year, uint8_t month, uint8_t day)
 {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1359,6 +1359,13 @@ private:
     std::string decrypt_with_view_secret_key(const std::string &ciphertext, bool authenticated = true) const;
 
     std::string make_uri(const std::string &address, const std::string &payment_id, uint64_t amount, const std::string &tx_description, const std::string &recipient_name, std::string &error) const;
+    struct uri_destination
+    {
+      std::string address;
+      uint64_t amount; // in atomic units, 0 if unspecified
+    };
+    std::string make_uri(const std::vector<uri_destination> &destinations, const std::string &tx_description, const std::string &recipient_names, std::string &error) const;
+    bool parse_uri(const std::string &uri, std::vector<uri_destination> &destinations, std::string &payment_id, std::string &tx_description, std::string &recipient_names, std::vector<std::string> &unknown_parameters, std::string &error);
     bool parse_uri(const std::string &uri, std::string &address, std::string &payment_id, uint64_t &amount, std::string &tx_description, std::string &recipient_name, std::vector<std::string> &unknown_parameters, std::string &error);
 
     uint64_t get_blockchain_height_by_date(uint16_t year, uint8_t month, uint8_t day);    // 1<=month<=12, 1<=day<=31

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3241,7 +3241,27 @@ namespace tools
   {
     if (!m_wallet) return not_open(er);
     std::string error;
-    std::string uri = m_wallet->make_uri(req.address, req.payment_id, req.amount, req.tx_description, req.recipient_name, error);
+    std::string uri;
+    if (!req.destinations.empty())
+    {
+      if (!req.address.empty() || req.amount != 0)
+      {
+        er.code = WALLET_RPC_ERROR_CODE_WRONG_URI;
+        er.message = "Cannot make URI: supplying both a single address and a list of destinations is not allowed";
+        return false;
+      }
+      std::vector<tools::wallet2::uri_destination> destinations;
+      for (const wallet_rpc::uri_destination_spec &spec: req.destinations)
+      {
+        tools::wallet2::uri_destination d;
+        d.address = spec.address;
+        d.amount = spec.amount;
+        destinations.push_back(std::move(d));
+      }
+      uri = m_wallet->make_uri(destinations, req.tx_description, req.recipient_name, error);
+    }
+    else
+      uri = m_wallet->make_uri(req.address, req.payment_id, req.amount, req.tx_description, req.recipient_name, error);
     if (uri.empty())
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_URI;
@@ -3257,12 +3277,24 @@ namespace tools
   {
     if (!m_wallet) return not_open(er);
     std::string error;
-    if (!m_wallet->parse_uri(req.uri, res.uri.address, res.uri.payment_id, res.uri.amount, res.uri.tx_description, res.uri.recipient_name, res.unknown_parameters, error))
+    std::vector<tools::wallet2::uri_destination> destinations;
+    if (!m_wallet->parse_uri(req.uri, destinations, res.uri.payment_id, res.uri.tx_description, res.uri.recipient_name, res.unknown_parameters, error))
     {
       er.code = WALLET_RPC_ERROR_CODE_WRONG_URI;
       er.message = "Error parsing URI: " + error;
       return false;
     }
+    for (const tools::wallet2::uri_destination &d: destinations)
+    {
+      wallet_rpc::uri_destination_spec spec;
+      spec.address = d.address;
+      spec.amount = d.amount;
+      res.destinations.push_back(std::move(spec));
+    }
+    // the single-destination fields describe the first destination, and are kept for
+    // clients which do not know about the destinations list
+    res.uri.address = destinations.at(0).address;
+    res.uri.amount = destinations.at(0).amount;
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -1871,6 +1871,17 @@ namespace wallet_rpc
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
+  struct uri_destination_spec
+  {
+    std::string address;
+    uint64_t amount;
+
+    BEGIN_KV_SERIALIZE_MAP()
+      KV_SERIALIZE(address)
+      KV_SERIALIZE(amount)
+    END_KV_SERIALIZE_MAP()
+  };
+
   struct uri_spec
   {
     std::string address;
@@ -1892,6 +1903,12 @@ namespace wallet_rpc
   {
     struct request_t: public uri_spec
     {
+      std::vector<uri_destination_spec> destinations;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(uri_spec)
+        KV_SERIALIZE(destinations)
+      END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
 
@@ -1921,10 +1938,12 @@ namespace wallet_rpc
     struct response_t
     {
       uri_spec uri;
+      std::vector<uri_destination_spec> destinations;
       std::vector<std::string> unknown_parameters;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(uri)
+        KV_SERIALIZE(destinations)
         KV_SERIALIZE(unknown_parameters)
       END_KV_SERIALIZE_MAP()
     };

--- a/tests/functional_tests/uri.py
+++ b/tests/functional_tests/uri.py
@@ -43,6 +43,7 @@ class URITest():
     def run_test(self):
       self.create()
       self.test_monero_uri()
+      self.test_multi_destination_uri()
 
     def create(self):
         print('Creating wallet')
@@ -222,6 +223,38 @@ class URITest():
         assert res.uri.address == address
         assert res.uri.amount == 239390140000000
         assert res.unknown_parameters == [u'unknown=' + quoted_utf8string[0]], res
+
+
+    def test_multi_destination_uri(self):
+        print('Testing multi-destination URIs')
+        wallet = Wallet()
+        address1 = '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        address2 = '8AsN91rznfkBGTY8psSNkJBg9SZgxxGGRUhGwRptBhgr5XSQ1XzmA9m8QAnoxydecSh5aLJXdrgXwTDMMZ1AuXsN1EX5Mtm'
+
+        res = wallet.make_uri(destinations = [{'address': address1, 'amount': 1000000000000}, {'address': address2, 'amount': 2000000000000}], tx_description = 'split payment')
+        assert res.uri == 'monero:' + address1 + ';' + address2 + '?tx_amount=1.000000000000;2.000000000000&tx_description=split%20payment', res.uri
+        res = wallet.parse_uri(uri = res.uri)
+        assert len(res.destinations) == 2, res
+        assert res.destinations[0].address == address1
+        assert res.destinations[0].amount == 1000000000000
+        assert res.destinations[1].address == address2
+        assert res.destinations[1].amount == 2000000000000
+        # the single-destination fields mirror the first destination
+        assert res.uri.address == address1
+        assert res.uri.amount == 1000000000000
+        assert res.uri.tx_description == 'split payment'
+
+        # the number of amounts must match the number of destinations
+        ok = False
+        try: wallet.parse_uri(uri = 'monero:' + address1 + ';' + address2 + '?tx_amount=1')
+        except: ok = True
+        assert ok
+
+        # a single-destination request with a destinations list set must not set the single fields
+        ok = False
+        try: wallet.make_uri(address = address1, destinations = [{'address': address2, 'amount': 1}])
+        except: ok = True
+        assert ok
 
 
 

--- a/tests/unit_tests/uri.cpp
+++ b/tests/unit_tests/uri.cpp
@@ -290,3 +290,114 @@ TEST(uri, make_uri_encodes_equals)
   EXPECT_EQ(recipient_name, "name=value");
   EXPECT_EQ(description, "key=value");
 }
+
+TEST(uri, make_multi_destination)
+{
+  tools::wallet2 w(cryptonote::TESTNET);
+  std::string error;
+  std::vector<tools::wallet2::uri_destination> destinations;
+  destinations.push_back({TEST_ADDRESS, 1500000000000});
+  destinations.push_back({TEST_ADDRESS, 2000000000000});
+  const std::string uri = w.make_uri(destinations, "desc", "names", error);
+  ASSERT_TRUE(error.empty());
+  ASSERT_EQ(uri, "monero:" TEST_ADDRESS ";" TEST_ADDRESS "?tx_amount=1.500000000000;2.000000000000&recipient_name=names&tx_description=desc");
+}
+
+TEST(uri, make_multi_destination_no_amounts)
+{
+  tools::wallet2 w(cryptonote::TESTNET);
+  std::string error;
+  std::vector<tools::wallet2::uri_destination> destinations;
+  destinations.push_back({TEST_ADDRESS, 0});
+  destinations.push_back({TEST_ADDRESS, 0});
+  const std::string uri = w.make_uri(destinations, "", "", error);
+  ASSERT_TRUE(error.empty());
+  ASSERT_EQ(uri, "monero:" TEST_ADDRESS ";" TEST_ADDRESS "?tx_amount=0.000000000000;0.000000000000");
+}
+
+TEST(uri, make_multi_destination_rejects_two_integrated)
+{
+  tools::wallet2 w(cryptonote::TESTNET);
+  std::string error;
+  std::vector<tools::wallet2::uri_destination> destinations;
+  destinations.push_back({TEST_INTEGRATED_ADDRESS, 1});
+  destinations.push_back({TEST_INTEGRATED_ADDRESS, 2});
+  ASSERT_TRUE(w.make_uri(destinations, "", "", error).empty());
+  ASSERT_FALSE(error.empty());
+}
+
+TEST(uri, parse_multi_destination)
+{
+  tools::wallet2 w(cryptonote::TESTNET);
+  std::vector<tools::wallet2::uri_destination> destinations;
+  std::string payment_id, description, recipient_names, error;
+  std::vector<std::string> unknown_parameters;
+  ASSERT_TRUE(w.parse_uri("monero:" TEST_ADDRESS ";" TEST_ADDRESS "?tx_amount=1.5;2", destinations, payment_id, description, recipient_names, unknown_parameters, error));
+  ASSERT_EQ(destinations.size(), 2);
+  EXPECT_EQ(destinations[0].address, TEST_ADDRESS);
+  EXPECT_EQ(destinations[0].amount, 1500000000000);
+  EXPECT_EQ(destinations[1].address, TEST_ADDRESS);
+  EXPECT_EQ(destinations[1].amount, 2000000000000);
+  EXPECT_TRUE(payment_id.empty());
+  EXPECT_TRUE(description.empty());
+  EXPECT_TRUE(recipient_names.empty());
+}
+
+TEST(uri, parse_multi_destination_round_trip)
+{
+  tools::wallet2 w(cryptonote::TESTNET);
+  std::string error;
+  std::vector<tools::wallet2::uri_destination> made;
+  made.push_back({TEST_ADDRESS, 1000000000000});
+  made.push_back({TEST_ADDRESS, 200000000000});
+  const std::string uri = w.make_uri(made, "some desc", "a name", error);
+  ASSERT_TRUE(error.empty());
+
+  std::vector<tools::wallet2::uri_destination> parsed;
+  std::string payment_id, description, recipient_names;
+  std::vector<std::string> unknown_parameters;
+  ASSERT_TRUE(w.parse_uri(uri, parsed, payment_id, description, recipient_names, unknown_parameters, error));
+  ASSERT_EQ(parsed.size(), made.size());
+  for (size_t i = 0; i < parsed.size(); ++i)
+  {
+    EXPECT_EQ(parsed[i].address, made[i].address);
+    EXPECT_EQ(parsed[i].amount, made[i].amount);
+  }
+  EXPECT_EQ(description, "some desc");
+  EXPECT_EQ(recipient_names, "a name");
+}
+
+TEST(uri, parse_multi_destination_amount_mismatch)
+{
+  tools::wallet2 w(cryptonote::TESTNET);
+  std::vector<tools::wallet2::uri_destination> destinations;
+  std::string payment_id, description, recipient_names, error;
+  std::vector<std::string> unknown_parameters;
+  ASSERT_FALSE(w.parse_uri("monero:" TEST_ADDRESS ";" TEST_ADDRESS "?tx_amount=1", destinations, payment_id, description, recipient_names, unknown_parameters, error));
+  ASSERT_FALSE(w.parse_uri("monero:" TEST_ADDRESS ";?tx_amount=1;2", destinations, payment_id, description, recipient_names, unknown_parameters, error));
+}
+
+TEST(uri, parse_multi_destination_single_destination_rejects)
+{
+  // the deprecated single-destination parser refuses multi-destination URIs
+  tools::wallet2 w(cryptonote::TESTNET);
+  std::string address, payment_id, recipient_name, description, error;
+  uint64_t amount;
+  std::vector<std::string> unknown_parameters;
+  ASSERT_FALSE(w.parse_uri("monero:" TEST_ADDRESS ";" TEST_ADDRESS, address, payment_id, amount, description, recipient_name, unknown_parameters, error));
+}
+
+TEST(uri, multi_destination_with_payment_id)
+{
+  // a payment id is accepted, but only if no destination uses an integrated address,
+  // and it is exposed to callers which choose to reject it
+  tools::wallet2 w(cryptonote::TESTNET);
+  std::vector<tools::wallet2::uri_destination> destinations;
+  std::string payment_id, description, recipient_names, error;
+  std::vector<std::string> unknown_parameters;
+  ASSERT_TRUE(w.parse_uri("monero:" TEST_ADDRESS ";" TEST_ADDRESS "?tx_payment_id=1234567890123456789012345678901234567890123456789012345678901234", destinations, payment_id, description, recipient_names, unknown_parameters, error));
+  ASSERT_EQ(destinations.size(), 2);
+  ASSERT_FALSE(payment_id.empty());
+
+  ASSERT_FALSE(w.parse_uri("monero:" TEST_INTEGRATED_ADDRESS ";" TEST_ADDRESS "?tx_payment_id=1234567890123456789012345678901234567890123456789012345678901234", destinations, payment_id, description, recipient_names, unknown_parameters, error));
+}


### PR DESCRIPTION
---

**## Title**

`uri: add multi-destination support to make_uri and parse_uri`

**## Body**

Implements the multi-destination extension of the Monero URI scheme
(https://github.com/monero-project/monero/wiki/URI-Formatting), which
updates the URI format to let a single URI request funds from several
destinations at once:

```
monero:<addr1>;<addr2>?tx_amount=<amount1>;<amount2>&recipient_name=...&tx_description=...
```

Motivation: the bounty https://github.com/haveno-dex/haveno/issues/83
(and the upstream monero-labs/monero-dev-pool#2) ask for `make_uri`
and `parse_uri` to accept multiple destinations/amounts.

Changes:

- `wallet2::make_uri` gains an overload taking a vector of
  `uri_destination` (`address` + `amount`). Addresses are joined with
  `;`, amounts likewise, in matching order. A multi-destination URI
  always carries `tx_amount`. At most one destination may be an
  integrated address (matching transaction constraints).
- `wallet2::parse_uri` gains an overload which fills a vector of
  destinations, validates each address, permits at most one integrated
  address, and requires the number of `tx_amount` entries to match the
  number of destinations exactly.
- The old single-destination `parse_uri` is a thin deprecated wrapper
  over the new one: it refuses multi-destination URIs and keeps the
  previous single-destination behavior, including `tx_payment_id`
  support.
- `simplewallet` `transfer` transparently accepts multi-destination
  URIs, expanding them into one destination per address.
- The `make_uri` RPC accepts an optional `destinations` list
  (`{address, amount}` pairs); the `parse_uri` RPC response adds a
  `destinations` list alongside the existing single-destination fields,
  which mirror the first destination. Existing clients are unaffected.

Example:

```
monero:4...?tx_amount=1.000000000000;2.000000000000
```

## Notes for reviewers (responds to #9830 review threads)

- `tx_payment_id` is not accepted by the multi-destination RPC flow in
  `simplewallet` (which is where funds would actually move); it stays
  parseable for single-destination backward compatibility, per the
  deprecation wording in the spec ("deprecated").
- No v2 endpoints were added: the new list fields on the existing
  `make_uri`/`parse_uri` endpoints are purely additive (missing in a
  request = empty list; response always keeps the legacy single fields
  populated with the first destination), so nothing new needs to be
  remembered or versioned.
- Spec compliance: the `recipient_name` field is carried through
  unmodified (joined by `;`); `tx_description` is single; counts are
  validated one-to-one for amounts.


---

Done with help from Qwen3.8 Flash Next
