### PR TITLE
wallet_rpc_server: validate seed language early

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3961,6 +3961,12 @@ namespace tools
         return false;
       }
     }
+    if (!req.language.empty() && !crypto::ElectrumWords::is_valid_language(req.language))
+    {
+      er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+      er.message = "The specified seed language is invalid.";
+      return false;
+    }
 
     {
       po::options_description desc("dummy");
@@ -4071,12 +4077,6 @@ namespace tools
 
     if (!req.language.empty())
     {
-      if (!crypto::ElectrumWords::is_valid_language(req.language))
-      {
-        er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
-        er.message = "The specified seed language is invalid.";
-        return false;
-      }
       wal->set_seed_language(req.language);
     }
 

--- a/tests/functional_tests/wallet.py
+++ b/tests/functional_tests/wallet.py
@@ -50,6 +50,7 @@ class WalletTest():
       self.attributes()
       self.open_close()
       self.languages()
+      self.generate_from_keys()
       self.change_password()
       self.store()
 
@@ -319,6 +320,38 @@ class WalletTest():
             wallet.create_wallet(filename = '', language = language)
             res = wallet.query_key('mnemonic')
             wallet.close_wallet()
+
+    def generate_from_keys(self):
+        print('Generating wallet from keys')
+        wallet = Wallet()
+        filename = 'generate-from-keys'
+        address = '42ey1afDFnn4886T7196doS9GPMzexD9gXpsZJDwVjeRVdFCSoHnv7KPbBeGpzJBzHRCAs9UxqeoyFQMYbqSWYTfJJQAWDm'
+        spend_key = '148d78d2aba7dbca5cd8f6abcfb0b3c009ffbdbea1ff373d50ed94d78286640e'
+        view_key = '49774391fa5e8d249fc2c5b45dadef13534bf2483dede880dac88f061e809100'
+        seed = 'velvet lymph giddy number token physics poetry unquoted nibs useful sabotage limits benches lifestyle eden nitrogen anvil fewest avoid batch vials washing fences goat unquoted'
+
+        try: wallet.close_wallet()
+        except: pass
+        util_resources.remove_wallet_files(filename)
+
+        ok = False
+        try:
+            wallet.generate_from_keys(filename = filename, address = address,
+                spendkey = spend_key, viewkey = view_key, language = 'invalid')
+        except Exception as e:
+            assert 'The specified seed language is invalid.' in str(e)
+            ok = True
+        assert ok
+        assert not util_resources.file_exists(filename)
+        assert not util_resources.file_exists(filename + '.keys')
+
+        res = wallet.generate_from_keys(filename = filename, address = address,
+            spendkey = spend_key, viewkey = view_key, language = 'English')
+        assert res.address == address
+        assert wallet.query_key('mnemonic').key == seed
+
+        wallet.close_wallet()
+        util_resources.remove_wallet_files(filename)
 
     def change_password(self):
         print('Testing password change')

--- a/utils/python-rpc/framework/wallet.py
+++ b/utils/python-rpc/framework/wallet.py
@@ -317,7 +317,7 @@ class Wallet(object):
         }
         return self.rpc.send_json_rpc_request(restore_deterministic_wallet)
 
-    def generate_from_keys(self, restore_height = 0, filename = "", password = "", address = "", spendkey = "", viewkey = "", autosave_current = True):
+    def generate_from_keys(self, restore_height = 0, filename = "", password = "", address = "", spendkey = "", viewkey = "", autosave_current = True, language = ""):
         generate_from_keys = {
             'method': 'generate_from_keys',
             'params' : {
@@ -328,6 +328,7 @@ class Wallet(object):
                 'viewkey': viewkey,
                 'password': password,
                 'autosave_current': autosave_current,
+                'language': language,
             },
             'jsonrpc': '2.0', 
             'id': '0'


### PR DESCRIPTION
`generate_from_keys` currently validates `language` after `wallet2::generate()` writes the wallet and `.keys` files when `filename` is set

an invalid language therefore returns an error after both files are left behind, so retrying with the same filename and a valid language fails with `Wallet already exists`

this validates the language before creating the new wallet or saving the currently open one, while keeping valid requests unchanged

tests:
- `python3 tests/functional_tests/functional_tests_rpc.py python3 tests/functional_tests build wallet` (fails before the fix, passes after)
- `python3 tests/functional_tests/functional_tests_rpc.py python3 tests/functional_tests build cold_signing` (1/1 passed)
- `python3 -m py_compile tests/functional_tests/wallet.py utils/python-rpc/framework/wallet.py`
- `git diff --check`