### PR TITLE
db: Making monerod able to notify user about truncated database corruption

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2479,7 +2479,10 @@ cryptonote::blobdata BlockchainLMDB::get_block_blob_from_height(const uint64_t& 
     throw0(BLOCK_DNE(std::string("Attempt to get block from height ").append(boost::lexical_cast<std::string>(height)).append(" failed -- block not in db").c_str()));
   }
   else if (get_result)
-    throw0(DB_ERROR("Error attempting to retrieve a block from the db"));
+    throw0(DB_ERROR(
+      "Error attempting to retrieve a block from the db\n"
+      "If this occurred while loading the blockchain, the blockchain database may be corrupted.\n"
+      "Remove the damaged blockchain database file and resynchronize"));
 
   blobdata bd;
   bd.assign(reinterpret_cast<char*>(result.mv_data), result.mv_size);

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -498,7 +498,24 @@ namespace tools
   }
 #endif
 #else
+#ifndef _WIN32
+  static void posix_sigbus_handler(int signal)
+  {
+    static const char message[] =
+      "\nSIGBUS error: If this occurred while loading the blockchain, the blockchain database may be corrupted.\n"
+      "Remove the damaged blockchain database file and resynchronize.\n";
+    const ssize_t ignored = write(STDERR_FILENO, message, sizeof(message) - 1);
+    (void)ignored;
+    _exit(128 + signal);
+  }
+
+  static void setup_crash_dump()
+  {
+    signal(SIGBUS, posix_sigbus_handler);
+  }
+#else
   static void setup_crash_dump() {}
+#endif
 #endif
 
   bool disable_core_dumps()


### PR DESCRIPTION
When database is corrupted due to truncation from power loss or abnormal termination, monerod might access these non-existent pages that causes a page fault. Currently monerod client is not able to notify the user that database might be corrupted. This PR will attempt to add warning message to client.

1.Unix
When monerod tries to access a non-existent page a sigbus error will be triggered. This sigbus exception is not properly handled, and will become a process wide exception.  So a global sigbus handler is registered for notifying about the error. By default the release build did not include the STACK_TRACE flag, so the handler is defined outside the #ifdef STACK_TRACE because it is intended for warning users.

2.Windows
Seems windows page fault is correctly handled, and will become a normal c++ exception. So the warning message is directly added to the failed get_result branch.