### PR TITLE
wallet: include txid in cold-signing output export

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -14061,6 +14061,7 @@ std::tuple<uint64_t, uint64_t, std::vector<tools::wallet2::exported_transfer_det
     etd.m_additional_tx_keys = get_additional_tx_pub_keys_from_extra(td.m_tx);
     etd.m_subaddr_index_major = td.m_subaddr_index.major;
     etd.m_subaddr_index_minor = td.m_subaddr_index.minor;
+    etd.m_txid = td.m_txid;
 
     outs.push_back(etd);
   }
@@ -14198,7 +14199,7 @@ size_t wallet2::import_outputs(const std::tuple<uint64_t, uint64_t, std::vector<
 
     // setup td with "cheap" loaded data
     td.m_block_height = 0;
-    td.m_txid = crypto::null_hash;
+    td.m_txid = etd.m_txid;
     td.m_global_output_index = etd.m_global_output_index;
     td.m_spent = etd.m_flags.m_spent;
     td.m_frozen = etd.m_flags.m_frozen;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -285,8 +285,9 @@ private:
       uint32_t m_subaddr_index_major;
       uint32_t m_subaddr_index_minor;
 
+      crypto::hash m_txid = crypto::null_hash;
       BEGIN_SERIALIZE_OBJECT()
-        VERSION_FIELD(1)
+        VERSION_FIELD(2)
         if (version < 1)
           return false;
         FIELD(m_pubkey)
@@ -298,6 +299,8 @@ private:
         FIELD(m_additional_tx_keys)
         VARINT_FIELD(m_subaddr_index_major)
         VARINT_FIELD(m_subaddr_index_minor)
+        if (version >= 2)
+          FIELD(m_txid)
       END_SERIALIZE()
     };
 

--- a/tests/functional_tests/cold_signing.py
+++ b/tests/functional_tests/cold_signing.py
@@ -147,7 +147,7 @@ class ColdSigningTest():
             for i in range(len(hot_transfers_list)):
                 assert len(hot_transfers_list[i]['tx_hash']) == 64
                 assert hot_transfers_list[i]['tx_hash'] != '0' * 64
-                assert cold_transfers_list[i]['tx_hash'] == '', cold_transfers_list[i]['tx_hash']
+                assert cold_transfers_list[i]['tx_hash'] == hot_transfers_list[i]['tx_hash']
                 for attr in attributes_to_cmp:
                     hot_val = hot_transfers_list[i][attr]
                     cold_val = cold_transfers_list[i][attr]


### PR DESCRIPTION
## Summary

Include the transaction hash (`txid`) in the cold-signing output export format.

## Changes

- Add `m_txid` to `exported_transfer_details`.
- Bump the serialized structure version to 2.
- Serialize `m_txid` for version 2 exports.
- Preserve backward compatibility with version 1 export data.
- Populate `m_txid` when exporting and importing transfer details.

## Testing

- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j4`
- `git diff --check`
- Build completed successfully with no compilation errors.

Fixes #11180