### PR TITLE
crypto: init p3 double scalarmult result when both scalars are zero

### DIFF
--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -42,6 +42,7 @@ DISABLE_VS_WARNINGS(4146 4244)
 static void ge_madd(ge_p1p1 *, const ge_p3 *, const ge_precomp *);
 static void ge_msub(ge_p1p1 *, const ge_p3 *, const ge_precomp *);
 static void ge_p2_0(ge_p2 *);
+static void ge_p3_0(ge_p3 *);
 static void fe_divpowm1(fe, const fe, const fe);
 
 /* Common functions */
@@ -1340,6 +1341,7 @@ void ge_double_scalarmult_base_vartime_p3(ge_p3 *r3, const unsigned char *a, con
   ge_dsm_precomp(Ai, A);
 
   ge_p2_0(&r);
+  ge_p3_0(r3);
 
   for (i = 255; i >= 0; --i) {
     if (aslide[i] || bslide[i]) break;
@@ -2308,6 +2310,7 @@ void ge_double_scalarmult_precomp_vartime2_p3(ge_p3 *r3, const unsigned char *a,
   slide(bslide, b);
 
   ge_p2_0(&r);
+  ge_p3_0(r3);
 
   for (i = 255; i >= 0; --i) {
     if (aslide[i] || bslide[i]) break;

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -574,3 +574,20 @@ TEST(Crypto, fe_constants)
   ASSERT_TRUE(memcmp(a_inv_3_bytes, A_INV_3_PAPER, 32) == 0);
   ASSERT_TRUE(memcmp(fe_c_bytes,    FE_C_PAPER,    32) == 0);
 }
+
+TEST(Crypto, double_scalarmult_p3_zero_scalars)
+{
+  static const unsigned char zero[32] = {0};
+  const ge_p3 &G = crypto::get_G_p3();
+  ge_dsmp Gi;
+  ge_dsm_precomp(Gi, &G);
+
+  ge_p3 r3;
+  memset(&r3, 0x01, sizeof(r3));
+  ge_double_scalarmult_base_vartime_p3(&r3, zero, &G, zero);
+  EXPECT_TRUE(ge_p3_is_point_at_infinity_vartime(&r3));
+
+  memset(&r3, 0x01, sizeof(r3));
+  ge_double_scalarmult_precomp_vartime2_p3(&r3, zero, Gi, zero, Gi);
+  EXPECT_TRUE(ge_p3_is_point_at_infinity_vartime(&r3));
+}


### PR DESCRIPTION
`ge_double_scalarmult_base_vartime_p3` and `ge_double_scalarmult_precomp_vartime2_p3` only write their result on the last loop iteration. When both scalars are zero the loop never runs and the result is never written, unlike the p2 variants, which return the identity. Initialize the result before the loop, as the p2 variants do.

Not reachable from current callers so no impact on existing proofs. Adds a unit test that fails without the fix.