### PR TITLE
p2p: don't drop peers who re-relay invalid blocks with good PoW

### DIFF
--- a/src/cryptonote_basic/verification_context.h
+++ b/src/cryptonote_basic/verification_context.h
@@ -66,6 +66,7 @@ namespace cryptonote
   {
     bool m_added_to_main_chain;
     bool m_verifivation_failed; //bad block, should drop connection
+    bool m_no_drop_offense; // we may not want to drop if the block passed the PoW check e.g.
     bool m_marked_as_orphaned;
     bool m_already_exists;
     bool m_partial_block_reward;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2009,6 +2009,8 @@ bool Blockchain::handle_alternative_block(const block& b, const crypto::hash& id
       bvc.m_bad_pow = true;
       return false;
     }
+    else
+      bvc.m_no_drop_offense = true; // good PoW, so don't drop
 
     if(!prevalidate_miner_transaction(b, bei.height, hf_version))
     {
@@ -2820,6 +2822,7 @@ bool Blockchain::add_block_as_invalid(const block& bl, const crypto::hash& h)
 //------------------------------------------------------------------
 bool Blockchain::add_block_as_invalid(const block_extended_info& bei, const crypto::hash& h)
 {
+  // WARNING: we expect that the PoW check already passed
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
   auto i_res = m_invalid_blocks.insert(std::map<crypto::hash, block_extended_info>::value_type(h, bei));
@@ -3925,6 +3928,18 @@ leave:
     goto leave;
   }
 
+  // If we're at a checkpoint, ensure that our hardcoded checkpoint hash
+  // is correct.
+  if(m_checkpoints.is_in_checkpoint_zone(blockchain_height))
+  {
+    if(!m_checkpoints.check_block(blockchain_height, id))
+    {
+      LOG_ERROR("CHECKPOINT VALIDATION FAILED");
+      bvc.m_verifivation_failed = true;
+      goto leave;
+    }
+  }
+
   TIME_MEASURE_FINISH(t1);
   TIME_MEASURE_START(t2);
 
@@ -4006,18 +4021,8 @@ leave:
       bvc.m_bad_pow = true;
       goto leave;
     }
-  }
-
-  // If we're at a checkpoint, ensure that our hardcoded checkpoint hash
-  // is correct.
-  if(m_checkpoints.is_in_checkpoint_zone(blockchain_height))
-  {
-    if(!m_checkpoints.check_block(blockchain_height, id))
-    {
-      LOG_ERROR("CHECKPOINT VALIDATION FAILED");
-      bvc.m_verifivation_failed = true;
-      goto leave;
-    }
+    else
+      bvc.m_no_drop_offense = true; // good PoW, so don't drop
   }
 
   TIME_MEASURE_FINISH(longhash_calculating_time);
@@ -4516,7 +4521,10 @@ bool Blockchain::add_new_block(const block& bl, block_verification_context& bvc,
     LOG_PRINT_L3("block with id = " << id << " already exists");
     bvc.m_already_exists = true;
     if (where == HAVE_BLOCK_INVALID)
+    {
       bvc.m_verifivation_failed = true;
+      bvc.m_no_drop_offense = true; // it's assumed that any cached invalid block must have passed PoW already
+    }
     return false;
   }
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -638,7 +638,7 @@ namespace cryptonote
 
     // Pause mining and resume after block verification to prevent wasted mining cycles while
     // validating the next block. Needs more research into if this is a DoS vector or not. Invalid
-    // block validation will cause disconnects and bans, so it might not be that bad.
+    // block validation before the PoW check will cause disconnects and bans, so it might not be that bad.
     m_core.pause_mine();
     const epee::scope_guard resume_mine_on_leave([this](){ m_core.resume_mine(); });
 
@@ -730,6 +730,16 @@ namespace cryptonote
         MLOG_P2P_MESSAGE("-->>NOTIFY_REQUEST_FLUFFY_MISSING_TX: missing_tx_indices.size()=" << missing_tx_req.missing_tx_indices.size() );
         post_notify<NOTIFY_REQUEST_FLUFFY_MISSING_TX>(missing_tx_req, context);
       }
+      else if (bvc.m_no_drop_offense)
+      {
+        // Let it fall through in this case.
+        // Some nodes in the future may re-relay blocks immediately after PoW checks pass, but before expensive
+        // validation occurs, in order to speed up block propagation around the network. Therefore an honest
+        // node may re-relay an invalid block that has valid PoW.
+        // At time of writing, this isn't implemented for monerod, but it may be implemented in the future.
+        // So we get ahead of it by avoiding dropping what could be honest peers.
+        LOG_PRINT_CCONTEXT_L1("Block verification failed, but not dropping peer");
+      }
       else // failure for some other reason besides missing txs...
       {
         // drop connection and punish peer
@@ -760,7 +770,7 @@ namespace cryptonote
       MLOG_PEER_STATE("requesting chain");
     }
 
-    if (bvc.m_added_to_main_chain || bvc.m_already_exists)
+    if (bvc.m_added_to_main_chain || (bvc.m_already_exists && !bvc.m_verifivation_failed))
     {
       // Update peer's sync height using this block we just validated
       // Note: peer_height is not guaranteed to be the height of the block we just validated + 1.


### PR DESCRIPTION
Idea proposed by @boog900 [here](https://github.com/seraphis-migration/monero/issues/454).

Some nodes in the future may re-relay blocks immediately after PoW checks pass, but before expensive validation occurs, in order to speed up block propagation around the network. Therefore an honest node could be "tricked" into re-relaying an invalid block that has valid PoW.

Thus, we don't want to drop connections to nodes that re-relay invalid blocks with good PoW since they could be honest.

Re-relaying blocks immediately after PoW checks pass and before expensive validation would be more beneficial with FCMP++, since blocks can take seconds to validate, and therefore take many seconds to propagate to the whole network.