### PR TITLE
epee: fix fragmented Levin messages on big endian

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -489,7 +489,15 @@ public:
 
             temp.swap(m_fragment_buffer);
             std::memcpy(std::addressof(m_current_head), std::addressof(temp[0]), sizeof(bucket_head2));
-            const std::uint64_t inner_size = SWAP64LE(m_current_head.m_cb);
+#if BYTE_ORDER != LITTLE_ENDIAN
+            m_current_head.m_signature = SWAP64LE(m_current_head.m_signature);
+            m_current_head.m_cb = SWAP64LE(m_current_head.m_cb);
+            m_current_head.m_command = SWAP32LE(m_current_head.m_command);
+            m_current_head.m_return_code = SWAP32LE(m_current_head.m_return_code);
+            m_current_head.m_flags = SWAP32LE(m_current_head.m_flags);
+            m_current_head.m_protocol_version = SWAP32LE(m_current_head.m_protocol_version);
+#endif
+            const std::uint64_t inner_size = m_current_head.m_cb;
             buff_to_invoke = {reinterpret_cast<const uint8_t*>(temp.data()) + sizeof(bucket_head2), temp.size() - sizeof(bucket_head2)};
             if (buff_to_invoke.size() < inner_size)
             {

--- a/contrib/epee/src/levin_base.cpp
+++ b/contrib/epee/src/levin_base.cpp
@@ -120,7 +120,7 @@ namespace levin
       copy_size = payload.remove_prefix(payload_space);
 
       if (payload.empty())
-        head.m_flags = LEVIN_PACKET_END;
+        head.m_flags = SWAP32LE(LEVIN_PACKET_END);
 
       buffer.write(as_byte_span(head));
       buffer.write(payload.data() - copy_size, copy_size);

--- a/tests/unit_tests/epee_levin_protocol_handler_async.cpp
+++ b/tests/unit_tests/epee_levin_protocol_handler_async.cpp
@@ -560,7 +560,7 @@ TEST_F(test_levin_protocol_handler__hanle_recv_with_invalid_data, handles_invali
 
 TEST_F(test_levin_protocol_handler__hanle_recv_with_invalid_data, handles_big_cb)
 {
-  m_req_head.m_cb = max_packet_size + 1;
+  m_req_head.m_cb = SWAP64LE(max_packet_size + 1);
   prepare_buf();
 
   ASSERT_FALSE(m_conn->m_protocol_handler.handle_recv(m_buf.data(), m_buf.size()));
@@ -636,15 +636,15 @@ TEST_F(test_levin_protocol_handler__hanle_recv_with_invalid_data, handles_unexpe
 
 TEST_F(test_levin_protocol_handler__hanle_recv_with_invalid_data, handles_short_fragment)
 {
-  m_req_head.m_cb = 1;
-  m_req_head.m_flags = LEVIN_PACKET_BEGIN;
-  m_req_head.m_command = 0;
+  m_req_head.m_cb = SWAP64LE(1);
+  m_req_head.m_flags = SWAP32LE(LEVIN_PACKET_BEGIN);
+  m_req_head.m_command = SWAP32LE(0);
   m_in_data.resize(1);
   prepare_buf();
 
   ASSERT_TRUE(m_conn->m_protocol_handler.handle_recv(m_buf.data(), m_buf.size()));
 
-  m_req_head.m_flags = LEVIN_PACKET_END;
+  m_req_head.m_flags = SWAP32LE(LEVIN_PACKET_END);
   prepare_buf();
 
   ASSERT_FALSE(m_conn->m_protocol_handler.handle_recv(m_buf.data(), m_buf.size()));
@@ -652,16 +652,16 @@ TEST_F(test_levin_protocol_handler__hanle_recv_with_invalid_data, handles_short_
 
 TEST_F(test_levin_protocol_handler__hanle_recv_with_invalid_data, handles_bad_cb)
 {
-  m_req_head.m_cb = sizeof(epee::levin::bucket_head2);
-  m_req_head.m_flags = LEVIN_PACKET_BEGIN;
-  m_req_head.m_command = 0;
+  m_req_head.m_cb = SWAP64LE(sizeof(epee::levin::bucket_head2));
+  m_req_head.m_flags = SWAP32LE(LEVIN_PACKET_BEGIN);
+  m_req_head.m_command = SWAP32LE(0);
   m_in_data.resize(sizeof(epee::levin::bucket_head2));
   prepare_buf();
 
   ASSERT_TRUE(m_conn->m_protocol_handler.handle_recv(m_buf.data(), m_buf.size()));
 
-  m_req_head.m_cb = 1;
-  m_req_head.m_flags = LEVIN_PACKET_END;
+  m_req_head.m_cb = SWAP64LE(1);
+  m_req_head.m_flags = SWAP32LE(LEVIN_PACKET_END);
   m_in_data.resize(1);
   prepare_buf();
 

--- a/tests/unit_tests/levin.cpp
+++ b/tests/unit_tests/levin.cpp
@@ -567,9 +567,7 @@ TEST(make_fragment, multiple)
     EXPECT_TRUE(std::memcmp(std::addressof(header), fragment.data(), sizeof(header)) == 0);
 
     fragment.take_slice(sizeof(header));
-    header.m_flags = LEVIN_PACKET_REQUEST;
-    header.m_cb = bytes.size();
-    header.m_command = 114;
+    header = epee::levin::make_header(114, bytes.size(), LEVIN_PACKET_REQUEST, false);
 
     ASSERT_LE(sizeof(header), fragment.size());
     EXPECT_TRUE(std::memcmp(std::addressof(header), fragment.data(), sizeof(header)) == 0);
@@ -581,9 +579,7 @@ TEST(make_fragment, multiple)
 
     bytes.erase(0, 1024 - sizeof(header) * 2);
     fragment.take_slice(1024 - sizeof(header) * 2);
-    header.m_flags = 0;
-    header.m_cb = 1024 - sizeof(header);
-    header.m_command = 0;
+    header = epee::levin::make_header(0, 1024 - sizeof(header), 0, false);
 
     ASSERT_LE(sizeof(header), fragment.size());
     EXPECT_TRUE(std::memcmp(std::addressof(header), fragment.data(), sizeof(header)) == 0);
@@ -595,7 +591,7 @@ TEST(make_fragment, multiple)
 
     bytes.erase(0, 1024 - sizeof(header));
     fragment.take_slice(1024 - sizeof(header));
-    header.m_flags = LEVIN_PACKET_END;
+    header = epee::levin::make_header(0, 1024 - sizeof(header), LEVIN_PACKET_END, false);
 
     ASSERT_LE(sizeof(header), fragment.size());
     EXPECT_TRUE(std::memcmp(std::addressof(header), fragment.data(), sizeof(header)) == 0);


### PR DESCRIPTION
## what changed

Fragmented Levin messages include a complete inner Levin header

On big-endian hosts, the final outer fragment flag was written in host byte order, so receivers did not recognize the end of the sequence. The inner header was also copied without converting its multi-byte fields, which left the command, size, flags, return code, signature, and protocol version in wire order

This writes the final flag in little-endian form and decodes the reassembled inner header the same way as a regular Levin header. The affected test fixtures now build headers in wire order too

## tests

- `unit_tests` on x86-64: 1313 passed, 2 hardware-dependent skips
- 57 Levin, fragmentation, and noise relay tests on s390x under QEMU
- verified `make_fragment.multiple` and `handler_processes_handle_read_as_fragment` fail before and pass after on s390x
