### PR TITLE
cryptonote_basic: simplify Hardfork

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -39,8 +39,6 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "blockchain.db"
 
-using epee::string_tools::pod_to_hex;
-
 namespace cryptonote
 {
 
@@ -292,16 +290,11 @@ uint64_t BlockchainDB::add_block( const std::pair<block, blobdata>& blck
   TIME_MEASURE_FINISH(time1);
   time_add_block1 += time1;
 
-  m_hardfork->add(blk, prev_height);
+  set_hard_fork_version(prev_height, blk.major_version);
 
   ++num_calls;
 
   return prev_height;
-}
-
-void BlockchainDB::set_hard_fork(HardFork* hf)
-{
-  m_hardfork = hf;
 }
 
 void BlockchainDB::pop_block(block& blk, std::vector<transaction>* txs)

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -38,8 +38,8 @@
 #include "cryptonote_basic/blobdatatype.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/difficulty.h"
-#include "cryptonote_basic/hardfork.h"
 #include "cryptonote_protocol/enums.h"
+#include "syncobj.h"
 
 /** \file
  * Cryptonote Blockchain Database Interface
@@ -575,14 +575,12 @@ protected:
   uint64_t time_commit1 = 0;  //!< a performance metric
   bool m_auto_remove_logs = true;  //!< whether or not to automatically remove old logs
 
-  HardFork* m_hardfork;
-
 public:
 
   /**
    * @brief An empty constructor.
    */
-  BlockchainDB(): m_hardfork(NULL), m_open(false) { }
+  BlockchainDB(): m_open(false) { }
 
   /**
    * @brief An empty destructor.
@@ -793,8 +791,6 @@ public:
   virtual bool block_rtxn_start() const = 0;
   virtual void block_rtxn_stop() const = 0;
   virtual void block_rtxn_abort() const = 0;
-
-  virtual void set_hard_fork(HardFork* hf);
 
   // adds a block with the given metadata to the top of the blockchain, returns the new height
   /**

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1290,8 +1290,6 @@ BlockchainLMDB::BlockchainLMDB(bool batch_transactions): BlockchainDB()
   m_cum_count = 0;
 
   // reset may also need changing when initialize things here
-
-  m_hardfork = nullptr;
 }
 
 #ifdef WIN32

--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2026, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -26,11 +26,9 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <algorithm>
-#include <cstdio>
+#include <ctime>
 
 #include "cryptonote_basic/cryptonote_basic.h"
-#include "blockchain_db/blockchain_db.h"
 #include "hardfork.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
@@ -54,20 +52,12 @@ static uint8_t get_block_version(const cryptonote::block &b)
   return b.major_version;
 }
 
-HardFork::HardFork(cryptonote::BlockchainDB &db, uint8_t original_version, uint64_t original_version_till_height, time_t forked_time, time_t update_time, uint64_t window_size, uint8_t default_threshold_percent):
-  db(db),
+HardFork::HardFork(uint8_t original_version, uint64_t original_version_till_height, time_t forked_time, time_t update_time):
   forked_time(forked_time),
   update_time(update_time),
-  window_size(window_size),
-  default_threshold_percent(default_threshold_percent),
   original_version(original_version),
-  original_version_till_height(original_version_till_height),
-  current_fork_index(0)
+  original_version_till_height(original_version_till_height)
 {
-  if (window_size == 0)
-    throw "window_size needs to be strictly positive";
-  if (default_threshold_percent > 100)
-    throw "default_threshold_percent needs to be between 0 and 100";
 }
 
 bool HardFork::add_fork(uint8_t version, uint64_t height, uint8_t threshold, time_t time)
@@ -93,76 +83,19 @@ bool HardFork::add_fork(uint8_t version, uint64_t height, uint8_t threshold, tim
 
 bool HardFork::add_fork(uint8_t version, uint64_t height, time_t time)
 {
-  return add_fork(version, height, default_threshold_percent, time);
-}
-
-uint8_t HardFork::get_effective_version(uint8_t voting_version) const
-{
-  if (!heights.empty()) {
-    uint8_t max_version = heights.back().version;
-    if (voting_version > max_version)
-      voting_version = max_version;
-  }
-  return voting_version;
-}
-
-bool HardFork::do_check(uint8_t block_version, uint8_t voting_version) const
-{
-  return block_version == heights[current_fork_index].version
-      && voting_version >= heights[current_fork_index].version;
-}
-
-bool HardFork::check(const cryptonote::block &block) const
-{
-  CRITICAL_REGION_LOCAL(lock);
-  return do_check(::get_block_version(block), ::get_block_vote(block));
+  return add_fork(version, height, /*threshold=*/0, time);
 }
 
 bool HardFork::do_check_for_height(uint8_t block_version, uint8_t voting_version, uint64_t height) const
 {
-  int fork_index = get_voted_fork_index(height);
-  return block_version == heights[fork_index].version
-      && voting_version >= heights[fork_index].version;
+  const uint8_t checking_version = get_ideal_version(height);
+  return block_version == checking_version && voting_version >= checking_version;
 }
 
 bool HardFork::check_for_height(const cryptonote::block &block, uint64_t height) const
 {
   CRITICAL_REGION_LOCAL(lock);
   return do_check_for_height(::get_block_version(block), ::get_block_vote(block), height);
-}
-
-bool HardFork::add(uint8_t block_version, uint8_t voting_version, uint64_t height)
-{
-  CRITICAL_REGION_LOCAL(lock);
-
-  if (!do_check(block_version, voting_version))
-    return false;
-
-  db.set_hard_fork_version(height, heights[current_fork_index].version);
-
-  voting_version = get_effective_version(voting_version);
-
-  while (versions.size() >= window_size) {
-    const uint8_t old_version = versions.front();
-    assert(last_versions[old_version] >= 1);
-    last_versions[old_version]--;
-    versions.pop_front();
-  }
-
-  last_versions[voting_version]++;
-  versions.push_back(voting_version);
-
-  uint8_t voted = get_voted_fork_index(height + 1);
-  if (voted > current_fork_index) {
-    current_fork_index = voted;
-  }
-
-  return true;
-}
-
-bool HardFork::add(const cryptonote::block &block, uint64_t height)
-{
-  return add(::get_block_version(block), ::get_block_vote(block), height);
 }
 
 void HardFork::init()
@@ -173,154 +106,7 @@ void HardFork::init()
   if (heights.empty())
     heights.push_back(hardfork_t(original_version, 0, 0, 0));
 
-  versions.clear();
-  for (size_t n = 0; n < 256; ++n)
-    last_versions[n] = 0;
-  current_fork_index = 0;
-
-  // restore state from DB
-  uint64_t height = db.height();
-  if (height > window_size)
-    height -= window_size - 1;
-  else
-    height = 1;
-
-  rescan_from_chain_height(height);
   MDEBUG("init done");
-}
-
-uint8_t HardFork::get_block_version(uint64_t height) const
-{
-  if (height <= original_version_till_height)
-    return original_version;
-
-  const cryptonote::block &block = db.get_block_from_height(height);
-  return ::get_block_version(block);
-}
-
-bool HardFork::reorganize_from_block_height(uint64_t height)
-{
-  CRITICAL_REGION_LOCAL(lock);
-  if (height >= db.height())
-    return false;
-
-  bool stop_batch = db.batch_start();
-
-  versions.clear();
-
-  for (size_t n = 0; n < 256; ++n)
-    last_versions[n] = 0;
-  const uint64_t rescan_height = height >= (window_size - 1) ? height - (window_size  -1) : 0;
-  const uint8_t start_version = height == 0 ? original_version : db.get_hard_fork_version(height);
-  while (current_fork_index > 0 && heights[current_fork_index].version > start_version) {
-    --current_fork_index;
-  }
-  for (uint64_t h = rescan_height; h <= height; ++h) {
-    cryptonote::block b = db.get_block_from_height(h);
-    const uint8_t v = get_effective_version(get_block_vote(b));
-    last_versions[v]++;
-    versions.push_back(v);
-  }
-
-  uint8_t voted = get_voted_fork_index(height + 1);
-  if (voted > current_fork_index) {
-    current_fork_index = voted;
-  }
-
-  const uint64_t bc_height = db.height();
-  for (uint64_t h = height + 1; h < bc_height; ++h) {
-    add(db.get_block_from_height(h), h);
-  }
-
-  if (stop_batch)
-    db.batch_stop();
-
-  return true;
-}
-
-bool HardFork::reorganize_from_chain_height(uint64_t height)
-{
-  if (height == 0)
-    return false;
-  return reorganize_from_block_height(height - 1);
-}
-
-bool HardFork::rescan_from_block_height(uint64_t height)
-{
-  CRITICAL_REGION_LOCAL(lock);
-  db_rtxn_guard rtxn_guard(&db);
-  if (height >= db.height())
-    return false;
-
-  versions.clear();
-
-  for (size_t n = 0; n < 256; ++n)
-    last_versions[n] = 0;
-  for (uint64_t h = height; h < db.height(); ++h) {
-    cryptonote::block b = db.get_block_from_height(h);
-    const uint8_t v = get_effective_version(get_block_vote(b));
-    last_versions[v]++;
-    versions.push_back(v);
-  }
-
-  uint8_t lastv = db.get_hard_fork_version(db.height() - 1);
-  current_fork_index = 0;
-  while (current_fork_index + 1 < heights.size() && heights[current_fork_index].version != lastv)
-    ++current_fork_index;
-
-  uint8_t voted = get_voted_fork_index(db.height());
-  if (voted > current_fork_index) {
-    current_fork_index = voted;
-  }
-
-  return true;
-}
-
-bool HardFork::rescan_from_chain_height(uint64_t height)
-{
-  if (height == 0)
-    return false;
-  return rescan_from_block_height(height - 1);
-}
-
-void HardFork::on_block_popped(uint64_t nblocks)
-{
-  CHECK_AND_ASSERT_THROW_MES(nblocks > 0, "nblocks must be greater than 0");
-
-  CRITICAL_REGION_LOCAL(lock);
-
-  const uint64_t new_chain_height = db.height();
-  const uint64_t old_chain_height = new_chain_height + nblocks;
-  uint8_t version;
-  for (uint64_t height = old_chain_height - 1; height >= new_chain_height; --height)
-  {
-    version = versions.back();
-    last_versions[version]--;
-    versions.pop_back();
-    version = db.get_hard_fork_version(height);
-    versions.push_front(version);
-    last_versions[version]++;
-  }
-
-  // does not take voting into account
-  for (current_fork_index = heights.size() - 1; current_fork_index > 0; --current_fork_index)
-    if (new_chain_height >= heights[current_fork_index].height)
-      break;
-}
-
-int HardFork::get_voted_fork_index(uint64_t height) const
-{
-  CRITICAL_REGION_LOCAL(lock);
-  uint32_t accumulated_votes = 0;
-  for (int n = heights.size() - 1; n >= 0; --n) {
-    uint8_t v = heights[n].version;
-    accumulated_votes += last_versions[v];
-    uint32_t threshold = (window_size * heights[n].threshold + 99) / 100;
-    if (height >= heights[n].height && accumulated_votes >= threshold) {
-      return n;
-    }
-  }
-  return current_fork_index;
 }
 
 HardFork::State HardFork::get_state(time_t t) const
@@ -342,25 +128,6 @@ HardFork::State HardFork::get_state(time_t t) const
 HardFork::State HardFork::get_state() const
 {
   return get_state(time(NULL));
-}
-
-uint8_t HardFork::get(uint64_t height) const
-{
-  CRITICAL_REGION_LOCAL(lock);
-  if (height > db.height()) {
-    assert(false);
-    return 255;
-  }
-  if (height == db.height()) {
-    return get_current_version();
-  }
-  return db.get_hard_fork_version(height);
-}
-
-uint8_t HardFork::get_current_version() const
-{
-  CRITICAL_REGION_LOCAL(lock);
-  return heights[current_fork_index].version;
 }
 
 uint8_t HardFork::get_ideal_version() const
@@ -392,33 +159,3 @@ uint64_t HardFork::get_earliest_ideal_height_for_version(uint8_t version) const
   }
   return height;
 }
-
-uint8_t HardFork::get_next_version() const
-{
-  CRITICAL_REGION_LOCAL(lock);
-  uint64_t height = db.height();
-  for (auto i = heights.rbegin(); i != heights.rend(); ++i) {
-    if (height >= i->height) {
-      return (i == heights.rbegin() ? i : (i - 1))->version;
-    }
-  }
-  return original_version;
-}
-
-bool HardFork::get_voting_info(uint8_t version, uint32_t &window, uint32_t &votes, uint32_t &threshold, uint64_t &earliest_height, uint8_t &voting) const
-{
-  CRITICAL_REGION_LOCAL(lock);
-
-  const uint8_t current_version = heights[current_fork_index].version;
-  const bool enabled = current_version >= version;
-  window = versions.size();
-  votes = 0;
-  for (size_t n = version; n < 256; ++n)
-      votes += last_versions[n];
-  threshold = (window * heights[current_fork_index].threshold + 99) / 100;
-  //assert((votes >= threshold) == enabled);
-  earliest_height = get_earliest_ideal_height_for_version(version);
-  voting = heights.back().version;
-  return enabled;
-}
-

--- a/src/cryptonote_basic/hardfork.h
+++ b/src/cryptonote_basic/hardfork.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2026, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -30,11 +30,12 @@
 
 #include "syncobj.h"
 #include "hardforks/hardforks.h"
-#include "cryptonote_basic/cryptonote_basic.h"
+
+#include <vector>
 
 namespace cryptonote
 {
-  class BlockchainDB;
+  struct block;
 
   class HardFork
   {
@@ -45,11 +46,10 @@ namespace cryptonote
       Ready,
     } State;
 
-    static const uint64_t DEFAULT_ORIGINAL_VERSION_TILL_HEIGHT = 0; // <= actual height
-    static const time_t DEFAULT_FORKED_TIME = 31557600; // a year in seconds
-    static const time_t DEFAULT_UPDATE_TIME = 31557600 / 2;
-    static const uint64_t DEFAULT_WINDOW_SIZE = 10080; // supermajority window check length - a week
-    static const uint8_t DEFAULT_THRESHOLD_PERCENT = 80;
+    static constexpr uint64_t DEFAULT_ORIGINAL_VERSION_TILL_HEIGHT = 0; // <= actual height
+    static constexpr time_t DEFAULT_FORKED_TIME = 31557600; // a year in seconds
+    static constexpr time_t DEFAULT_UPDATE_TIME = 31557600 / 2;
+    static constexpr uint64_t DEFAULT_WINDOW_SIZE = 10080; // supermajority window check length - a week
 
     /**
      * @brief creates a new HardFork object
@@ -57,10 +57,8 @@ namespace cryptonote
      * @param original_version the block version for blocks 0 through to the first fork
      * @param forked_time the time in seconds before thinking we're forked
      * @param update_time the time in seconds before thinking we need to update
-     * @param window_size the size of the window in blocks to consider for version voting
-     * @param default_threshold_percent the size of the majority in percents
      */
-    HardFork(cryptonote::BlockchainDB &db, uint8_t original_version = 1, uint64_t original_version_till_height = DEFAULT_ORIGINAL_VERSION_TILL_HEIGHT, time_t forked_time = DEFAULT_FORKED_TIME, time_t update_time = DEFAULT_UPDATE_TIME, uint64_t window_size = DEFAULT_WINDOW_SIZE, uint8_t default_threshold_percent = DEFAULT_THRESHOLD_PERCENT);
+    HardFork(uint8_t original_version = 1, uint64_t original_version_till_height = DEFAULT_ORIGINAL_VERSION_TILL_HEIGHT, time_t forked_time = DEFAULT_FORKED_TIME, time_t update_time = DEFAULT_UPDATE_TIME);
 
     /**
      * @brief add a new hardfork height
@@ -75,7 +73,7 @@ namespace cryptonote
     bool add_fork(uint8_t version, uint64_t height, uint8_t threshold, time_t time);
 
     /**
-     * @brief add a new hardfork height
+     * @brief add a new hardfork height, with threshold 0 (non-voting)
      *
      * returns true if no error, false otherwise
      *
@@ -93,7 +91,11 @@ namespace cryptonote
     void init();
 
     /**
-     * @brief check whether a new block would be accepted
+     * @brief check whether a new block would be accepted at given height
+     *
+     * NOTE: this does not play well with voting, and relies on voting to be
+     * disabled (that is, forks happen on the scheduled date, whether or not
+     * enough blocks have voted for the fork).
      *
      * returns true if the block is accepted, false otherwise
      *
@@ -111,54 +113,7 @@ namespace cryptonote
      * block being invalid, double spending, etc) would cause the
      * hardfork object to reorganize.
      */
-    bool check(const cryptonote::block &block) const;
-
-    /**
-     * @brief same as check, but for a particular height, rather than the top
-     *
-     * NOTE: this does not play well with voting, and relies on voting to be
-     * disabled (that is, forks happen on the scheduled date, whether or not
-     * enough blocks have voted for the fork).
-     *
-     * returns true if no error, false otherwise
-     *
-     * @param block the new block
-     * @param height which height to check for
-     */
     bool check_for_height(const cryptonote::block &block, uint64_t height) const;
-
-    /**
-     * @brief add a new block
-     *
-     * returns true if no error, false otherwise
-     *
-     * @param block the new block
-     */
-    bool add(const cryptonote::block &block, uint64_t height);
-
-    /**
-     * @brief called when the blockchain is reorganized
-     *
-     * This will rescan the blockchain to determine which hard forks
-     * have been triggered
-     *
-     * returns true if no error, false otherwise
-     *
-     * @param blockchain the blockchain
-     * @param height of the last block kept from the previous blockchain
-     */
-    bool reorganize_from_block_height(uint64_t height);
-    bool reorganize_from_chain_height(uint64_t height);
-
-    /**
-     * @brief called when one or more blocks are popped from the blockchain
-     *
-     * The current fork will be updated by looking up the db,
-     * which is much cheaper than recomputing everything
-     *
-     * @param new_chain_height the height of the chain after popping
-     */
-    void on_block_popped(uint64_t new_chain_height);
 
     /**
      * @brief returns current state at the given time
@@ -170,13 +125,6 @@ namespace cryptonote
      */
     State get_state(time_t t) const;
     State get_state() const;
-
-    /**
-     * @brief returns the hard fork version for the given block height
-     *
-     * @param height height of the block to check
-     */
-    uint8_t get(uint64_t height) const;
 
     /**
      * @brief returns the latest "ideal" version
@@ -193,42 +141,9 @@ namespace cryptonote
     uint8_t get_ideal_version(uint64_t height) const;
 
     /**
-     * @brief returns the next version
-     *
-     * This is the version which will we fork to next
-     */
-    uint8_t get_next_version() const;
-
-    /**
-     * @brief returns the current version
-     *
-     * This is the latest version that's past its trigger date and had enough votes
-     * at one point in the past.
-     */
-    uint8_t get_current_version() const;
-
-    /**
      * @brief returns the earliest block a given version may activate
      */
     uint64_t get_earliest_ideal_height_for_version(uint8_t version) const;
-
-    /**
-     * @brief returns information about current voting state
-     *
-     * returns true if the given version is enabled (ie, the current version
-     * is at least the passed version), false otherwise
-     *
-     * @param version the version to check voting for
-     * @param window the number of blocks considered in voting
-     * @param votes number of votes for next version
-     * @param threshold number of votes needed to switch to next version
-     * @param earliest_height earliest height at which the version can take effect
-     */
-    bool get_voting_info(uint8_t version, uint32_t &window, uint32_t &votes, uint32_t &threshold, uint64_t &earliest_height, uint8_t &voting) const;
-
-    /**
-     * @brief returns the size of the voting window in blocks
-     */
 
     /**
      * @brief returns info for all known hard forks
@@ -236,34 +151,15 @@ namespace cryptonote
     const std::vector<hardfork_t>& get_hardforks() const { return heights; }
 
   private:
-
-    uint8_t get_block_version(uint64_t height) const;
-    bool do_check(uint8_t block_version, uint8_t voting_version) const;
     bool do_check_for_height(uint8_t block_version, uint8_t voting_version, uint64_t height) const;
-    int get_voted_fork_index(uint64_t height) const;
-    uint8_t get_effective_version(uint8_t voting_version) const;
-    bool add(uint8_t block_version, uint8_t voting_version, uint64_t height);
-
-    bool rescan_from_block_height(uint64_t height);
-    bool rescan_from_chain_height(uint64_t height);
-
-  private:
-
-    BlockchainDB &db;
 
     time_t forked_time;
     time_t update_time;
-    uint64_t window_size;
-    uint8_t default_threshold_percent;
 
     uint8_t original_version;
     uint64_t original_version_till_height;
 
     std::vector<hardfork_t> heights;
-
-    std::deque<uint8_t> versions; /* rolling window of the last N blocks' versions */
-    unsigned int last_versions[256]; /* count of the block versions in the last N blocks */
-    uint32_t current_fork_index;
 
     mutable epee::critical_section lock;
   };

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -85,7 +85,7 @@ DISABLE_VS_WARNINGS(4267)
 
 //------------------------------------------------------------------
 Blockchain::Blockchain(tx_memory_pool& tx_pool) :
-  m_db(), m_tx_pool(tx_pool), m_hardfork(NULL), m_timestamps_and_difficulties_height(0), m_reset_timestamps_and_difficulties_height(true), m_current_block_cumul_weight_limit(0), m_current_block_cumul_weight_median(0),
+  m_db(), m_tx_pool(tx_pool), m_timestamps_and_difficulties_height(0), m_reset_timestamps_and_difficulties_height(true), m_current_block_cumul_weight_limit(0), m_current_block_cumul_weight_median(0),
   m_enforce_dns_checkpoints(false), m_max_prepare_blocks_threads(4), m_db_sync_on_blocks(true), m_db_sync_threshold(1), m_db_sync_mode(db_async), m_db_default_sync(false), m_fast_sync(true), m_show_time_stats(false), m_sync_counter(0), m_bytes_to_sync(0), m_cancel(false),
   m_long_term_block_weights_window(CRYPTONOTE_LONG_TERM_BLOCK_WEIGHT_WINDOW_SIZE),
   m_long_term_effective_median_block_weight(0),
@@ -301,14 +301,13 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
   m_nettype = test_options != NULL ? FAKECHAIN : nettype;
   m_offline = offline;
   m_fixed_difficulty = fixed_difficulty;
-  if (m_hardfork == nullptr)
   {
     if (m_nettype ==  FAKECHAIN || m_nettype == STAGENET)
-      m_hardfork = new HardFork(*db, 1, 0);
+      m_hardfork.emplace(1, 0);
     else if (m_nettype == TESTNET)
-      m_hardfork = new HardFork(*db, 1, testnet_hard_fork_version_1_till);
+      m_hardfork.emplace(1, testnet_hard_fork_version_1_till);
     else
-      m_hardfork = new HardFork(*db, 1, mainnet_hard_fork_version_1_till);
+      m_hardfork.emplace(1, mainnet_hard_fork_version_1_till);
   }
   if (m_nettype == FAKECHAIN)
   {
@@ -331,8 +330,6 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
       m_hardfork->add_fork(mainnet_hard_forks[n].version, mainnet_hard_forks[n].height, mainnet_hard_forks[n].threshold, mainnet_hard_forks[n].time);
   }
   m_hardfork->init();
-
-  m_db->set_hard_fork(m_hardfork);
 
   // if the blockchain is new, add the genesis block
   // this feels kinda kludgy to do it this way, but can be looked at later.
@@ -428,7 +425,6 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
   {
     m_timestamps_and_difficulties_height = 0;
     m_reset_timestamps_and_difficulties_height = true;
-    m_hardfork->reorganize_from_chain_height(get_current_blockchain_height());
     uint64_t top_block_height;
     crypto::hash top_block_hash = get_tail_id(top_block_height);
     m_tx_pool.on_blockchain_dec(top_block_height, top_block_hash);
@@ -455,7 +451,7 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
       return false;
   }
 
-  if (m_hardfork->get_current_version() >= RX_BLOCK_VERSION)
+  if (get_current_hard_fork_version() >= RX_BLOCK_VERSION)
   {
     const crypto::hash seedhash = get_block_id_by_height(crypto::rx_seedheight(m_db->height()));
     if (seedhash != crypto::null_hash)
@@ -526,8 +522,7 @@ bool Blockchain::deinit()
     LOG_ERROR("There was an issue closing/storing the blockchain, shutting down now to prevent issues!");
   }
 
-  delete m_hardfork;
-  m_hardfork = NULL;
+  m_hardfork.reset();
   delete m_db;
   m_db = NULL;
   return true;
@@ -567,7 +562,7 @@ void Blockchain::pop_blocks(uint64_t nblocks, const bool keep_txs)
   if (stop_batch)
     m_db->batch_stop();
 
-  if (m_hardfork->get_current_version() >= RX_BLOCK_VERSION)
+  if (get_current_hard_fork_version() >= RX_BLOCK_VERSION)
   {
     const crypto::hash seedhash = get_block_id_by_height(crypto::rx_seedheight(m_db->height()));
     rx_set_main_seedhash(seedhash.data, tools::get_max_concurrency());
@@ -607,9 +602,6 @@ block Blockchain::pop_block_from_blockchain(bool keep_txs)
     LOG_ERROR("Error popping block from blockchain, throwing!");
     throw;
   }
-
-  // make sure the hard fork object updates its current version
-  m_hardfork->on_block_popped(1);
 
   // return transactions from popped block to the tx_pool
   size_t pruned = 0;
@@ -1108,9 +1100,6 @@ bool Blockchain::rollback_blockchain_switching(std::list<block>& original_chain,
   }
   CHECK_AND_ASSERT_THROW_MES(update_next_cumulative_weight_limit(), "Error updating next cumulative weight limit");
 
-  // make sure the hard fork object updates its current version
-  m_hardfork->reorganize_from_chain_height(rollback_height);
-
   //return back original chain
   for (auto& bl : original_chain)
   {
@@ -1118,8 +1107,6 @@ bool Blockchain::rollback_blockchain_switching(std::list<block>& original_chain,
     bool r = handle_block_to_main_chain(bl, bvc);
     CHECK_AND_ASSERT_MES(r && bvc.m_added_to_main_chain, false, "PANIC! failed to add (again) block while chain switching during the rollback!");
   }
-
-  m_hardfork->reorganize_from_chain_height(rollback_height);
 
   MINFO("Rollback to height " << rollback_height << " was successful.");
   if (!original_chain.empty())
@@ -1220,8 +1207,6 @@ bool Blockchain::switch_to_alternative_blockchain(std::list<block_extended_info>
     m_db->remove_alt_block(cryptonote::get_block_hash(bei.bl));
   }
 
-  m_hardfork->reorganize_from_chain_height(split_height);
-
   std::shared_ptr<tools::Notify> reorg_notify = m_reorg_notify;
   if (reorg_notify)
     reorg_notify->notify("%s", std::to_string(split_height).c_str(), "%h", std::to_string(m_db->height()).c_str(),
@@ -1246,7 +1231,7 @@ bool Blockchain::switch_to_alternative_blockchain(std::list<block_extended_info>
     }
   }
 
-  if (m_hardfork->get_current_version() >= RX_BLOCK_VERSION)
+  if (get_current_hard_fork_version() >= RX_BLOCK_VERSION)
     rx_set_main_seedhash(seedhash.data, tools::get_max_concurrency());
 
   MGINFO_GREEN("REORGANIZE SUCCESS! on height: " << split_height << ", new blockchain size: " << m_db->height());
@@ -1581,7 +1566,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
       CHECK_AND_ASSERT_MES(get_block_by_hash(*from_block, prev_block), false, "From block not found"); // TODO
       uint64_t from_block_height = cryptonote::get_block_height(prev_block);
       height = from_block_height + 1;
-      if (m_hardfork->get_current_version() >= RX_BLOCK_VERSION)
+      if (get_current_hard_fork_version() >= RX_BLOCK_VERSION)
       {
         uint64_t next_height;
         crypto::rx_seedheights(height, &seed_height, &next_height);
@@ -1637,13 +1622,13 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
   else
   {
     height = m_db->height();
-    b.major_version = m_hardfork->get_current_version();
+    b.major_version = get_current_hard_fork_version();
     b.minor_version = m_hardfork->get_ideal_version();
     b.prev_id = get_tail_id();
     median_weight = m_current_block_cumul_weight_limit / 2;
     diffic = get_difficulty_for_next_block();
     already_generated_coins = m_db->get_block_already_generated_coins(height - 1);
-    if (m_hardfork->get_current_version() >= RX_BLOCK_VERSION)
+    if (get_current_hard_fork_version() >= RX_BLOCK_VERSION)
     {
       uint64_t next_height;
       crypto::rx_seedheights(height, &seed_height, &next_height);
@@ -1801,7 +1786,7 @@ bool Blockchain::get_miner_data(uint8_t& major_version, uint64_t& height, crypto
   major_version = m_hardfork->get_ideal_version(height);
 
   seed_hash = crypto::null_hash;
-  if (m_hardfork->get_current_version() >= RX_BLOCK_VERSION)
+  if (get_current_hard_fork_version() >= RX_BLOCK_VERSION)
   {
     uint64_t seed_height, next_height;
     crypto::rx_seedheights(height, &seed_height, &next_height);
@@ -2343,7 +2328,7 @@ bool Blockchain::get_outs(const COMMAND_RPC_GET_OUTPUTS_BIN::request& req, COMMA
       MERROR("Unexpected output data size: expected " << req.outputs.size() << ", got " << data.size());
       return false;
     }
-    const uint8_t hf_version = m_hardfork->get_current_version();
+    const uint8_t hf_version = get_current_hard_fork_version();
     for (const auto &t: data)
       res.outs.push_back({t.pubkey, t.commitment, is_tx_spendtime_unlocked(t.unlock_time, hf_version), t.height, crypto::null_hash});
 
@@ -2369,7 +2354,7 @@ void Blockchain::get_output_key_mask_unlocked(const uint64_t& amount, const uint
   key = o_data.pubkey;
   mask = o_data.commitment;
   tx_out_index toi = m_db->get_output_tx_and_index(amount, index);
-  const uint8_t hf_version = m_hardfork->get_current_version();
+  const uint8_t hf_version = get_current_hard_fork_version();
   unlocked = is_tx_spendtime_unlocked(m_db->get_tx_unlock_time(toi.first), hf_version);
 }
 //------------------------------------------------------------------
@@ -3312,7 +3297,7 @@ bool Blockchain::check_tx_inputs(transaction& tx,
 
   crypto::hash tx_prefix_hash = get_transaction_prefix_hash(tx);
 
-  const uint8_t hf_version = m_hardfork->get_current_version();
+  const uint8_t hf_version = get_current_hard_fork_version();
 
   if (hf_version >= HF_VERSION_MIN_2_OUTPUTS)
   {
@@ -3918,7 +3903,7 @@ leave:
 
   // this is a cheap test
   const uint8_t hf_version = get_current_hard_fork_version();
-  if (!m_hardfork->check(bl))
+  if (!m_hardfork->check_for_height(bl, blockchain_height))
   {
     MERROR_VER("Block with id: " << id << std::endl << "has old version: " << (unsigned)bl.major_version << std::endl << "current: " << (unsigned)hf_version);
     bvc.m_verifivation_failed = true;
@@ -4258,7 +4243,7 @@ leave:
   TIME_MEASURE_START(vmt);
   uint64_t base_reward = 0;
   uint64_t already_generated_coins = blockchain_height ? m_db->get_block_already_generated_coins(blockchain_height - 1) : 0;
-  if(!validate_miner_transaction(bl, cumulative_block_weight, fee_summary, base_reward, already_generated_coins, bvc.m_partial_block_reward, m_hardfork->get_current_version()))
+  if(!validate_miner_transaction(bl, cumulative_block_weight, fee_summary, base_reward, already_generated_coins, bvc.m_partial_block_reward, get_current_hard_fork_version()))
   {
     MERROR_VER("Block with id: " << id << " has incorrect miner transaction");
     bvc.m_verifivation_failed = true;
@@ -4372,7 +4357,7 @@ leave:
   for (const auto& notifier: m_block_notifiers)
     notifier(new_height - 1, {std::addressof(bl), 1});
 
-  if (m_hardfork->get_current_version() >= RX_BLOCK_VERSION)
+  if (get_current_hard_fork_version() >= RX_BLOCK_VERSION)
     rx_set_main_seedhash(seedhash.data, tools::get_max_concurrency());
 
   return true;
@@ -5372,9 +5357,40 @@ HardFork::State Blockchain::get_hard_fork_state() const
   return m_hardfork->get_state();
 }
 
+uint8_t Blockchain::get_current_hard_fork_version() const
+{
+  return m_hardfork->get_ideal_version(m_db->height());
+}
+
+uint8_t Blockchain::get_hard_fork_version(uint64_t height) const
+{
+  const std::uint64_t db_height = m_db->height();
+  if (height > db_height)
+  {
+    return 255;
+  }
+  else if (height == db_height)
+  {
+    return m_hardfork->get_ideal_version(db_height);
+  }
+  else
+  {
+    return m_db->get_hard_fork_version(height);
+  }
+}
+
 bool Blockchain::get_hard_fork_voting_info(uint8_t version, uint32_t &window, uint32_t &votes, uint32_t &threshold, uint64_t &earliest_height, uint8_t &voting) const
 {
-  return m_hardfork->get_voting_info(version, window, votes, threshold, earliest_height, voting);
+  const uint64_t db_height = m_db->height();
+  const uint8_t current_hf_version = get_current_hard_fork_version();
+  window = std::min(HardFork::DEFAULT_WINDOW_SIZE, db_height);
+  // assumed threshold (see actual fork tables):
+  threshold = 0;
+  earliest_height = m_hardfork->get_earliest_ideal_height_for_version(version);
+  // fake vote count based on ideal conditions:
+  votes = (db_height >= earliest_height) ? std::min<uint32_t>(db_height - earliest_height, window) : 0;
+  voting = m_hardfork->get_ideal_version();
+  return current_hf_version >= version;
 }
 
 uint64_t Blockchain::get_difficulty_target() const

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -901,7 +901,7 @@ namespace cryptonote
      *
      * @return the version
      */
-    uint8_t get_current_hard_fork_version() const { return m_hardfork->get_current_version(); }
+    uint8_t get_current_hard_fork_version() const;
 
     /**
      * @brief returns the newest hardfork version known to the blockchain
@@ -909,13 +909,6 @@ namespace cryptonote
      * @return the version
      */
     uint8_t get_ideal_hard_fork_version() const { return m_hardfork->get_ideal_version(); }
-
-    /**
-     * @brief returns the next hardfork version
-     *
-     * @return the version
-     */
-    uint8_t get_next_hard_fork_version() const { return m_hardfork->get_next_version(); }
 
     /**
      * @brief returns the newest hardfork version voted to be enabled
@@ -934,7 +927,7 @@ namespace cryptonote
      *
      * @return the version
      */
-    uint8_t get_hard_fork_version(uint64_t height) const { return m_hardfork->get(height); }
+    uint8_t get_hard_fork_version(uint64_t height) const;
 
     /**
      * @brief returns the earliest block a given version may activate
@@ -1221,7 +1214,7 @@ namespace cryptonote
     checkpoints m_checkpoints;
     bool m_enforce_dns_checkpoints;
 
-    HardFork *m_hardfork;
+    std::optional<HardFork> m_hardfork;
 
     network_type m_nettype;
     bool m_offline;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2026, The Monero Project
 //
 // All rights reserved.
 //
@@ -1609,11 +1609,6 @@ namespace cryptonote
   uint8_t core::get_ideal_hard_fork_version(uint64_t height) const
   {
     return get_blockchain_storage().get_ideal_hard_fork_version(height);
-  }
-  //-----------------------------------------------------------------------------------------------
-  uint8_t core::get_hard_fork_version(uint64_t height) const
-  {
-    return get_blockchain_storage().get_hard_fork_version(height);
   }
   //-----------------------------------------------------------------------------------------------
   uint64_t core::get_earliest_ideal_height_for_version(uint8_t version) const

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2026, The Monero Project
 //
 // All rights reserved.
 //
@@ -678,13 +678,6 @@ namespace cryptonote
       * @return what it says above
       */
      uint8_t get_ideal_hard_fork_version(uint64_t height) const;
-
-     /**
-      * @brief return the hard fork version for a given block height
-      *
-      * @return what it says above
-      */
-     uint8_t get_hard_fork_version(uint64_t height) const;
 
      /**
       * @brief return the earliest block a given version may activate

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2299,8 +2299,8 @@ namespace cryptonote
     RPC_TRACKER(hard_fork_info);
 
     const Blockchain &blockchain = m_core.get_blockchain_storage();
-    uint8_t version = req.version > 0 ? req.version : blockchain.get_next_hard_fork_version();
     res.version = blockchain.get_current_hard_fork_version();
+    const uint8_t version = req.version > 0 ? req.version : res.version;
     res.enabled = blockchain.get_hard_fork_voting_info(version, res.window, res.votes, res.threshold, res.earliest_height, res.voting);
     res.state = blockchain.get_hard_fork_state();
     res.status = CORE_RPC_STATUS_OK;

--- a/tests/unit_tests/blockchain_db.cpp
+++ b/tests/unit_tests/blockchain_db.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2026, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -30,8 +30,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <cstdio>
 #include <iostream>
-#include <chrono>
-#include <thread>
 
 #include "gtest/gtest.h"
 
@@ -328,7 +326,7 @@ template <typename T>
 class BlockchainDBTest : public testing::Test
 {
 protected:
-  BlockchainDBTest() : m_db(new T()), m_hardfork(*m_db, 1, 0)
+  BlockchainDBTest() : m_db(new T())
   {
     for (auto& i : t_blocks)
     {
@@ -357,17 +355,10 @@ protected:
   }
 
   BlockchainDB* m_db;
-  HardFork m_hardfork;
   std::string m_prefix;
   std::vector<std::pair<block, blobdata>> m_blocks;
   std::vector<std::vector<std::pair<transaction, blobdata>>> m_txs;
   std::vector<std::string> m_filenames;
-
-  void init_hard_fork()
-  {
-    m_hardfork.init();
-    m_db->set_hard_fork(&m_hardfork);
-  }
 
   void get_filenames()
   {
@@ -437,7 +428,6 @@ TYPED_TEST(BlockchainDBTest, AddBlock)
   // make sure open does not throw
   ASSERT_NO_THROW(this->m_db->open(dirPath));
   this->get_filenames();
-  this->init_hard_fork();
 
   db_wtxn_guard guard(this->m_db);
 
@@ -485,7 +475,6 @@ TYPED_TEST(BlockchainDBTest, RetrieveBlockData)
   // make sure open does not throw
   ASSERT_NO_THROW(this->m_db->open(dirPath));
   this->get_filenames();
-  this->init_hard_fork();
 
   db_wtxn_guard guard(this->m_db);
 

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2026, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -28,55 +28,15 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
-#include <algorithm>
 #include "gtest/gtest.h"
 
-#include "blockchain_db/blockchain_db.h"
-#include "cryptonote_basic/cryptonote_format_utils.h"
+#include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/hardfork.h"
-#include "blockchain_db/testdb.h"
 
 using namespace cryptonote;
 
 #define BLOCKS_PER_YEAR 525960
 #define SECONDS_PER_YEAR 31557600
-
-namespace
-{
-
-class TestDB: public cryptonote::BaseTestDB {
-public:
-  virtual uint64_t height() const override { return blocks.size(); }
-  using cryptonote::BaseTestDB::add_block;
-  virtual void add_block( const block& blk
-                        , size_t block_weight
-                        , uint64_t long_term_block_weight
-                        , const difficulty_type& cumulative_difficulty
-                        , const uint64_t& coins_generated
-                        , uint64_t num_rct_outs
-                        , const crypto::hash& blk_hash
-                        ) override {
-    blocks.push_back(blk);
-  }
-  virtual void remove_block() override { blocks.pop_back(); }
-  virtual block get_block_from_height(const uint64_t& height) const override {
-    return blocks.at(height);
-  }
-  virtual void set_hard_fork_version(uint64_t height, uint8_t version) override {
-    if (versions.size() <= height) 
-      versions.resize(height+1); 
-    versions[height] = version;
-  }
-  virtual uint8_t get_hard_fork_version(uint64_t height) const override {
-    return versions.at(height);
-  }
-
-private:
-  std::vector<block> blocks;
-  std::deque<uint8_t> versions;
-};
-
-}
 
 static cryptonote::block mkblock(uint8_t version, uint8_t vote)
 {
@@ -89,15 +49,14 @@ static cryptonote::block mkblock(uint8_t version, uint8_t vote)
 static cryptonote::block mkblock(const HardFork &hf, uint64_t height, uint8_t vote)
 {
   cryptonote::block b;
-  b.major_version = hf.get(height);
+  b.major_version = hf.get_ideal_version(height);
   b.minor_version = vote;
   return b;
 }
 
 TEST(major, Only)
 {
-  TestDB db;
-  HardFork hf(db, 1, 0, 0, 0, 1, 0); // no voting
+  HardFork hf(1, 0, 0, 0); // no voting
 
   //                      v  h  t
   ASSERT_TRUE(hf.add_fork(1, 0, 0));
@@ -105,29 +64,25 @@ TEST(major, Only)
   hf.init();
 
   // block height 0, only version 1 is accepted
-  ASSERT_FALSE(hf.add(mkblock(0, 2), 0));
-  ASSERT_FALSE(hf.add(mkblock(2, 2), 0));
-  ASSERT_TRUE(hf.add(mkblock(1, 2), 0));
-  db.add_block(mkblock(1, 1), 0, 0, 0, 0, 0, crypto::hash());
+  ASSERT_FALSE(hf.check_for_height(mkblock(0, 2), 0));
+  ASSERT_FALSE(hf.check_for_height(mkblock(2, 2), 0));
+  ASSERT_TRUE(hf.check_for_height(mkblock(1, 2), 0));
 
   // block height 1, only version 1 is accepted
-  ASSERT_FALSE(hf.add(mkblock(0, 2), 1));
-  ASSERT_FALSE(hf.add(mkblock(2, 2), 1));
-  ASSERT_TRUE(hf.add(mkblock(1, 2), 1));
-  db.add_block(mkblock(1, 1), 0, 0, 0, 0, 0, crypto::hash());
+  ASSERT_FALSE(hf.check_for_height(mkblock(0, 2), 1));
+  ASSERT_FALSE(hf.check_for_height(mkblock(2, 2), 1));
+  ASSERT_TRUE(hf.check_for_height(mkblock(1, 2), 1));
 
   // block height 2, only version 2 is accepted
-  ASSERT_FALSE(hf.add(mkblock(0, 2), 2));
-  ASSERT_FALSE(hf.add(mkblock(1, 2), 2));
-  ASSERT_FALSE(hf.add(mkblock(3, 2), 2));
-  ASSERT_TRUE(hf.add(mkblock(2, 2), 2));
-  db.add_block(mkblock(2, 1), 0, 0, 0, 0, 0, crypto::hash());
+  ASSERT_FALSE(hf.check_for_height(mkblock(0, 2), 2));
+  ASSERT_FALSE(hf.check_for_height(mkblock(1, 2), 2));
+  ASSERT_FALSE(hf.check_for_height(mkblock(3, 2), 2));
+  ASSERT_TRUE(hf.check_for_height(mkblock(2, 2), 2));
 }
 
 TEST(empty_hardforks, Success)
 {
-  TestDB db;
-  HardFork hf(db);
+  HardFork hf;
 
   ASSERT_TRUE(hf.add_fork(1, 0, 0));
   hf.init();
@@ -135,18 +90,16 @@ TEST(empty_hardforks, Success)
   ASSERT_TRUE(hf.get_state(time(NULL) + 3600*24*400) == HardFork::Ready);
 
   for (uint64_t h = 0; h <= 10; ++h) {
-    db.add_block(mkblock(hf, h, 1), 0, 0, 0, 0, 0, crypto::hash());
-    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
+    ASSERT_TRUE(hf.check_for_height(mkblock(1, 1), h));
   }
-  ASSERT_EQ(hf.get(0), 1);
-  ASSERT_EQ(hf.get(1), 1);
-  ASSERT_EQ(hf.get(10), 1);
+  ASSERT_EQ(hf.get_ideal_version(0), 1);
+  ASSERT_EQ(hf.get_ideal_version(1), 1);
+  ASSERT_EQ(hf.get_ideal_version(10), 1);
 }
 
 TEST(ordering, Success)
 {
-  TestDB db;
-  HardFork hf(db);
+  HardFork hf;
 
   ASSERT_TRUE(hf.add_fork(2, 2, 1));
   ASSERT_FALSE(hf.add_fork(3, 3, 1));
@@ -159,8 +112,7 @@ TEST(ordering, Success)
 
 TEST(check_for_height, Success)
 {
-  TestDB db;
-  HardFork hf(db, 1, 0, 0, 0, 1, 0); // no voting
+  HardFork hf(1, 0, 0, 0); // no voting
 
   ASSERT_TRUE(hf.add_fork(1, 0, 0));
   ASSERT_TRUE(hf.add_fork(2, 5, 1));
@@ -169,51 +121,19 @@ TEST(check_for_height, Success)
   for (uint64_t h = 0; h <= 4; ++h) {
     ASSERT_TRUE(hf.check_for_height(mkblock(1, 1), h));
     ASSERT_FALSE(hf.check_for_height(mkblock(2, 2), h));  // block version is too high
-    db.add_block(mkblock(hf, h, 1), 0, 0, 0, 0, 0, crypto::hash());
-    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
+    ASSERT_TRUE(hf.check_for_height(mkblock(hf, h, 1), h));
   }
 
   for (uint64_t h = 5; h <= 10; ++h) {
     ASSERT_FALSE(hf.check_for_height(mkblock(1, 1), h));  // block version is too low
     ASSERT_TRUE(hf.check_for_height(mkblock(2, 2), h));
-    db.add_block(mkblock(hf, h, 2), 0, 0, 0, 0, 0, crypto::hash());
-    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
-  }
-}
-
-TEST(get, next_version)
-{
-  TestDB db;
-  HardFork hf(db);
-
-  ASSERT_TRUE(hf.add_fork(1, 0, 0));
-  ASSERT_TRUE(hf.add_fork(2, 5, 1));
-  ASSERT_TRUE(hf.add_fork(4, 10, 2));
-  hf.init();
-
-  for (uint64_t h = 0; h <= 4; ++h) {
-    ASSERT_EQ(2, hf.get_next_version());
-    db.add_block(mkblock(hf, h, 1), 0, 0, 0, 0, 0, crypto::hash());
-    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
-  }
-
-  for (uint64_t h = 5; h <= 9; ++h) {
-    ASSERT_EQ(4, hf.get_next_version());
-    db.add_block(mkblock(hf, h, 2), 0, 0, 0, 0, 0, crypto::hash());
-    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
-  }
-
-  for (uint64_t h = 10; h <= 15; ++h) {
-    ASSERT_EQ(4, hf.get_next_version());
-    db.add_block(mkblock(hf, h, 4), 0, 0, 0, 0, 0, crypto::hash());
-    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
+    ASSERT_TRUE(hf.check_for_height(mkblock(hf, h, 2), h));
   }
 }
 
 TEST(states, Success)
 {
-  TestDB db;
-  HardFork hf(db);
+  HardFork hf;
 
   ASSERT_TRUE(hf.add_fork(1, 0, 0));
   ASSERT_TRUE(hf.add_fork(2, BLOCKS_PER_YEAR, SECONDS_PER_YEAR));
@@ -235,8 +155,7 @@ TEST(states, Success)
 
 TEST(steps_asap, Success)
 {
-  TestDB db;
-  HardFork hf(db, 1,0,1,1,1);
+  HardFork hf(1,0,1,1);
 
   //                 v  h  t
   ASSERT_TRUE(hf.add_fork(1, 0, 0));
@@ -246,26 +165,24 @@ TEST(steps_asap, Success)
   hf.init();
 
   for (uint64_t h = 0; h < 10; ++h) {
-    db.add_block(mkblock(hf, h, 9), 0, 0, 0, 0, 0, crypto::hash());
-    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
+    ASSERT_TRUE(hf.check_for_height(mkblock(hf, h, 9), h));
   }
 
-  ASSERT_EQ(hf.get(0), 1);
-  ASSERT_EQ(hf.get(1), 1);
-  ASSERT_EQ(hf.get(2), 4);
-  ASSERT_EQ(hf.get(3), 4);
-  ASSERT_EQ(hf.get(4), 7);
-  ASSERT_EQ(hf.get(5), 7);
-  ASSERT_EQ(hf.get(6), 9);
-  ASSERT_EQ(hf.get(7), 9);
-  ASSERT_EQ(hf.get(8), 9);
-  ASSERT_EQ(hf.get(9), 9);
+  ASSERT_EQ(hf.get_ideal_version(0), 1);
+  ASSERT_EQ(hf.get_ideal_version(1), 1);
+  ASSERT_EQ(hf.get_ideal_version(2), 4);
+  ASSERT_EQ(hf.get_ideal_version(3), 4);
+  ASSERT_EQ(hf.get_ideal_version(4), 7);
+  ASSERT_EQ(hf.get_ideal_version(5), 7);
+  ASSERT_EQ(hf.get_ideal_version(6), 9);
+  ASSERT_EQ(hf.get_ideal_version(7), 9);
+  ASSERT_EQ(hf.get_ideal_version(8), 9);
+  ASSERT_EQ(hf.get_ideal_version(9), 9);
 }
 
 TEST(steps_1, Success)
 {
-  TestDB db;
-  HardFork hf(db, 1,0,1,1,1);
+  HardFork hf(1,0,1,1);
 
   ASSERT_TRUE(hf.add_fork(1, 0, 0));
   for (int n = 1 ; n < 10; ++n)
@@ -273,296 +190,32 @@ TEST(steps_1, Success)
   hf.init();
 
   for (uint64_t h = 0 ; h < 10; ++h) {
-    db.add_block(mkblock(hf, h, h+1), 0, 0, 0, 0, 0, crypto::hash());
-    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
+    ASSERT_TRUE(hf.check_for_height(mkblock(hf, h, h+1), h));
   }
-
-  for (uint64_t h = 0; h < 10; ++h) {
-    ASSERT_EQ(hf.get(h), std::max(1,(int)h));
-  }
-}
-
-TEST(reorganize, Same)
-{
-  for (int history = 1; history <= 12; ++history) {
-    TestDB db;
-    HardFork hf(db, 1, 0, 1, 1, history, 100);
-
-    //                 v  h  t
-    ASSERT_TRUE(hf.add_fork(1, 0, 0));
-    ASSERT_TRUE(hf.add_fork(4, 2, 1));
-    ASSERT_TRUE(hf.add_fork(7, 4, 2));
-    ASSERT_TRUE(hf.add_fork(9, 6, 3));
-    hf.init();
-
-    //                                 index  0  1  2  3  4  5  6  7  8  9
-    static const uint8_t block_versions[] = { 1, 1, 4, 4, 7, 7, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 };
-    for (uint64_t h = 0; h < 20; ++h) {
-      db.add_block(mkblock(hf, h, block_versions[h]), 0, 0, 0, 0, 0, crypto::hash());
-      ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
-    }
-
-    for (uint64_t rh = 0; rh < 20; ++rh) {
-      hf.reorganize_from_block_height(rh);
-      for (int hh = 0; hh < 20; ++hh) {
-        uint8_t version = hh >= history ? block_versions[hh - history] : 1;
-        ASSERT_EQ(hf.get(hh), version);
-      }
-    }
-  }
-}
-
-TEST(reorganize, Changed)
-{
-  TestDB db;
-  HardFork hf(db, 1, 0, 1, 1, 4, 100);
-
-  //                 v  h  t
-  ASSERT_TRUE(hf.add_fork(1, 0, 0));
-  ASSERT_TRUE(hf.add_fork(4, 2, 1));
-  ASSERT_TRUE(hf.add_fork(7, 4, 2));
-  ASSERT_TRUE(hf.add_fork(9, 6, 3));
-  hf.init();
-
-  //                                    fork         4     7     9
-  //                                    index  0  1  2  3  4  5  6  7  8  9
-  static const uint8_t block_versions[] =    { 1, 1, 4, 4, 7, 7, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 };
-  static const uint8_t expected_versions[] = { 1, 1, 1, 1, 1, 1, 4, 4, 7, 7, 9, 9, 9, 9, 9, 9 };
-  for (uint64_t h = 0; h < 16; ++h) {
-    db.add_block(mkblock(hf, h, block_versions[h]), 0, 0, 0, 0, 0, crypto::hash());
-    ASSERT_TRUE (hf.add(db.get_block_from_height(h), h));
-  }
-
-  for (uint64_t rh = 0; rh < 16; ++rh) {
-    hf.reorganize_from_block_height(rh);
-    for (int hh = 0; hh < 16; ++hh) {
-      ASSERT_EQ(hf.get(hh), expected_versions[hh]);
-    }
-  }
-
-  // delay a bit for 9, and go back to 1 to check it stays at 9
-  static const uint8_t block_versions_new[] =    { 1, 1, 4, 4, 7, 7, 4, 7, 7, 7, 9, 9, 9, 9, 9, 1 };
-  static const uint8_t expected_versions_new[] = { 1, 1, 1, 1, 1, 1, 4, 4, 4, 4, 4, 7, 7, 7, 9, 9 };
-  for (uint64_t h = 3; h < 16; ++h) {
-    db.remove_block();
-  }
-  ASSERT_EQ(db.height(), 3);
-  hf.reorganize_from_block_height(2);
-  for (uint64_t h = 3; h < 16; ++h) {
-    db.add_block(mkblock(hf, h, block_versions_new[h]), 0, 0, 0, 0, 0, crypto::hash());
-    bool ret = hf.add(db.get_block_from_height(h), h);
-    ASSERT_EQ (ret, h < 15);
-  }
-  db.remove_block(); // last block added to the blockchain, but not hf
-  ASSERT_EQ(db.height(), 15);
-  for (int hh = 0; hh < 15; ++hh) {
-    ASSERT_EQ(hf.get(hh), expected_versions_new[hh]);
-  }
-}
-
-TEST(voting, threshold)
-{
-  for (int threshold = 87; threshold <= 88; ++threshold) {
-    TestDB db;
-    HardFork hf(db, 1, 0, 1, 1, 8, threshold);
-
-    //                 v  h  t
-    ASSERT_TRUE(hf.add_fork(1, 0, 0));
-    ASSERT_TRUE(hf.add_fork(2, 2, 1));
-    hf.init();
-
-    for (uint64_t h = 0; h <= 8; ++h) {
-      uint8_t v = 1 + !!(h % 8);
-      db.add_block(mkblock(hf, h, v), 0, 0, 0, 0, 0, crypto::hash());
-      bool ret = hf.add(db.get_block_from_height(h), h);
-      if (h >= 8 && threshold == 87) {
-        // for threshold 87, we reach the threshold at height 7, so from height 8, hard fork to version 2, but 8 tries to add 1
-        ASSERT_FALSE(ret);
-      }
-      else {
-        // for threshold 88, we never reach the threshold
-        ASSERT_TRUE(ret);
-        uint8_t expected = threshold == 88 ? 1 : h < 8 ? 1 : 2;
-        ASSERT_EQ(hf.get(h), expected);
-      }
-    }
-  }
-}
-
-TEST(voting, different_thresholds)
-{
-  for (int threshold = 87; threshold <= 88; ++threshold) {
-    TestDB db;
-    HardFork hf(db, 1, 0, 1, 1, 4, 50); // window size 4
-
-    //                 v  h  t
-    ASSERT_TRUE(hf.add_fork(1, 0, 0));
-    ASSERT_TRUE(hf.add_fork(2, 5, 0, 1)); // asap
-    ASSERT_TRUE(hf.add_fork(3, 10, 100, 2)); // all votes
-    ASSERT_TRUE(hf.add_fork(4, 15, 3)); // default 50% votes
-    hf.init();
-
-    //                                           0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5  6  7  8  9
-    static const uint8_t block_versions[] =    { 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4 };
-    static const uint8_t expected_versions[] = { 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 };
-
-    for (uint64_t h = 0; h < sizeof(block_versions) / sizeof(block_versions[0]); ++h) {
-      db.add_block(mkblock(hf, h, block_versions[h]), 0, 0, 0, 0, 0, crypto::hash());
-      bool ret = hf.add(db.get_block_from_height(h), h);
-      ASSERT_EQ(ret, true);
-    }
-    for (uint64_t h = 0; h < sizeof(expected_versions) / sizeof(expected_versions[0]); ++h) {
-      ASSERT_EQ(hf.get(h), expected_versions[h]);
-    }
-  }
-}
-
-TEST(voting, info)
-{
-  TestDB db;
-  HardFork hf(db, 1, 0, 1, 1, 4, 50); // window size 4, default threshold 50%
-
-  //                      v  h  ts
-  ASSERT_TRUE(hf.add_fork(1, 0,  0));
-  //                      v  h   thr  ts
-  ASSERT_TRUE(hf.add_fork(2, 5,    0,  1)); // asap
-  ASSERT_TRUE(hf.add_fork(3, 10, 100,  2)); // all votes
-  //                      v   h  ts
-  ASSERT_TRUE(hf.add_fork(4, 15,  3)); // default 50% votes
-  hf.init();
-
-  //                                             0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5  6  7  8  9
-  static const uint8_t block_versions[]      = { 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4 };
-  static const uint8_t expected_thresholds[] = { 0, 1, 1, 2, 2, 0, 0, 0, 0, 0, 0, 0, 4, 4, 4, 4, 2, 2, 2, 2 };
-
-  for (uint64_t h = 0; h < sizeof(block_versions) / sizeof(block_versions[0]); ++h) {
-    uint32_t window, votes, threshold;
-    uint64_t earliest_height;
-    uint8_t voting;
-
-    ASSERT_TRUE(hf.get_voting_info(1, window, votes, threshold, earliest_height, voting));
-    ASSERT_EQ(std::min<uint64_t>(h, 4), votes);
-    ASSERT_EQ(0, earliest_height);
-
-    ASSERT_EQ(hf.get_current_version() >= 2, hf.get_voting_info(2, window, votes, threshold, earliest_height, voting));
-    ASSERT_EQ(std::min<uint64_t>(h <= 3 ? 0 : h - 3, 4), votes);
-    ASSERT_EQ(5, earliest_height);
-
-    ASSERT_EQ(hf.get_current_version() >= 3, hf.get_voting_info(3, window, votes, threshold, earliest_height, voting));
-    ASSERT_EQ(std::min<uint64_t>(h <= 8 ? 0 : h - 8, 4), votes);
-    ASSERT_EQ(10, earliest_height);
-
-    ASSERT_EQ(hf.get_current_version() == 4, hf.get_voting_info(4, window, votes, threshold, earliest_height, voting));
-    ASSERT_EQ(std::min<uint64_t>(h <= 14 ? 0 : h - 14, 4), votes);
-    ASSERT_EQ(15, earliest_height);
-
-    ASSERT_EQ(std::min<uint64_t>(h, 4), window);
-    ASSERT_EQ(expected_thresholds[h], threshold);
-    ASSERT_EQ(4, voting);
-
-    db.add_block(mkblock(hf, h, block_versions[h]), 0, 0, 0, 0, 0, crypto::hash());
-    ASSERT_TRUE(hf.add(db.get_block_from_height(h), h));
-  }
-}
-
-TEST(new_blocks, denied)
-{
-    TestDB db;
-    HardFork hf(db, 1, 0, 1, 1, 4, 50);
-
-    //                 v  h  t
-    ASSERT_TRUE(hf.add_fork(1, 0, 0));
-    ASSERT_TRUE(hf.add_fork(2, 2, 1));
-    hf.init();
-
-    ASSERT_TRUE(hf.add(mkblock(1, 1), 0));
-    ASSERT_TRUE(hf.add(mkblock(1, 1), 1));
-    ASSERT_TRUE(hf.add(mkblock(1, 1), 2));
-    ASSERT_TRUE(hf.add(mkblock(1, 2), 3));
-    ASSERT_TRUE(hf.add(mkblock(1, 1), 4));
-    ASSERT_TRUE(hf.add(mkblock(1, 1), 5));
-    ASSERT_TRUE(hf.add(mkblock(1, 1), 6));
-    ASSERT_TRUE(hf.add(mkblock(1, 2), 7));
-    ASSERT_TRUE(hf.add(mkblock(1, 2), 8)); // we reach 50% of the last 4
-    ASSERT_FALSE(hf.add(mkblock(2, 1), 9)); // so this one can't get added
-    ASSERT_TRUE(hf.add(mkblock(2, 2), 9));
 }
 
 TEST(new_version, early)
 {
-    TestDB db;
-    HardFork hf(db, 1, 0, 1, 1, 4, 50);
+    HardFork hf(1, 0, 1, 1);
 
     //                 v  h  t
     ASSERT_TRUE(hf.add_fork(1, 0, 0));
     ASSERT_TRUE(hf.add_fork(2, 4, 1));
     hf.init();
 
-    ASSERT_TRUE(hf.add(mkblock(1, 2), 0));
-    ASSERT_TRUE(hf.add(mkblock(1, 2), 1)); // we have enough votes already
-    ASSERT_TRUE(hf.add(mkblock(1, 2), 2));
-    ASSERT_TRUE(hf.add(mkblock(1, 1), 3)); // we accept a previous version because we did not switch, even with all the votes
-    ASSERT_TRUE(hf.add(mkblock(2, 2), 4)); // but have to wait for the declared height anyway
-    ASSERT_TRUE(hf.add(mkblock(2, 2), 5));
-    ASSERT_FALSE(hf.add(mkblock(2, 1), 6)); // we don't accept 1 anymore
-    ASSERT_TRUE(hf.add(mkblock(2, 2), 7)); // but we do accept 2
-}
-
-TEST(reorganize, changed)
-{
-    TestDB db;
-    HardFork hf(db, 1, 0, 1, 1, 4, 50);
-
-    //                 v  h  t
-    ASSERT_TRUE(hf.add_fork(1, 0, 0));
-    ASSERT_TRUE(hf.add_fork(2, 2, 1));
-    ASSERT_TRUE(hf.add_fork(3, 5, 2));
-    ASSERT_TRUE(hf.add_fork(4, 555, 222));
-    hf.init();
-
-#define ADD(v, h, a) \
-  do { \
-    cryptonote::block b = mkblock(hf, h, v); \
-    db.add_block(b, 0, 0, 0, 0, 0, crypto::hash()); \
-    ASSERT_##a(hf.add(b, h)); \
-  } while(0)
-#define ADD_TRUE(v, h) ADD(v, h, TRUE)
-#define ADD_FALSE(v, h) ADD(v, h, FALSE)
-
-    ADD_TRUE(1, 0);
-    ADD_TRUE(1, 1);
-    ADD_TRUE(2, 2);
-    ADD_TRUE(2, 3); // switch to 2 here
-    ADD_TRUE(2, 4);
-    ADD_TRUE(2, 5);
-    ADD_TRUE(2, 6);
-    ASSERT_EQ(hf.get_current_version(), 2);
-    ADD_TRUE(3, 7);
-    ADD_TRUE(4, 8);
-    ADD_TRUE(4, 9);
-    ASSERT_EQ(hf.get_current_version(), 3);
-
-    // pop a few blocks and check current version goes back down
-    db.remove_block();
-    hf.reorganize_from_block_height(8);
-    ASSERT_EQ(hf.get_current_version(), 3);
-    db.remove_block();
-    hf.reorganize_from_block_height(7);
-    ASSERT_EQ(hf.get_current_version(), 2);
-    db.remove_block();
-    ASSERT_EQ(hf.get_current_version(), 2);
-
-    // add blocks again, but remaining at 2
-    ADD_TRUE(2, 7);
-    ADD_TRUE(2, 8);
-    ADD_TRUE(2, 9);
-    ASSERT_EQ(hf.get_current_version(), 2); // we did not bump to 3 this time
+    ASSERT_TRUE(hf.check_for_height(mkblock(1, 2), 0));
+    ASSERT_TRUE(hf.check_for_height(mkblock(1, 2), 1)); // we have enough votes already
+    ASSERT_TRUE(hf.check_for_height(mkblock(1, 2), 2));
+    ASSERT_TRUE(hf.check_for_height(mkblock(1, 1), 3)); // we accept a previous version because we did not switch, even with all the votes
+    ASSERT_TRUE(hf.check_for_height(mkblock(2, 2), 4)); // but have to wait for the declared height anyway
+    ASSERT_TRUE(hf.check_for_height(mkblock(2, 2), 5));
+    ASSERT_FALSE(hf.check_for_height(mkblock(2, 1), 6)); // we don't accept 1 anymore
+    ASSERT_TRUE(hf.check_for_height(mkblock(2, 2), 7)); // but we do accept 2
 }
 
 TEST(get, higher)
 {
-    TestDB db;
-    HardFork hf(db, 1, 0, 1, 1, 4, 50);
+    HardFork hf(1, 0, 1, 1);
 
     //                 v  h  t
     ASSERT_TRUE(hf.add_fork(1, 0, 0));
@@ -582,8 +235,7 @@ TEST(get, higher)
 
 TEST(get, earliest_ideal_height)
 {
-    TestDB db;
-    HardFork hf(db, 1, 0, 1, 1, 4, 50);
+    HardFork hf(1, 0, 1, 1);
 
     //                      v  h  t
     ASSERT_TRUE(hf.add_fork(1, 0, 0));


### PR DESCRIPTION
- Removes the circular linking dependency between `libcryptonote_basic` and `libblockchain_db` (which causes link-time falures in some debug builds)
- Removes circular logical dependency of `BlockchainDB` on `Hardfork`, and vice versa
- Makes `Hardfork` stateless
- Guts a lot of unused voting logic

This design has been bothering me for a while due to it being fragile and hard to reason about. But I recently got an link-time error while trying to build with debug + ASAN, so now I have an actual excuse to fix it. I'm confident that if we wanted to introduce fork voting logic back into the codebase sometime in the future, that we can implement it a bit better.