### PR TITLE
rpc: add network type to get_version response

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -247,6 +247,23 @@ namespace cryptonote {
       get_account_address_from_str(info, nettype, address_str);
   }
   //--------------------------------------------------------------------------------
+  const char* get_network_type_name(const network_type nettype)
+  {
+    switch (nettype)
+    {
+    case MAINNET:
+      return "mainnet";
+    case TESTNET:
+      return "testnet";
+    case STAGENET:
+      return "stagenet";
+    case FAKECHAIN:
+      return "fakechain";
+    default:
+      return "unknown";
+    };
+  }
+  //--------------------------------------------------------------------------------
   bool operator ==(const cryptonote::transaction& a, const cryptonote::transaction& b) {
     return cryptonote::get_transaction_hash(a) == cryptonote::get_transaction_hash(b);
   }

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "cryptonote_basic.h"
-#include "crypto/crypto.h"
 #include "crypto/hash.h"
 
 
@@ -97,6 +96,13 @@ namespace cryptonote {
     , bool allow_dns
     , std::function<std::string(const std::string&, const std::vector<std::string>&, bool)> dns_confirm = return_first_address
     );
+
+  /**
+   * @brief Get human-readable name from network type
+   * @param nettype Network type
+   * @return One of ["mainnet", "testnet", "stagenet", "fakechain", "unknown"]
+   */
+  const char* get_network_type_name(network_type nettype);
 
   bool operator ==(const cryptonote::transaction& a, const cryptonote::transaction& b);
   bool operator ==(const cryptonote::block& a, const cryptonote::block& b);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -320,7 +320,7 @@ namespace cryptonote
     res.mainnet = net_type == MAINNET;
     res.testnet = net_type == TESTNET;
     res.stagenet = net_type == STAGENET;
-    res.nettype = net_type == MAINNET ? "mainnet" : net_type == TESTNET ? "testnet" : net_type == STAGENET ? "stagenet" : "fakechain";
+    res.nettype = get_network_type_name(net_type);
     store_difficulty(m_core.get_blockchain_storage().get_db().get_block_cumulative_difficulty(res.height - 1),
         res.cumulative_difficulty, res.wide_cumulative_difficulty, res.cumulative_difficulty_top64);
     res.block_size_limit = res.block_weight_limit = m_core.get_blockchain_storage().get_current_cumulative_block_weight_limit();
@@ -2536,6 +2536,7 @@ namespace cryptonote
     res.target_height = m_p2p.get_payload_object().is_synchronized() ? 0 : m_core.get_target_blockchain_height();
     for (const auto &hf : m_core.get_blockchain_storage().get_hardforks())
        res.hard_forks.push_back({hf.version, hf.height});
+    res.nettype = get_network_type_name(nettype());
     res.status = CORE_RPC_STATUS_OK;
     return true;
   }

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -101,7 +101,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
 // advance which version they will stop working with
 // Don't go over 32767 for any of these
 #define CORE_RPC_VERSION_MAJOR 3
-#define CORE_RPC_VERSION_MINOR 18
+#define CORE_RPC_VERSION_MINOR 19
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 
@@ -2132,6 +2132,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
       uint64_t current_height;
       uint64_t target_height;
       std::vector<hf_entry> hard_forks;
+      std::string nettype;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_response_base)
@@ -2140,6 +2141,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
         KV_SERIALIZE_OPT(current_height, (uint64_t)0)
         KV_SERIALIZE_OPT(target_height, (uint64_t)0)
         KV_SERIALIZE_OPT(hard_forks, std::vector<hf_entry>())
+        KV_SERIALIZE_OPT(nettype, std::string())
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;


### PR DESCRIPTION
This could have many potential use cases, though the specific one I had in mind was being able to warn the user that they are connected to an incompatible daemon (for example, in the GUI wallet).