### PR TITLE
tests: fix unused result warning in cpu_power_test

### DIFF
--- a/tests/functional_tests/cpu_power_test.cpp
+++ b/tests/functional_tests/cpu_power_test.cpp
@@ -100,7 +100,7 @@ int main(int argc, const char ** argv)
     const std::chrono::steady_clock::time_point tbegin = std::chrono::steady_clock::now();
     for(auto & e : futures) 
     {
-       e.get();
+       (void)e.get();
     }
     // Stop measuring the time.
     const std::chrono::steady_clock::time_point tend = std::chrono::steady_clock::now();


### PR DESCRIPTION
```text
monero/tests/functional_tests/cpu_power_test.cpp:103:8: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
  103 |        e.get();
      |        ^~~~~
1 warning generated.
```