### PR TITLE
multisig: reject mismatched key image component count

### DIFF
--- a/src/multisig/multisig.cpp
+++ b/src/multisig/multisig.cpp
@@ -33,6 +33,7 @@
 #include "include_base_utils.h"
 #include "multisig.h"
 #include "ringct/rctOps.h"
+#include "common/combinator.h"
 
 #include <algorithm>
 #include <unordered_map>
@@ -90,6 +91,8 @@ namespace multisig
     const std::vector<crypto::public_key> &additional_tx_public_keys,
     std::size_t real_output_index,
     const std::vector<crypto::key_image> &pkis,
+    std::size_t num_signers,
+    std::size_t threshold,
     crypto::key_image &ki)
   {
     // create a multisig partial key image
@@ -133,6 +136,11 @@ namespace multisig
     // at the end, 'ki' will hold the true key image for our output if inputs were sufficient
     // - if 'pkis' (the other participants' KI components) is missing some components
     //   then 'ki' will not be complete
+
+    // since 'ki' is only legitimate if it was made using the exact number of intended key image
+    // components, it should be checked to ensure this is the case.
+    const std::size_t expected_num_key_image_components = tools::combinations_count(num_signers - threshold + 1, num_signers);
+    if (used.size() != expected_num_key_image_components) return false;
 
     return true;
   }

--- a/src/multisig/multisig.h
+++ b/src/multisig/multisig.h
@@ -65,5 +65,7 @@ namespace multisig
     const std::vector<crypto::public_key> &additional_tx_public_keys,
     std::size_t real_output_index,
     const std::vector<crypto::key_image> &pkis,
+    std::size_t num_signers,
+    std::size_t threshold,
     crypto::key_image &ki);
 } //namespace multisig

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -14467,7 +14467,8 @@ crypto::key_image wallet2::get_multisig_composite_key_image(size_t n) const
   for (const auto &info: td.m_multisig_info)
     for (const auto &pki: info.m_partial_key_images)
       pkis.push_back(pki);
-  bool r = multisig::generate_multisig_composite_key_image(get_account().get_keys(), m_subaddresses, td.get_public_key(), tx_key, additional_tx_keys, td.m_internal_output_index, pkis, ki);
+
+  bool r = multisig::generate_multisig_composite_key_image(get_account().get_keys(), m_subaddresses, td.get_public_key(), tx_key, additional_tx_keys, td.m_internal_output_index, pkis, m_multisig_signers.size(), m_multisig_threshold, ki);
   THROW_WALLET_EXCEPTION_IF(!r, error::wallet_internal_error, "Failed to generate key image");
   return ki;
 }

--- a/tests/core_tests/multisig.cpp
+++ b/tests/core_tests/multisig.cpp
@@ -253,13 +253,13 @@ bool gen_multisig_tx_validation_base::generate_with(std::vector<test_event_entry
     for (size_t msidx = 0; msidx < total; ++msidx)
       for (size_t n = 0; n < account_ki[msidx][tdidx].size(); ++n)
         pkis.push_back(account_ki[msidx][tdidx][n]);
-    r = multisig::generate_multisig_composite_key_image(miner_account[0].get_keys(), subaddresses, output_pub_key[tdidx], tx_pub_key[tdidx], additional_tx_keys, 0, pkis, (crypto::key_image&)kLRki.ki);
+    r = multisig::generate_multisig_composite_key_image(miner_account[0].get_keys(), subaddresses, output_pub_key[tdidx], tx_pub_key[tdidx], additional_tx_keys, 0, pkis, total, threshold, (crypto::key_image&)kLRki.ki);
     CHECK_AND_ASSERT_MES(r, false, "Failed to generate composite key image");
     MDEBUG("composite ki: " << kLRki.ki);
     for (size_t n = 1; n < total; ++n)
     {
       rct::key ki;
-      r = multisig::generate_multisig_composite_key_image(miner_account[n].get_keys(), subaddresses, output_pub_key[tdidx], tx_pub_key[tdidx], additional_tx_keys, 0, pkis, (crypto::key_image&)ki);
+      r = multisig::generate_multisig_composite_key_image(miner_account[n].get_keys(), subaddresses, output_pub_key[tdidx], tx_pub_key[tdidx], additional_tx_keys, 0, pkis, total, threshold, (crypto::key_image&)ki);
       CHECK_AND_ASSERT_MES(r, false, "Failed to generate composite key image");
       CHECK_AND_ASSERT_MES(kLRki.ki == ki, false, "Composite key images do not match");
     }


### PR DESCRIPTION
Adds a defense-in-depth check to ensure other signers provide the correct number of partial key image components. As the code currently stands, an incomplete set can still "successfully" produce a (wrong) key image, without signaling this to the caller.

I am not 100% sure the comments I added are entirely accurate or intuitive (my cryptography 'skills' are pretty terrible), so it would be good to have some feedback on that, too ;)