### PR TITLE
lmdb: increase minimum batch resize increment to 1 GiB

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -638,7 +638,7 @@ void BlockchainLMDB::check_and_resize_for_batch(uint64_t batch_num_blocks, uint6
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   MTRACE("[" << __func__ << "] " << "checking DB size");
-  const uint64_t min_increase_size = 512 * (1 << 20);
+  const uint64_t min_increase_size = 1ULL << 30;
   uint64_t threshold_size = 0;
   uint64_t increase_size = 0;
   if (batch_num_blocks > 0)


### PR DESCRIPTION
This should halve the number of resizes during chain sync. More sophisticated solutions are possible, but I'm proposing this as a simple first step.