### PR TITLE
p2p: don't reset timeout timer for handshakes [v0.18]

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -263,6 +263,8 @@ public:
     }
     virtual void reset_timer()
     {
+      if (m_command == connection_context::handshake_command())
+        return;
       boost::system::error_code ignored_ec;
       if (!m_cancel_timer_called && m_timer.cancel(ignored_ec) > 0)
       {


### PR DESCRIPTION
#11082

On this branch, `reset_timer` isn't called on connection open, so doesn't need that `first` handling from the other PR.