### PR TITLE
dns_utils: don't leave ub_result pointer uninitialized

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -269,7 +269,7 @@ std::vector<std::string> DNSResolver::get_record(const std::string& url, int rec
   dnssec_available = false;
   dnssec_valid = false;
   
-  ub_result *result;
+  ub_result *result = NULL;
   // Make sure we are cleaning after result.
   const epee::scope_guard scope_exit_handler([&](){
     ub_resolve_free(result);


### PR DESCRIPTION
The variable `ub_result` is declared uninitialized, and `scope_guard` unconditionally calls `ub_resolve_free(result)` upon scope exit, regardless of whether `ub_resolve()` actually succeeded. Unbound headers don't seem to guarantee that `NULL` will always be written on failure cases, so it's probably a good idea to initialize it, just to be safe.