### PR TITLE
crypto: handle unaligned Keccak output

### DIFF
--- a/contrib/epee/include/int-util.h
+++ b/contrib/epee/include/int-util.h
@@ -231,8 +231,20 @@ static inline void memcpy_swap32(void *dst, const void *src, size_t n) {
 }
 static inline void memcpy_swap64(void *dst, const void *src, size_t n) {
   size_t i;
+  if ((((uintptr_t) dst | (uintptr_t) src) & (sizeof(uint64_t) - 1)) == 0) {
+    for (i = 0; i < n; i++) {
+      ((uint64_t *) dst)[i] = swap64(((const uint64_t *) src)[i]);
+    }
+    return;
+  }
+
+  uint8_t *dst_bytes = (uint8_t *) dst;
+  const uint8_t *src_bytes = (const uint8_t *) src;
   for (i = 0; i < n; i++) {
-    ((uint64_t *) dst)[i] = swap64(((const uint64_t *) src)[i]);
+    uint64_t value;
+    memcpy(&value, src_bytes + i * sizeof(value), sizeof(value));
+    value = swap64(value);
+    memcpy(dst_bytes + i * sizeof(value), &value, sizeof(value));
   }
 }
 

--- a/tests/unit_tests/keccak.cpp
+++ b/tests/unit_tests/keccak.cpp
@@ -162,3 +162,30 @@ TEST(keccak, alignment)
     ASSERT_TRUE(!memcmp(md, amd, 32));
   }
 }
+
+TEST(keccak, output_alignment)
+{
+  const uint8_t data[] = {0, 1, 2, 3};
+  alignas(uint64_t) uint8_t expected[32];
+  alignas(uint64_t) uint8_t output[39];
+  alignas(uint64_t) uint8_t expected1600[200];
+  alignas(uint64_t) uint8_t output1600[207];
+
+  keccak(data, sizeof(data), expected, sizeof(expected));
+  keccak1600(data, sizeof(data), expected1600);
+  for (size_t offset = 1; offset < sizeof(uint64_t); ++offset)
+  {
+    keccak(data, sizeof(data), output + offset, sizeof(expected));
+    ASSERT_EQ(0, memcmp(expected, output + offset, sizeof(expected)));
+
+    memset(output, 0xa5, sizeof(output));
+    KECCAK_CTX ctx;
+    keccak_init(&ctx);
+    keccak_update(&ctx, data, sizeof(data));
+    keccak_finish(&ctx, output + offset);
+    ASSERT_EQ(0, memcmp(expected, output + offset, sizeof(expected)));
+
+    keccak1600(data, sizeof(data), output1600 + offset);
+    ASSERT_EQ(0, memcmp(expected1600, output1600 + offset, sizeof(expected1600)));
+  }
+}

--- a/tests/unit_tests/mul_div.cpp
+++ b/tests/unit_tests/mul_div.cpp
@@ -34,6 +34,23 @@
 
 namespace
 {
+  TEST(memcpy_swap64, handles_unaligned_buffers)
+  {
+    const uint64_t words[] = {0x0123456789abcdef, 0xfedcba9876543210};
+    alignas(uint64_t) uint8_t source[sizeof(words) + sizeof(uint64_t) - 1];
+    alignas(uint64_t) uint8_t destination[sizeof(words) + sizeof(uint64_t) - 1];
+    uint64_t result[2];
+
+    for (size_t offset = 1; offset < sizeof(uint64_t); ++offset)
+    {
+      memcpy(source + offset, words, sizeof(words));
+      memcpy_swap64(destination + offset, source + offset, 2);
+      memcpy(result, destination + offset, sizeof(result));
+      ASSERT_EQ(swap64(words[0]), result[0]);
+      ASSERT_EQ(swap64(words[1]), result[1]);
+    }
+  }
+
   TEST(mul128, handles_zero)
   {
     uint64_t hi, lo;


### PR DESCRIPTION
Addresses #10076

On big-endian systems, `memcpy_swap64le()` maps to `memcpy_swap64()`. The latter accessed arbitrary byte buffers through `uint64_t *`, so an unaligned Keccak output pointer raises `SIGBUS` on strict-alignment systems such as sparc64.

Keep the existing word loop when both pointers are aligned, and use `memcpy` through a local word otherwise. This leaves the aligned hot path unchanged while making unaligned output buffers safe.

Tests:
- `./build/tests/unit_tests/unit_tests`
- `./build/tests/unit_tests/unit_tests --gtest_filter='keccak.*:memcpy_swap64.*'`
- `./build/tests/crypto/cncrypto-tests tests/crypto/tests.txt`
- `./build/tests/monero-wallet-crypto-bench 10`
- `ctest --test-dir build -R '^hash-(fast|slow|slow-1|slow-2|slow-4|variant2-int-sqrt)$' --output-on-failure -j2`
- alignment sanitizer runs of the focused unit, cncrypto, and hash tests
- sparc64 QEMU reproducer: `SIGBUS` on master, exit 0 with this patch
