### PR TITLE
crypto: bound inner-product length against the generator table

### DIFF
--- a/src/ringct/bulletproofs.cc
+++ b/src/ringct/bulletproofs.cc
@@ -884,6 +884,7 @@ bool bulletproof_VERIFY(const std::vector<const Bulletproof*> &proofs)
   }
   CHECK_AND_ASSERT_MES(max_length < 32, false, "At least one proof is too large");
   size_t maxMN = 1u << max_length;
+  CHECK_AND_ASSERT_MES(maxMN <= maxN*maxM, false, "Proof inner-product length exceeds the generator table");
 
   rct::key tmp;
 

--- a/src/ringct/bulletproofs_plus.cc
+++ b/src/ringct/bulletproofs_plus.cc
@@ -874,6 +874,7 @@ try_again:
         }
         CHECK_AND_ASSERT_MES(max_length < 32, false, "At least one proof is too large");
         size_t maxMN = 1u << max_length;
+        CHECK_AND_ASSERT_MES(maxMN <= maxN*maxM, false, "Proof inner-product length exceeds the generator table");
 
         rct::key temp;
         rct::key temp2;


### PR DESCRIPTION
Both verifiers cache generators in fixed static arrays of `maxN*maxM` entries, but only bound the batch inner-product length against 32. A proof with `V.size() > maxM` yields `maxMN > maxN*maxM` and `indexes Gi_p3/Hi_p3` out of bounds. Reject such proofs instead.

Discovered by an llm and validated with ASAN