### PR TITLE
wallet2: handle non-curve tx public keys in reserve proofs [release-v0.18]

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -305,11 +305,9 @@ namespace cryptonote
       if (!r)
       {
         MWARNING("key image helper: failed to generate_key_derivation(" << additional_tx_public_keys[i] << ", <viewkey>)");
+        memcpy(&additional_recv_derivation, rct::identity().bytes, sizeof(additional_recv_derivation));
       }
-      else
-      {
-        additional_recv_derivations.push_back(additional_recv_derivation);
-      }
+      additional_recv_derivations.push_back(additional_recv_derivation);
     }
 
     boost::optional<subaddress_receive_info> subaddr_recv_info = is_out_to_acc_precomp(subaddresses, out_key, recv_derivation, additional_recv_derivations, real_output_index,hwdev);

--- a/tests/unit_tests/test_tx_utils.cpp
+++ b/tests/unit_tests/test_tx_utils.cpp
@@ -34,6 +34,7 @@
 
 #include "common/util.h"
 #include "cryptonote_basic/cryptonote_basic.h"
+#include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_basic/tx_extra.h"
 #include "cryptonote_core/cryptonote_tx_utils.h"
 
@@ -356,4 +357,41 @@ TEST(remove_field_from_tx_extra, invalid_varint)
 
   ASSERT_FALSE(cryptonote::remove_field_from_tx_extra(extra, typeid(cryptonote::tx_extra_nonce)));
   ASSERT_EQ(sizeof(extra_arr), extra.size());
+}
+
+TEST(cn_format_utils, generate_key_image_helper_additional_derivations_stay_aligned)
+{
+    // An additional tx pubkey that is not a valid point makes generate_key_derivation()
+    // fail for that entry. The derivations must stay index-aligned with the pubkeys
+    // anyway, because is_out_to_acc_precomp() indexes them by the output index.
+    cryptonote::account_base acc;
+    acc.generate();
+    const cryptonote::account_keys &keys = acc.get_keys();
+    hw::device &hwdev = hw::get_device("default");
+
+    crypto::public_key tx_pub_key, additional_tx_pub_key;
+    crypto::secret_key tx_sec_key, additional_tx_sec_key;
+    crypto::generate_keys(tx_pub_key, tx_sec_key);
+    crypto::generate_keys(additional_tx_pub_key, additional_tx_sec_key);
+
+    // The output we own sits at index 1, derived from the additional pubkey there.
+    crypto::key_derivation derivation;
+    ASSERT_TRUE(hwdev.generate_key_derivation(additional_tx_pub_key, keys.m_view_secret_key, derivation));
+    crypto::public_key out_key;
+    ASSERT_TRUE(crypto::derive_public_key(derivation, 1, keys.m_account_address.m_spend_public_key, out_key));
+
+    std::unordered_map<crypto::public_key, cryptonote::subaddress_index> subaddresses;
+    subaddresses[keys.m_account_address.m_spend_public_key] = {0, 0};
+
+    crypto::public_key invalid_pub_key = crypto::null_pkey;
+    reinterpret_cast<unsigned char*>(&invalid_pub_key)[31] = 0x7f;
+    crypto::key_derivation unused;
+    ASSERT_FALSE(hwdev.generate_key_derivation(invalid_pub_key, keys.m_view_secret_key, unused));
+
+    const std::vector<crypto::public_key> additional_tx_pub_keys = {invalid_pub_key, additional_tx_pub_key};
+
+    cryptonote::keypair in_ephemeral;
+    crypto::key_image ki;
+    ASSERT_TRUE(cryptonote::generate_key_image_helper(keys, subaddresses, out_key, tx_pub_key,
+        additional_tx_pub_keys, 1, in_ephemeral, ki, hwdev));
 }


### PR DESCRIPTION
#11297 

Also contains backport of #11019, as this patch builds on top of it.