### PR TITLE
wallet_rpc_server: use start mining response

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -488,10 +488,10 @@ namespace tools
     req2.threads_count = 1;
     req2.do_background_mining = true;
     req2.ignore_battery = false;
-    r = m_wallet->invoke_http_json("/start_mining", req2, res);
+    r = m_wallet->invoke_http_json("/start_mining", req2, res2);
     if (!r || res2.status != CORE_RPC_STATUS_OK)
     {
-      MERROR("Failed to setup background mining: " << (r ? res.status : "No connection to daemon"));
+      MERROR("Failed to setup background mining: " << (r ? res2.status : "No connection to daemon"));
       return;
     }
 


### PR DESCRIPTION
`check_background_mining()` currently passes the mining status response object to `/start_mining`, then checks the untouched start mining response

This makes a successful request log `Failed to setup background mining: OK` even though the daemon accepted it, matching the output reported in #8156

Use the matching response object for the request and status handling

Tests:
- built the `wallet_rpc_server` target
- ran the unit test suite
- ran `check_missing_rpc_methods`
- verified that `OK` reaches the success path
- verified that `BUSY` is reported correctly