### PR TITLE
command_line: fix parsing error

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(common
     ${LIBUNWIND_LIBRARIES}
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
     ${Boost_REGEX_LIBRARY}

--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -31,6 +31,7 @@
 #include "command_line.h"
 #include <boost/algorithm/string/compare.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <stdexcept>
 #include "common/i18n.h"
 
 namespace command_line
@@ -69,6 +70,30 @@ namespace command_line
       return true;
 
     return false;
+  }
+
+  void check_string_swallowed_option(const boost::program_options::options_description& desc, const boost::program_options::parsed_options& parsed)
+  {
+    for (const auto& option : parsed.options)
+    {
+      if (option.original_tokens.size() < 2 || option.value.empty())
+        continue;
+
+      const std::string& value = option.value.front();
+      if (value.size() < 3 || value[0] != '-' || value[1] != '-')
+        continue;
+
+      const std::string::size_type eq = value.find('=');
+      const std::string candidate = value.substr(2, eq == std::string::npos ? std::string::npos : eq - 2);
+      if (candidate.empty()) continue;
+
+      if (desc.find_nothrow(candidate, false) != nullptr)
+      {
+        throw std::runtime_error(
+          "required argument for --" + option.string_key + " is missing; " +
+          "it looks like it consumed --" + candidate + " as its value instead");
+      }
+    }
   }
 
   const arg_descriptor<bool> arg_help = {"help", "Produce help message"};

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -280,6 +280,12 @@ namespace command_line
     return get_arg(vm, arg);
   }
 
+  /**
+   * @brief Detects cases in which a command-line option with a required value
+   * is not given one, causing `boost::program_options` to falsely consume the
+   * following option's "--name" token as its value instead of raising an error.
+   */
+  void check_string_swallowed_option(const boost::program_options::options_description& desc, const boost::program_options::parsed_options& parsed);
 
   extern const arg_descriptor<bool> arg_help;
   extern const arg_descriptor<bool> arg_version;

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -180,11 +180,10 @@ int main(int argc, char const * argv[])
     po::variables_map vm;
     bool ok = command_line::handle_error_helper(visible_options, [&]()
     {
-      boost::program_options::store(
-        boost::program_options::command_line_parser(argc, argv)
-          .options(all_options).positional(positional_options).run()
-      , vm
-      );
+      const auto parsed = boost::program_options::command_line_parser(argc, argv)
+        .options(all_options).positional(positional_options).run();
+      boost::program_options::store(parsed, vm);
+      command_line::check_string_swallowed_option(all_options, parsed);
 
       return true;
     });

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -138,7 +138,9 @@ namespace wallet_args
     bool r = command_line::handle_error_helper(desc_all, [&]()
     {
       auto parser = po::command_line_parser(argc, argv).options(desc_all).positional(positional_options);
-      po::store(parser.run(), vm);
+      const auto parsed = parser.run();
+      po::store(parsed, vm);
+      command_line::check_string_swallowed_option(desc_all, parsed);
 
       if (command_line::get_arg(vm, command_line::arg_help))
       {


### PR DESCRIPTION
This newly-added doc comment should suffice as an explanation for this change:

```
  /**
   * @brief Detects cases in which a command-line option with a required value
   * is not given one, causing `boost::program_options` to falsely consume the
   * following option's "--name" token as its value instead of raising an error.
   */
```

An example of this I ran into: attempting to create a new wallet using the `--generate-from-device` parameter (but providing the name of another command-line option in place of the name for the wallet file) will result in it saying "no device found" rather than "no parameter provided".

```
./build/Linux/args-error/debug/bin/monero-wallet-cli --generate-from-device --stagenet
Failed to parse arguments: required argument for --generate-from-device is missing; it looks like it consumed '--stagenet' as its value instead
```
^ This will now result in an error.