### PR TITLE
wallet2: validate account tags before mutation

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -12873,6 +12873,10 @@ void wallet2::set_account_tag(const std::set<uint32_t> &account_indices, const s
   for (uint32_t account_index : account_indices)
   {
     THROW_WALLET_EXCEPTION_IF(account_index >= get_num_subaddress_accounts(), error::wallet_internal_error, "Account index out of bound");
+  }
+
+  for (uint32_t account_index : account_indices)
+  {
     if (m_account_tags.second[account_index] == tag)
       MDEBUG("This tag is already assigned to this account");
     else

--- a/tests/functional_tests/wallet.py
+++ b/tests/functional_tests/wallet.py
@@ -236,6 +236,26 @@ class WalletTest():
         assert res.account_tags[0].tag == 'tagB'
         assert res.account_tags[0].label == ''
         assert res.account_tags[0].accounts == [0, 1]
+        ok = False
+        try: wallet.tag_accounts('tagC', [0, 3])
+        except Exception as e:
+            assert 'Account index out of bound' in str(e)
+            ok = True
+        assert ok
+        res = wallet.get_account_tags()
+        assert len(res.account_tags) == 1
+        assert res.account_tags[0].tag == 'tagB'
+        assert res.account_tags[0].accounts == [0, 1]
+        ok = False
+        try: wallet.untag_accounts([0, 3])
+        except Exception as e:
+            assert 'Account index out of bound' in str(e)
+            ok = True
+        assert ok
+        res = wallet.get_account_tags()
+        assert len(res.account_tags) == 1
+        assert res.account_tags[0].tag == 'tagB'
+        assert res.account_tags[0].accounts == [0, 1]
         wallet.set_account_tag_description('tagB', 'tag B')
         res = wallet.get_account_tags()
         assert len(res.account_tags) == 1


### PR DESCRIPTION
`set_account_tag()` currently validates each account index immediately before updating it. when a request mixes valid and invalid indices, accounts preceding the invalid one are changed even though the call returns an error

validate the complete set before mutation so failed `tag_accounts` and `untag_accounts` requests leave existing tags unchanged

tests:
- `functional_tests_rpc wallet`
- `unit_tests`