### PR TITLE
ci: replace EOL Debian 11 with Debian 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,8 +152,8 @@ jobs:
       matrix:
         include:
           # Oldest supported Debian version
-          - name: Debian 11
-            container: debian:11
+          - name: Debian 12
+            container: debian:12
           # Oldest supported Ubuntu LTS version
           - name: Ubuntu 22.04
             container: ubuntu:22.04


### PR DESCRIPTION
Debian 11 is EOL and bullseye-security's Release file expired on 7 Sep so apt update exits 100 and the job fails before checkout on every run since.

Keeping it isn't viable: ignoring the expiry then 404s on the purged security pool and dropping the suite leaves the image's security-updated libraries unsatisfiable against main's older versions.